### PR TITLE
fix: Sources 引用リストを Evidence セクション内に表示

### DIFF
--- a/web/src/app/admin/preview/[id]/page.tsx
+++ b/web/src/app/admin/preview/[id]/page.tsx
@@ -17,7 +17,7 @@ import {
 } from "lucide-react"
 import Markdown from "react-markdown"
 import remarkGfm from "remark-gfm"
-import { stripSourcesSection } from "@/lib/strip-sources"
+import { stripSourcesSection, extractSourcesSection } from "@/lib/strip-sources"
 import { notFound } from "next/navigation"
 
 // Dynamic rendering for preview (no caching)
@@ -58,6 +58,7 @@ export default async function PreviewPage({
   const summary = mystery.summary_en || mystery.summary
   const narrativeContentRaw = mystery.narrative_content_en || mystery.narrative_content
   const narrativeContent = narrativeContentRaw ? stripSourcesSection(narrativeContentRaw) : narrativeContentRaw
+  const sourcesMarkdown = narrativeContentRaw ? extractSourcesSection(narrativeContentRaw) : null
   const discrepancyDetected = mystery.discrepancy_detected_en || mystery.discrepancy_detected
   const hypothesis = mystery.hypothesis_en || mystery.hypothesis
   const alternativeHypotheses = mystery.alternative_hypotheses_en || mystery.alternative_hypotheses
@@ -221,6 +222,14 @@ export default async function PreviewPage({
                     <EvidenceBlock key={i} evidence={ev} label={`Additional Evidence ${i + 1}`} />
                   ))}
                 </div>
+                {sourcesMarkdown && (
+                  <div className="mt-8 pt-6 border-t border-border">
+                    <p className="text-xs font-mono uppercase tracking-wide text-muted-foreground mb-3">Referenced Sources</p>
+                    <div className="prose prose-sm prose-invert max-w-none prose-li:text-foreground/70 prose-li:my-1">
+                      <Markdown remarkPlugins={[remarkGfm]}>{sourcesMarkdown}</Markdown>
+                    </div>
+                  </div>
+                )}
               </section>
 
               {/* Hypothesis */}

--- a/web/src/app/mystery/[id]/page.tsx
+++ b/web/src/app/mystery/[id]/page.tsx
@@ -17,7 +17,7 @@ import {
 } from "lucide-react"
 import Markdown from "react-markdown"
 import remarkGfm from "remark-gfm"
-import { stripSourcesSection } from "@/lib/strip-sources"
+import { stripSourcesSection, extractSourcesSection } from "@/lib/strip-sources"
 
 export const revalidate = 86400
 
@@ -65,6 +65,7 @@ export default async function MysteryDetailPage({
   const summary = mystery.summary_en || mystery.summary
   const narrativeContentRaw = mystery.narrative_content_en || mystery.narrative_content
   const narrativeContent = narrativeContentRaw ? stripSourcesSection(narrativeContentRaw) : narrativeContentRaw
+  const sourcesMarkdown = narrativeContentRaw ? extractSourcesSection(narrativeContentRaw) : null
   const discrepancyDetected = mystery.discrepancy_detected_en || mystery.discrepancy_detected
   const hypothesis = mystery.hypothesis_en || mystery.hypothesis
   const alternativeHypotheses = mystery.alternative_hypotheses_en || mystery.alternative_hypotheses
@@ -196,6 +197,14 @@ export default async function MysteryDetailPage({
                     <EvidenceBlock key={i} evidence={ev} label={`Additional Evidence ${i + 1}`} />
                   ))}
                 </div>
+                {sourcesMarkdown && (
+                  <div className="mt-8 pt-6 border-t border-border">
+                    <p className="text-xs font-mono uppercase tracking-wide text-muted-foreground mb-3">Referenced Sources</p>
+                    <div className="prose prose-sm prose-invert max-w-none prose-li:text-foreground/70 prose-li:my-1">
+                      <Markdown remarkPlugins={[remarkGfm]}>{sourcesMarkdown}</Markdown>
+                    </div>
+                  </div>
+                )}
               </section>
 
               {/* Hypothesis */}

--- a/web/src/lib/__tests__/strip-sources.test.ts
+++ b/web/src/lib/__tests__/strip-sources.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { stripSourcesSection } from "../strip-sources"
+import { stripSourcesSection, extractSourcesSection } from "../strip-sources"
 
 describe("stripSourcesSection", () => {
   it("removes a trailing Sources section with single-line list", () => {
@@ -70,7 +70,72 @@ Part 2.`
     expect(stripSourcesSection(input)).toBe(input)
   })
 
+  it("removes bold markdown **Sources:** format", () => {
+    const input = `# Title
+
+Content here.
+
+---
+**Sources:**
+
+*   Source A. Library of Congress.
+*   Source B. NYPL Digital Collections.`
+
+    expect(stripSourcesSection(input)).toBe(
+      `# Title
+
+Content here.`
+    )
+  })
+
   it("handles empty string", () => {
     expect(stripSourcesSection("")).toBe("")
+  })
+})
+
+describe("extractSourcesSection", () => {
+  it("extracts citation list from bold Sources format", () => {
+    const input = `# Title
+
+Content here.
+
+---
+**Sources:**
+
+*   Source A. Library of Congress.
+*   Source B. NYPL Digital Collections.`
+
+    expect(extractSourcesSection(input)).toBe(
+      `*   Source A. Library of Congress.
+*   Source B. NYPL Digital Collections.`
+    )
+  })
+
+  it("extracts citation list from plain Sources format", () => {
+    const input = `# Title
+
+Content.
+
+---
+Sources:
+- Library of Congress Digital Archive
+- DPLA: Boston Historical Society`
+
+    expect(extractSourcesSection(input)).toBe(
+      `- Library of Congress Digital Archive
+- DPLA: Boston Historical Society`
+    )
+  })
+
+  it("returns null when no Sources section exists", () => {
+    const input = `# Title
+
+Some content without sources.`
+
+    expect(extractSourcesSection(input)).toBeNull()
+  })
+
+  it("returns null for empty string", () => {
+    expect(extractSourcesSection("")).toBeNull()
   })
 })

--- a/web/src/lib/strip-sources.ts
+++ b/web/src/lib/strip-sources.ts
@@ -1,17 +1,30 @@
 /**
- * Remove the trailing "Sources" section from narrative_content.
+ * Extract and separate the trailing "Sources" section from narrative_content.
  *
- * Storyteller used to append a markdown section like:
+ * Storyteller appends a markdown section like:
  *   ---
- *   Sources: [list of citations]
+ *   **Sources:**
+ *   * Source A...
  *
- * This is now redundant because the same information is displayed in the
- * structured "Sources & Evidence" block. For backward compatibility with
- * existing articles we strip it at render time rather than migrating
- * Firestore documents.
+ * We split it from the narrative body so it can be rendered inside the
+ * "Sources & Evidence" section instead of at the end of the article text.
+ */
+
+const SOURCES_PATTERN = /\n---\n\s*\*{0,2}Sources:\*{0,2}([\s\S]*)$/;
+
+/**
+ * Remove the trailing Sources section from narrative_content.
  */
 export function stripSourcesSection(content: string): string {
-  // Match a trailing HR (---) followed by a line starting with "Sources:"
-  // and everything after it until end-of-string.
-  return content.replace(/\n---\n\s*Sources:[\s\S]*$/, "").trimEnd();
+  return content.replace(SOURCES_PATTERN, "").trimEnd();
+}
+
+/**
+ * Extract the Sources citation list from narrative_content.
+ * Returns the citation text (without the "Sources:" heading) or null if not found.
+ */
+export function extractSourcesSection(content: string): string | null {
+  const match = content.match(SOURCES_PATTERN);
+  if (!match) return null;
+  return match[1].trim() || null;
 }


### PR DESCRIPTION
## Summary

- `narrative_content` 末尾の Sources テキストを削除するだけでなく、`extractSourcesSection` で抽出して「Sources & Evidence」セクション内に「Referenced Sources」として表示
- `**Sources:**`（太字マークダウン）形式にも対応する正規表現修正
- 公開ページ・管理画面プレビューの両方に適用

## Background

PR #3 で Sources を strip していたが、Evidence ブロックの構造化データには含まれない引用情報（所蔵先名など）が失われていた。Sources テキストを抽出して Evidence セクション内に移動することで情報の欠落なく統合。

## Test plan

- [x] `vitest run` で全11テストパス（`stripSourcesSection` 7件 + `extractSourcesSection` 4件）
- [x] ローカル dev サーバーで既存記事の Sources が「Sources & Evidence」内に表示されることを目視確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)