### PR TITLE
chore: main ブランチへの直接コミットを防ぐ pre-commit hook を追加

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,7 @@
+#!/bin/sh
+branch="$(git branch --show-current)"
+if [ "$branch" = "main" ]; then
+  echo "ERROR: main ブランチへの直接コミットは禁止されています。"
+  echo "feature ブランチを作成してください: git checkout -b <prefix>/<branch-name>"
+  exit 1
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,16 @@ git worktree remove ../ghostinthearchive-<branch-name>
 - 各 worktree は独立したディレクトリで動作するため、複数ブランチの並列作業が可能
 - worktree のディレクトリ名は `ghostinthearchive-<branch-name>` とする
 
+### Git Hooks
+
+本リポジトリは `.githooks/` ディレクトリで Git hook を管理する。初回クローン時に以下を実行：
+
+```bash
+git config core.hooksPath .githooks
+```
+
+これにより main ブランチへの直接コミットがブロックされる。
+
 ## Tech Stack
 
 - **Infrastructure:** Google Cloud (Cloud Run, Cloud Scheduler)


### PR DESCRIPTION
## Summary

- `.githooks/pre-commit` を追加し、main ブランチ上での `git commit` をエラーで拒否するようにした
- `CLAUDE.md` に Git Hooks セクションを追加し、初回クローン時の `git config core.hooksPath .githooks` 手順を記載
- CLAUDE.md のブランチ戦略ルールを機械的に強制し、誤って main に直接コミットすることを防止

## Test plan

- [x] main ブランチ上で `git commit --allow-empty -m "test"` を実行し、エラーで拒否されることを確認
- [x] feature ブランチ上で正常にコミットできることを確認
- [x] `git config core.hooksPath` が `.githooks` に設定されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)