### PR TITLE
feat: /gen-test スキルを追加 — ADK ツール関数のテスト自動生成

### DIFF
--- a/.claude/skills/gen-test/SKILL.md
+++ b/.claude/skills/gen-test/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: gen-test
+description: "ADK ツール関数の TDD テストを生成。conftest.py モック・テスト配置規則・Red-Green-Refactor に準拠"
+argument-hint: "[tool_module_path]"
+disable-model-invocation: true
+allowed-tools: Read, Glob, Grep, Bash, Write, Edit
+---
+
+# /gen-test — ADK ツール関数のテスト自動生成
+
+対象ツールモジュールのパスを `$ARGUMENTS` で受け取り、プロジェクト規約に完全準拠したテストファイルを生成する。
+
+## ワークフロー
+
+### Step 1: ツールモジュール分析
+
+対象ファイル `$ARGUMENTS` を読み取り、以下を抽出する:
+
+1. **公開関数の一覧**: `def function_name(...)` のシグネチャ、引数、デフォルト値
+2. **外部依存**: import 文から依存先を特定
+   - `shared.firestore` → Firestore/Storage 依存
+   - `google.genai` → genai 依存
+   - `requests` → HTTP 依存
+   - ファイル I/O（`open`, `Path`）→ ファイルシステム依存
+3. **返り値フォーマット**: JSON 文字列（`json.dumps`）か、dict/None か
+4. **エラーハンドリング**: try/except パターン、エラー時の返り値
+5. **内部ヘルパー**: `_` プレフィックスのプライベート関数（テスト可能なものは含める）
+
+### Step 2: テスト配置決定
+
+CLAUDE.md のテスト配置規則に従い、テストファイルパスを決定する:
+
+| 対象コード | テストファイル |
+|-----------|---------------|
+| `archive_agents/tools/*.py` | `tests/unit/test_<module_name>.py` |
+| `podcast_agents/tools/*.py` | `tests/unit/test_podcast_<module_name>.py` |
+| `translator_agents/tools/*.py` | `tests/unit/test_translator_<module_name>.py` |
+| `archive_agents/utils/*.py` | `tests/unit/test_<module_name>.py` |
+| `archive_agents/schemas/*.py` | `tests/unit/test_schemas.py`（既存に追記） |
+
+**Firestore/Storage に直接依存する関数**がある場合、Integration テストも検討:
+- `tests/integration/test_<module_name>.py`
+
+### Step 3: 既存テスト確認
+
+```bash
+# 既存テストとの重複チェック
+pytest tests/ -v --collect-only -k "<module_name>"
+```
+
+既存テストがある場合:
+- 重複するテストは生成しない
+- 不足しているケースのみ追加する
+- 既存テストのスタイル（クラス名、命名規則）に合わせる
+
+### Step 4: Unit テスト生成
+
+[mock-patterns.md](mock-patterns.md) のモックパターンカタログを参照し、テストを生成する。
+
+#### テスト構造テンプレート
+
+```python
+"""Unit tests for <module_name>."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from <package>.tools.<module_name> import (
+    function_a,
+    function_b,
+    _helper_if_testable,
+)
+
+
+class TestFunctionAPascalCase:
+    """Tests for function_a."""
+
+    def test_function_a_success(self):
+        """Should <expected behavior> when <condition>."""
+        # Arrange
+        ...
+        # Act
+        result = function_a(...)
+        # Assert
+        ...
+
+    def test_function_a_error_case(self):
+        """Should <expected error behavior> when <error condition>."""
+        ...
+```
+
+#### テスト網羅性チェックリスト
+
+各公開関数に対して、以下のカテゴリを検討する:
+
+- [ ] **正常系**: 期待される入力で正しい出力を返すか
+- [ ] **入力バリデーション**: 不正な入力（空文字、None、型不一致）でエラーを返すか
+- [ ] **JSON パース**: JSON 文字列入力の場合、不正な JSON でエラーを返すか
+- [ ] **外部依存エラー**: Firestore/API/ファイルI/O の例外時に graceful にエラーを返すか
+- [ ] **エッジケース**: 空リスト、存在しないファイル、大量データ等
+- [ ] **返り値フォーマット**: JSON 文字列の場合、必須フィールドが含まれるか
+
+全カテゴリを網羅する必要はない。対象関数のロジックに応じて、意味のあるテストのみ生成する。
+
+### Step 5: Integration テスト生成（Firestore/Storage 依存がある場合のみ）
+
+Firestore/Storage に直接依存する関数がある場合のみ、Integration テストを生成する。
+
+```python
+"""Integration tests for <module_name>.
+
+These tests require Firebase Emulator to be running:
+    firebase emulators:start --only firestore,storage
+
+Run with:
+    pytest tests/integration/test_<module_name>.py -v -m integration
+"""
+
+import json
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.mark.integration
+class TestModuleNameWithEmulator:
+    """Integration tests requiring Firebase Emulator."""
+
+    @pytest.fixture(autouse=True)
+    def check_emulator(self):
+        """Skip if emulator is not running."""
+        if not os.environ.get("FIRESTORE_EMULATOR_HOST"):
+            pytest.skip("Firebase Emulator not running")
+
+    def test_end_to_end(self):
+        ...
+```
+
+### Step 6: Red フェーズ確認
+
+生成したテストを実行し、結果を確認する:
+
+```bash
+# Unit テスト実行
+pytest tests/unit/test_<module_name>.py -v
+
+# 既存テストが壊れていないことを確認
+pytest tests/unit/ -v --tb=short
+```
+
+**期待される結果:**
+- テストが実行可能であること（import エラーなし）
+- テストが PASS するか、実装の問題で FAIL するか（Red フェーズ）
+- 既存テストが影響を受けていないこと
+
+## テスト命名規則
+
+- **クラス名**: `TestFunctionNamePascalCase`（例: `TestPublishMystery`, `TestSanitizePrompt`）
+- **メソッド名**: `test_function_name_scenario`（例: `test_publish_mystery_success`, `test_publish_mystery_invalid_json`）
+- **docstring**: `"""Should <期待される振る舞い> when <条件>."""`
+
+## リファレンス
+
+- 依存別モックパターンの詳細は [mock-patterns.md](mock-patterns.md) を参照
+- テスト配置規則・TDD ワークフローは `CLAUDE.md` を参照
+- 既存テストの模範:
+  - `tests/unit/test_illustrator_tools.py`（genai モック、リトライ、JSON アサーション）
+  - `tests/integration/test_publisher_tools.py`（Firestore モック、emulator skip）

--- a/.claude/skills/gen-test/mock-patterns.md
+++ b/.claude/skills/gen-test/mock-patterns.md
@@ -1,0 +1,330 @@
+# モックパターンカタログ
+
+`/gen-test` スキルが参照する、依存別モックパターンの詳細リファレンス。
+
+## conftest.py フィクスチャ一覧
+
+`tests/conftest.py` で定義済みのフィクスチャ。テスト関数の引数に追加するだけで利用可能。
+
+### モックフィクスチャ
+
+| フィクスチャ名 | 型 | 用途 |
+|--------------|---|------|
+| `mock_firestore_client` | `MagicMock` | Firestore クライアント（collection/document/set/get チェーン設定済み） |
+| `mock_storage_bucket` | `MagicMock` | Storage バケット（blob/upload/make_public 設定済み、`public_url` プロパティあり） |
+| `patch_firestore` | `MagicMock` | `shared.firestore.get_firestore_client` を自動パッチ（yields mock_firestore_client） |
+| `patch_storage` | `MagicMock` | `shared.firestore.get_storage_bucket` を自動パッチ（yields mock_storage_bucket） |
+| `frozen_time` | `datetime` | 固定時刻 `2024-01-15T12:00:00Z` |
+
+### サンプルデータフィクスチャ
+
+| フィクスチャ名 | 用途 |
+|--------------|------|
+| `sample_archive_document_data` | ArchiveDocument の辞書データ |
+| `sample_evidence_data` | Evidence の辞書データ |
+| `sample_historical_context_data` | HistoricalContext の辞書データ |
+| `sample_mystery_report_data` | MysteryReport の辞書データ（evidence, historical_context 含む） |
+| `sample_search_results_data` | SearchResults の辞書データ |
+| `load_fixture` | `tests/fixtures/` から JSON ファイルを読み込むファクトリ |
+
+### conftest.py の sys.modules パッチ
+
+`conftest.py` で以下のモジュールが `sys.modules` に事前パッチされている。テストファイルで追加のパッチは不要:
+
+- `google.adk`, `google.adk.agents`, `google.adk.tools`
+- `google.genai`, `google.genai.types`
+- `firebase_admin`, `firebase_admin.credentials`, `firebase_admin.firestore`, `firebase_admin.storage`
+- `google.cloud.firestore`, `google.cloud.storage`
+
+## 依存別モックパターン
+
+### 1. Firestore 依存
+
+`shared.firestore.get_firestore_client` を使用する関数向け。
+
+#### パターン A: conftest フィクスチャ使用（推奨）
+
+```python
+def test_function_success(self, mock_firestore_client):
+    """conftest の mock_firestore_client を引数で受け取る。"""
+    with patch(
+        "<package>.tools.<module>.get_firestore_client",
+        return_value=mock_firestore_client,
+    ):
+        from <package>.tools.<module> import target_function
+
+        result = json.loads(target_function("test-id"))
+        assert result["status"] == "success"
+        mock_firestore_client.collection.assert_called_with("mysteries")
+```
+
+#### パターン B: Firestore 書き込みデータをキャプチャ
+
+```python
+def test_function_sets_data(self, mock_firestore_client):
+    """Firestore に書き込まれたデータを検証する。"""
+    captured_data = {}
+
+    def capture_set(data):
+        captured_data.update(data)
+
+    mock_doc = MagicMock()
+    mock_doc.set.side_effect = capture_set
+    mock_firestore_client.collection.return_value.document.return_value = mock_doc
+
+    with patch(
+        "<package>.tools.<module>.get_firestore_client",
+        return_value=mock_firestore_client,
+    ):
+        from <package>.tools.<module> import target_function
+        target_function(...)
+
+    assert "createdAt" in captured_data
+    assert captured_data["status"] == "pending"
+```
+
+#### パターン C: Firestore 読み取りモック
+
+```python
+def test_load_existing_document(self, mock_firestore_client):
+    """Firestore からデータを読み取る関数のテスト。"""
+    mock_doc = MagicMock()
+    mock_doc.exists = True
+    mock_doc.to_dict.return_value = {
+        "title": "Test Mystery",
+        "summary": "Test summary",
+        "narrative_content": "Test content",
+    }
+    mock_firestore_client.collection.return_value.document.return_value.get.return_value = mock_doc
+
+    with patch(
+        "<package>.tools.<module>.get_firestore_client",
+        return_value=mock_firestore_client,
+    ):
+        from <package>.tools.<module> import target_function
+        result = target_function("test-id")
+
+    assert result is not None
+    assert result["title"] == "Test Mystery"
+```
+
+#### パターン D: Firestore ドキュメント未存在
+
+```python
+def test_load_nonexistent_document(self, mock_firestore_client):
+    """存在しないドキュメントのテスト。"""
+    mock_doc = MagicMock()
+    mock_doc.exists = False
+    mock_firestore_client.collection.return_value.document.return_value.get.return_value = mock_doc
+
+    with patch(
+        "<package>.tools.<module>.get_firestore_client",
+        return_value=mock_firestore_client,
+    ):
+        from <package>.tools.<module> import target_function
+        result = target_function("nonexistent-id")
+
+    assert result is None
+```
+
+#### パターン E: Firestore update モック
+
+```python
+def test_update_document(self, mock_firestore_client):
+    """Firestore の update 呼び出しを検証する。"""
+    captured_data = {}
+
+    def capture_update(data):
+        captured_data.update(data)
+
+    mock_doc = MagicMock()
+    mock_doc.update.side_effect = capture_update
+    mock_firestore_client.collection.return_value.document.return_value = mock_doc
+
+    with patch(
+        "<package>.tools.<module>.get_firestore_client",
+        return_value=mock_firestore_client,
+    ):
+        from <package>.tools.<module> import target_function
+        target_function("test-id", ...)
+
+    assert captured_data["status"] == "published"
+    mock_doc.update.assert_called_once()
+```
+
+### 2. Cloud Storage 依存
+
+`shared.firestore.get_storage_bucket` を使用する関数向け。
+
+```python
+def test_upload_success(self, mock_storage_bucket):
+    """Storage へのアップロードテスト。"""
+    with patch(
+        "<package>.tools.<module>.get_storage_bucket",
+        return_value=mock_storage_bucket,
+    ):
+        from <package>.tools.<module> import upload_function
+
+        result = json.loads(upload_function("test-id", json.dumps(["/tmp/test.png"])))
+
+    assert result["status"] == "success"
+    mock_storage_bucket.blob.assert_called()
+```
+
+### 3. genai (Imagen) 依存
+
+`google.genai.Client` を使用する画像生成関数向け。
+
+```python
+@patch("<package>.tools.<module>._get_client")
+def test_image_generation_success(self, mock_get_client):
+    """Imagen API 呼び出しの成功テスト。"""
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
+
+    mock_image = MagicMock()
+    mock_response = MagicMock()
+    mock_response.generated_images = [MagicMock(image=mock_image)]
+    mock_client.models.generate_images.return_value = mock_response
+
+    from <package>.tools.<module> import generate_function
+
+    result = json.loads(generate_function("test prompt"))
+    assert result["status"] == "success"
+    assert mock_client.models.generate_images.call_count == 1
+```
+
+#### Safety filter / リトライのテスト
+
+```python
+@patch("<package>.tools.<module>._get_client")
+def test_retry_on_safety_filter(self, mock_get_client):
+    """Safety filter で空レスポンス → リトライのテスト。"""
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
+
+    mock_image = MagicMock()
+    mock_client.models.generate_images.side_effect = [
+        MagicMock(generated_images=[]),  # 1回目: Safety filter
+        MagicMock(generated_images=[MagicMock(image=mock_image)]),  # 2回目: 成功
+    ]
+
+    result = json.loads(generate_function("ghost ship"))
+    assert result["status"] == "success"
+    assert result["prompt_sanitized"] is True
+```
+
+### 4. HTTP (requests) 依存
+
+`requests` ライブラリを使用する関数向け。`responses` ライブラリでモックする。
+
+```python
+import responses
+
+@responses.activate
+def test_api_call_success(self):
+    """外部 API 呼び出しの成功テスト。"""
+    responses.add(
+        responses.GET,
+        "https://api.example.com/search",
+        json={"results": [{"title": "Test"}]},
+        status=200,
+    )
+
+    from <package>.tools.<module> import search_function
+    result = search_function("test query")
+    assert len(result["documents"]) > 0
+```
+
+#### API エラーのテスト
+
+```python
+@responses.activate
+def test_api_error(self):
+    """API エラー時の graceful エラーハンドリング。"""
+    responses.add(
+        responses.GET,
+        "https://api.example.com/search",
+        json={"error": "rate limited"},
+        status=429,
+    )
+
+    result = search_function("test query")
+    assert result.get("error") is not None
+```
+
+### 5. ファイル I/O 依存
+
+`open`, `Path`, `os` を使用するファイル操作関数向け。
+
+```python
+import tempfile
+
+def test_load_file_success(self):
+    """ファイル読み込みの成功テスト。"""
+    test_data = {"theme": "test", "results": {"documents": []}}
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".json", delete=False
+    ) as f:
+        json.dump(test_data, f)
+        temp_path = f.name
+
+    try:
+        result = json.loads(load_function(temp_path))
+        assert result["status"] == "success"
+    finally:
+        os.unlink(temp_path)
+```
+
+```python
+def test_load_file_not_found(self):
+    """存在しないファイルの読み込みテスト。"""
+    result = json.loads(load_function("/nonexistent/path.json"))
+    assert "error" in result
+```
+
+### 6. 時刻依存
+
+タイムスタンプを生成する関数は `freezegun` でテストする。
+
+```python
+from freezegun import freeze_time
+
+@freeze_time("2024-01-15 12:00:00")
+def test_timestamp_generation(self):
+    """タイムスタンプが正しく生成されるテスト。"""
+    result = generate_with_timestamp(...)
+    assert "20240115" in result["filename"]
+```
+
+## 既存テストの模範コード
+
+### test_illustrator_tools.py（genai モック + リトライ + JSON アサーション）
+
+```python
+# テストクラス構成の例
+class TestSanitizePrompt:         # ヘルパー関数のテスト
+class TestGenerateImageRetry:     # リトライメカニズムのテスト
+class TestGenerateImageFallback:  # フォールバックのテスト
+class TestGenerateImageStyles:    # パラメータバリエーション
+class TestGenerateImageOutput:    # 出力フォーマット検証
+```
+
+### test_publisher_tools.py（Firestore モック + emulator skip）
+
+```python
+# Unit テスト: mock_firestore_client を with patch で注入
+class TestPublishMystery:
+    def test_publish_mystery_success(self, mock_firestore_client, sample_mystery_report_data):
+        with patch("...get_firestore_client", return_value=mock_firestore_client):
+            ...
+
+# Integration テスト: @pytest.mark.integration + emulator チェック
+@pytest.mark.integration
+class TestPublisherToolsWithEmulator:
+    @pytest.fixture(autouse=True)
+    def check_emulator(self):
+        if not os.environ.get("FIRESTORE_EMULATOR_HOST"):
+            pytest.skip("Firebase Emulator not running")
+```


### PR DESCRIPTION
## Summary

- TDD 義務に対応する `/gen-test` スキルを `.claude/skills/gen-test/` に追加
- ツールモジュールのパスを引数に取り、conftest.py モック・テスト配置規則・Red-Green-Refactor に完全準拠したテストファイルを自動生成
- 依存別モックパターンカタログ（Firestore/Storage/genai/HTTP/ファイルI/O）をサポートファイルに分離

## Test plan

- [x] 既存 80 ユニットテスト全 PASS（影響なし）
- [ ] `/gen-test archive_agents/tools/scholar_tools.py` でテスト生成を実行し、`tests/unit/test_scholar_tools.py` が生成されることを確認
- [ ] 生成されたテストが `pytest tests/unit/test_scholar_tools.py -v` で実行可能であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)