### PR TITLE
feat: /gen-eval スキル追加 — ADK エージェント評価テスト自動生成

### DIFF
--- a/.claude/skills/gen-eval/SKILL.md
+++ b/.claude/skills/gen-eval/SKILL.md
@@ -1,97 +1,103 @@
 ---
 name: gen-eval
-description: "This skill should be used when the user asks to '/gen-eval', 'generate eval tests', 'create evaluation tests for agent', 'add golden dataset', 'generate ADK eval', or needs to create ADK agent-level evaluation tests including Golden Datasets, eval content verification tests, and agent handover tests."
+description: "ADK エージェントの評価テストを生成。Golden Dataset・eval 検証テスト・handover テストを自動生成"
 argument-hint: "[agent_module_path]"
+disable-model-invocation: true
+allowed-tools: Read, Glob, Grep, Bash, Write, Edit
 ---
 
-# ADK Agent Evaluation Test Generator
+# /gen-eval — ADK エージェント評価テスト自動生成
 
-Generate ADK agent-level evaluation tests: Golden Dataset (eval_set JSON), eval content verification tests, and agent handover tests.
+対象エージェントモジュールのパスを `$ARGUMENTS` で受け取り、以下の3つを生成する:
 
-## Workflow
+1. **Golden Dataset** — `tests/eval/eval_sets/{agent}_eval.json`
+2. **Eval コンテンツ検証テスト** — `tests/eval/test_adk_eval.py` の `TestEvalSetContent` にメソッド追加
+3. **Agent Handover テスト** — `tests/integration/test_agent_handover.py` にメソッド追加
 
-Follow these 7 steps in order when `$ARGUMENTS` is provided. If `$ARGUMENTS` is empty, ask the user to specify an agent module path (e.g., `archive_agents/agents/scholar.py`).
+## ワークフロー
 
-### Step 1: Parse Agent Module
+`$ARGUMENTS` が空の場合は、エージェントモジュールパス（例: `archive_agents/agents/scholar.py`）の指定を求める。
 
-Read the agent module file at `$ARGUMENTS` and extract:
+### Step 1: エージェントモジュール解析
 
-- **name**: Agent variable name (e.g., `scholar_agent`)
-- **model**: Model string (e.g., `gemini-3-pro-preview`)
-- **output_key**: Session state output key (e.g., `mystery_report`)
-- **tools**: List of tool functions (from `tools=[]` parameter)
-- **instruction**: Full instruction string (look for `{placeholder}` patterns)
-- **failure_markers_checked**: Markers the agent checks in upstream data (e.g., `NO_DOCUMENTS_FOUND`)
-- **failure_markers_emitted**: Markers the agent emits on failure (e.g., `INSUFFICIENT_DATA`)
+`$ARGUMENTS` のファイルを読み取り、以下を抽出する:
 
-### Step 2: Determine Pipeline Context
+- **name**: エージェント変数名（例: `scholar_agent`）
+- **model**: モデル文字列（例: `gemini-3-pro-preview`）
+- **output_key**: セッション状態の出力キー（例: `mystery_report`）
+- **tools**: ツール関数のリスト（`tools=[]` パラメータから取得）
+- **instruction**: instruction 文字列全体（`{placeholder}` パターンを探す）
+- **failure_markers_checked**: 上流データでチェックする失敗マーカー（例: `NO_DOCUMENTS_FOUND`）
+- **failure_markers_emitted**: 失敗時に出力するマーカー（例: `INSUFFICIENT_DATA`）
 
-Identify the pipeline from the file path prefix:
+### Step 2: パイプラインコンテキスト決定
 
-| Path Prefix | Pipeline | Commander |
-|-------------|----------|-----------|
-| `archive_agents/` | archive (blog) | `ghost_commander` |
+ファイルパスのプレフィックスからパイプラインを特定する:
+
+| パスプレフィックス | パイプライン | コマンダー |
+|-------------------|------------|-----------|
+| `archive_agents/` | archive（ブログ） | `ghost_commander` |
 | `podcast_agents/` | podcast | `podcast_commander` |
 | `translator_agents/` | translator | `translator_commander` |
 
-Cross-reference with `agent-catalog.md` (in this skill's directory) to determine:
-- Predecessor agent and its `output_key` (the session state key this agent reads)
-- Successor agent (if any)
-- Expected eval scenarios for this agent
+このスキルのディレクトリにある `agent-catalog.md` と照合し、以下を把握する:
+- 前段エージェントとその `output_key`（このエージェントが読み取るセッション状態キー）
+- 後段エージェント（存在する場合）
+- このエージェントに期待される eval シナリオ
 
-### Step 3: Check Existing Tests
+### Step 3: 既存テスト確認
 
-Scan for existing tests to avoid duplication:
+重複を避けるため、既存テストをスキャンする:
 
-1. **Eval set JSON**: Check `tests/eval/eval_sets/{agent_name}_eval.json`
-2. **Eval content tests**: Grep `tests/eval/test_adk_eval.py` for `test_{agent_name}_eval_covers`
-3. **Handover tests**: Grep `tests/integration/test_agent_handover.py` for `test_{agent_name}_output_key`
+1. **Eval set JSON**: `tests/eval/eval_sets/{agent_name}_eval.json` の存在確認
+2. **Eval コンテンツテスト**: `tests/eval/test_adk_eval.py` 内の `test_{agent_name}_eval_covers` を検索
+3. **Handover テスト**: `tests/integration/test_agent_handover.py` 内の `test_{agent_name}_output_key` を検索
 
-Report what exists and what needs to be generated.
+何が存在し、何を生成する必要があるか報告する。
 
-### Step 4: Generate Golden Dataset
+### Step 4: Golden Dataset 生成
 
-Create or update `tests/eval/eval_sets/{agent_name}_eval.json`.
+`tests/eval/eval_sets/{agent_name}_eval.json` を作成または更新する。
 
-Consult `eval-set-format.md` (in this skill's directory) for the exact ADK eval_set JSON format specification. Consult `agent-catalog.md` for the expected eval scenarios for this agent.
+このスキルのディレクトリにある `eval-set-format.md` で ADK eval_set JSON の正確なフォーマット仕様を確認する。`agent-catalog.md` でこのエージェントに期待される eval シナリオを確認する。
 
-**Rules:**
+**ルール:**
 - `eval_set_id`: `{agent_name}_eval_v1`
 - `eval_id`: `{agent_name}_{scenario_snake_case}`
-- `user_content.parts[0].text`: Always in Japanese
-- `intermediate_data.tool_uses`: List expected tools with `"args": {}` (empty args). Set to `[]` for agents without tools or for failure scenarios
-- `final_response.parts[0].text`: Include `output_key` name + expected keywords (space-separated). For failure scenarios, include the failure marker keyword
+- `user_content.parts[0].text`: 必ず日本語で記述
+- `intermediate_data.tool_uses`: 期待されるツールを `"args": {}`（空）で列挙。ツールなしのエージェントまたは失敗シナリオでは `[]`
+- `final_response.parts[0].text`: `output_key` 名 + 期待キーワード（スペース区切り）。失敗シナリオでは失敗マーカーキーワード
 
-If the file already exists, compare existing `eval_id` values against the expected scenarios from `agent-catalog.md`. Only add missing scenarios.
+ファイルが既に存在する場合は、既存の `eval_id` を `agent-catalog.md` の期待シナリオと比較し、不足シナリオのみ追加する。
 
-### Step 5: Generate Eval Content Verification Tests
+### Step 5: Eval コンテンツ検証テスト生成
 
-Add methods to `TestEvalSetContent` class in `tests/eval/test_adk_eval.py`.
+`tests/eval/test_adk_eval.py` の `TestEvalSetContent` クラスにメソッドを追加する。
 
-**Generate these test methods** (skip if already present):
+**生成するテストメソッド**（既に存在する場合はスキップ）:
 
-1. `test_{agent_name}_eval_covers_key_scenarios` — Verify eval_set contains expected scenario eval_ids. Use `any("keyword" in eid.lower() for eid in eval_ids)` pattern matching the existing test style
-2. For agents with tools: A test verifying `intermediate_data.tool_uses` contains expected tool names (follow `test_publisher_eval_covers_tool_usage` pattern)
-3. For agents that emit failure markers: Verify a failure scenario exists in the eval_set
+1. `test_{agent_name}_eval_covers_key_scenarios` — eval_set に期待されるシナリオの eval_id が含まれることを検証。`any("keyword" in eid.lower() for eid in eval_ids)` パターンで既存テストスタイルに合わせる
+2. ツールを持つエージェントの場合: `intermediate_data.tool_uses` に期待されるツール名が含まれることを検証（`test_publisher_eval_covers_tool_usage` パターンに従う）
+3. 失敗マーカーを出力するエージェントの場合: eval_set に失敗シナリオが存在することを検証
 
-Follow the exact code style of existing methods in `TestEvalSetContent`. Import nothing extra — the class already has `json`, `Path`, `EVAL_SETS_DIR` available.
+`TestEvalSetContent` の既存メソッドのコードスタイルに厳密に従う。追加 import は不要 — クラスのスコープで `json`, `Path`, `EVAL_SETS_DIR` が利用可能。
 
-### Step 6: Generate Agent Handover Tests
+### Step 6: Agent Handover テスト生成
 
-Add methods to the appropriate class in `tests/integration/test_agent_handover.py`.
+`tests/integration/test_agent_handover.py` の適切なクラスにメソッドを追加する。
 
-**Generate these test methods** (skip if already present):
+**生成するテストメソッド**（既に存在する場合はスキップ）:
 
-1. `test_{agent_name}_output_key` — Verify `agent.output_key == "expected_key"` (add to `TestSessionStateKeys` or `TestPodcastSessionStateKeys`)
-2. `test_{agent_name}_references_{predecessor_key}` — Verify `"{predecessor_key}" in agent.instruction` (add to `TestInstructionPlaceholders` or `TestPodcastInstructionPlaceholders`)
-3. `test_{agent_name}_checks_upstream_failure` — Verify the agent's instruction contains the upstream failure marker string (add to `TestFailureMarkers` if not already covered)
-4. `test_{agent_name}_uses_correct_model` — Verify `agent.model == "gemini-3-pro-preview"` (add to `TestAgentModels`)
+1. `test_{agent_name}_output_key` — `agent.output_key == "expected_key"` を検証（`TestSessionStateKeys` または `TestPodcastSessionStateKeys` に追加）
+2. `test_{agent_name}_references_{predecessor_key}` — `"{predecessor_key}" in agent.instruction` を検証（`TestInstructionPlaceholders` または `TestPodcastInstructionPlaceholders` に追加）
+3. `test_{agent_name}_checks_upstream_failure` — エージェントの instruction に上流の失敗マーカー文字列が含まれることを検証（`TestFailureMarkers` に追加。既にカバーされている場合はスキップ）
+4. `test_{agent_name}_uses_correct_model` — `agent.model == "gemini-3-pro-preview"` を検証（`TestAgentModels` に追加）
 
-Follow the exact import and assertion patterns of existing test methods.
+既存テストメソッドの import パターンとアサーションパターンに厳密に従う。
 
-### Step 7: Verify
+### Step 7: 検証
 
-Run structural tests to confirm generated files are valid:
+生成したファイルが有効であることを構造テストで確認する:
 
 ```bash
 pytest tests/eval/test_adk_eval.py::TestADKEvaluationSetup -v
@@ -99,11 +105,11 @@ pytest tests/eval/test_adk_eval.py::TestEvalSetContent -v
 pytest tests/integration/test_agent_handover.py -v
 ```
 
-Report results. If any test fails, fix and re-run.
+結果を報告する。テストが失敗した場合は修正して再実行する。
 
-## Reference Files
+## リファレンス
 
-Consult these files in this skill's directory for detailed specifications:
+このスキルのディレクトリにある以下のファイルで詳細仕様を確認:
 
-- **`agent-catalog.md`** — Full agent definitions catalog: properties, pipeline positions, expected eval scenarios
-- **`eval-set-format.md`** — ADK eval_set JSON format specification with annotated examples
+- **`agent-catalog.md`** — 全エージェント定義カタログ: プロパティ、パイプライン上の位置、期待される eval シナリオ
+- **`eval-set-format.md`** — ADK eval_set JSON フォーマット仕様（annotated example 付き）

--- a/.claude/skills/gen-eval/agent-catalog.md
+++ b/.claude/skills/gen-eval/agent-catalog.md
@@ -1,242 +1,242 @@
-# Agent Catalog
+# エージェントカタログ
 
-All ADK agents in the project with their properties and expected eval scenarios.
+プロジェクト内の全 ADK エージェントのプロパティと期待される eval シナリオの一覧。
 
-## Archive Pipeline (`archive_agents/`)
+## Archive パイプライン（`archive_agents/`）
 
-Pipeline order: Librarian → Scholar → Storyteller → Illustrator → Publisher
+パイプライン順序: Librarian → Scholar → Storyteller → Illustrator → Publisher
 
-Curator is a standalone agent (not in the sequential pipeline).
+Curator はスタンドアロンエージェント（シーケンシャルパイプラインには含まれない）。
 
 ### Librarian
 
-| Property | Value |
+| プロパティ | 値 |
 |----------|-------|
-| Module | `archive_agents/agents/librarian.py` |
-| Variable | `librarian_agent` |
-| Model | `gemini-3-pro-preview` |
-| Output Key | `collected_documents` |
-| Tools | `search_newspapers`, `search_archives`, `get_available_keywords` |
-| Predecessor | (none — first agent) |
-| Checks Marker | (none) |
-| Emits Marker | `NO_DOCUMENTS_FOUND` |
-| Placeholders | (none) |
+| モジュール | `archive_agents/agents/librarian.py` |
+| 変数名 | `librarian_agent` |
+| モデル | `gemini-3-pro-preview` |
+| 出力キー | `collected_documents` |
+| ツール | `search_newspapers`, `search_archives`, `get_available_keywords` |
+| 前段 | （なし — 最初のエージェント） |
+| チェックするマーカー | （なし） |
+| 出力するマーカー | `NO_DOCUMENTS_FOUND` |
+| プレースホルダー | （なし） |
 
-**Eval Scenarios:**
+**Eval シナリオ:**
 
-| eval_id | Description | tool_uses | final_response keywords |
-|---------|-------------|-----------|------------------------|
-| `librarian_basic_search` | Basic historical document search | `search_newspapers`, `search_archives` | `collected_documents total_found` |
-| `librarian_folklore_search` | Folklore/legend search with keyword discovery | `get_available_keywords`, `search_newspapers` | `ghost legend folklore` |
-| `librarian_no_results` | No documents found (impossible query) | `search_newspapers` | `NO_DOCUMENTS_FOUND` |
-| `librarian_bilingual_expansion` | Bilingual (English + Spanish) search | `search_newspapers`, `search_archives` | `sources_searched` |
+| eval_id | 説明 | tool_uses | final_response キーワード |
+|---------|------|-----------|------------------------|
+| `librarian_basic_search` | 基本的な歴史文書検索 | `search_newspapers`, `search_archives` | `collected_documents total_found` |
+| `librarian_folklore_search` | 民俗・伝説検索（キーワード探索あり） | `get_available_keywords`, `search_newspapers` | `ghost legend folklore` |
+| `librarian_no_results` | 文書なし（不可能なクエリ） | `search_newspapers` | `NO_DOCUMENTS_FOUND` |
+| `librarian_bilingual_expansion` | バイリンガル（英語＋スペイン語）検索 | `search_newspapers`, `search_archives` | `sources_searched` |
 
 ---
 
 ### Scholar
 
-| Property | Value |
+| プロパティ | 値 |
 |----------|-------|
-| Module | `archive_agents/agents/scholar.py` |
-| Variable | `scholar_agent` |
-| Model | `gemini-3-pro-preview` |
-| Output Key | `mystery_report` |
-| Tools | (none) |
-| Predecessor | Librarian (`collected_documents`) |
-| Checks Marker | `NO_DOCUMENTS_FOUND` |
-| Emits Marker | `INSUFFICIENT_DATA` |
-| Placeholders | `{collected_documents}` |
+| モジュール | `archive_agents/agents/scholar.py` |
+| 変数名 | `scholar_agent` |
+| モデル | `gemini-3-pro-preview` |
+| 出力キー | `mystery_report` |
+| ツール | （なし） |
+| 前段 | Librarian（`collected_documents`） |
+| チェックするマーカー | `NO_DOCUMENTS_FOUND` |
+| 出力するマーカー | `INSUFFICIENT_DATA` |
+| プレースホルダー | `{collected_documents}` |
 
-**Eval Scenarios:**
+**Eval シナリオ:**
 
-| eval_id | Description | tool_uses | final_response keywords |
-|---------|-------------|-----------|------------------------|
-| `scholar_fact_based_analysis` | Historical fact analysis with date/event discrepancies | `[]` | `mystery_report DATE_MISMATCH` |
-| `scholar_folklore_analysis` | Folklore anomaly analysis (recurring patterns, taboos) | `[]` | `Folkloric Context RECURRING_PATTERN` |
-| `scholar_anthropological_analysis` | Cultural anthropology analysis (power structures, rituals) | `[]` | `Anthropological Context POWER_ERASURE` |
-| `scholar_insufficient_data` | Insufficient data handling | `[]` | `INSUFFICIENT_DATA NO_DOCUMENTS_FOUND` |
-| `scholar_cross_reference_analysis` | Cross-reference of fact, folklore, and anthropology | `[]` | `Folkloric Context Anthropological Context` |
+| eval_id | 説明 | tool_uses | final_response キーワード |
+|---------|------|-----------|------------------------|
+| `scholar_fact_based_analysis` | 歴史的事実の分析（日付・事象の矛盾） | `[]` | `mystery_report DATE_MISMATCH` |
+| `scholar_folklore_analysis` | 民俗学的アノマリー分析（反復パターン、禁忌） | `[]` | `Folkloric Context RECURRING_PATTERN` |
+| `scholar_anthropological_analysis` | 文化人類学分析（権力構造、儀礼） | `[]` | `Anthropological Context POWER_ERASURE` |
+| `scholar_insufficient_data` | データ不足時の処理 | `[]` | `INSUFFICIENT_DATA NO_DOCUMENTS_FOUND` |
+| `scholar_cross_reference_analysis` | 事実・民俗・人類学の相互参照 | `[]` | `Folkloric Context Anthropological Context` |
 
 ---
 
 ### Storyteller
 
-| Property | Value |
+| プロパティ | 値 |
 |----------|-------|
-| Module | `archive_agents/agents/storyteller.py` |
-| Variable | `storyteller_agent` |
-| Model | `gemini-3-pro-preview` |
-| Output Key | `creative_content` |
-| Tools | (none) |
-| Predecessor | Scholar (`mystery_report`) |
-| Checks Marker | `INSUFFICIENT_DATA` |
-| Emits Marker | `NO_CONTENT` |
-| Placeholders | `{mystery_report}` |
+| モジュール | `archive_agents/agents/storyteller.py` |
+| 変数名 | `storyteller_agent` |
+| モデル | `gemini-3-pro-preview` |
+| 出力キー | `creative_content` |
+| ツール | （なし） |
+| 前段 | Scholar（`mystery_report`） |
+| チェックするマーカー | `INSUFFICIENT_DATA` |
+| 出力するマーカー | `NO_CONTENT` |
+| プレースホルダー | `{mystery_report}` |
 
-**Eval Scenarios:**
+**Eval シナリオ:**
 
-| eval_id | Description | tool_uses | final_response keywords |
-|---------|-------------|-----------|------------------------|
-| `storyteller_complete_narrative` | Full blog article generation | `[]` | `creative_content Sources Firestore` |
-| `storyteller_fact_folklore_balance` | Balance of historical fact and folklore elements | `[]` | `伝説 記録 Firestore` |
-| `storyteller_four_part_structure` | Four-part narrative structure (discovery, evidence, context, mystery) | `[]` | `アーカイブ Sources Firestore` |
-| `storyteller_insufficient_data` | NO_CONTENT emission on insufficient input | `[]` | `NO_CONTENT INSUFFICIENT_DATA` |
+| eval_id | 説明 | tool_uses | final_response キーワード |
+|---------|------|-----------|------------------------|
+| `storyteller_complete_narrative` | 完全なブログ記事生成 | `[]` | `creative_content Sources Firestore` |
+| `storyteller_fact_folklore_balance` | 歴史的事実と民俗要素のバランス | `[]` | `伝説 記録 Firestore` |
+| `storyteller_four_part_structure` | 4部構成（発掘、証拠、文脈、余韻） | `[]` | `アーカイブ Sources Firestore` |
+| `storyteller_insufficient_data` | 入力不足時の NO_CONTENT 出力 | `[]` | `NO_CONTENT INSUFFICIENT_DATA` |
 
 ---
 
 ### Illustrator
 
-| Property | Value |
+| プロパティ | 値 |
 |----------|-------|
-| Module | `archive_agents/agents/illustrator.py` |
-| Variable | `illustrator_agent` |
-| Model | `gemini-3-pro-preview` |
-| Output Key | `visual_assets` |
-| Tools | `generate_image` |
-| Predecessor | Storyteller (`creative_content`) |
-| Checks Marker | `NO_CONTENT` |
-| Emits Marker | (none) |
-| Placeholders | `{creative_content}` |
+| モジュール | `archive_agents/agents/illustrator.py` |
+| 変数名 | `illustrator_agent` |
+| モデル | `gemini-3-pro-preview` |
+| 出力キー | `visual_assets` |
+| ツール | `generate_image` |
+| 前段 | Storyteller（`creative_content`） |
+| チェックするマーカー | `NO_CONTENT` |
+| 出力するマーカー | （なし） |
+| プレースホルダー | `{creative_content}` |
 
-**Eval Scenarios:**
+**Eval シナリオ:**
 
-| eval_id | Description | tool_uses | final_response keywords |
-|---------|-------------|-----------|------------------------|
-| `illustrator_fact_style` | Fact-based image (white/black photo style) | `generate_image` | `visual_assets Fact` |
-| `illustrator_folklore_style` | Folklore-based image (19th-century engraving style) | `generate_image` | `visual_assets Folklore` |
-| `illustrator_no_content_skip` | Skip generation when NO_CONTENT | `[]` | `NO_CONTENT` |
+| eval_id | 説明 | tool_uses | final_response キーワード |
+|---------|------|-----------|------------------------|
+| `illustrator_fact_style` | Fact 系画像（白黒写真風） | `generate_image` | `visual_assets Fact` |
+| `illustrator_folklore_style` | Folklore 系画像（19世紀版画風） | `generate_image` | `visual_assets Folklore` |
+| `illustrator_no_content_skip` | NO_CONTENT 時の生成スキップ | `[]` | `NO_CONTENT` |
 
 ---
 
 ### Publisher
 
-| Property | Value |
+| プロパティ | 値 |
 |----------|-------|
-| Module | `archive_agents/agents/publisher.py` |
-| Variable | `publisher_agent` |
-| Model | `gemini-3-pro-preview` |
-| Output Key | `published_episode` |
-| Tools | `upload_images`, `publish_mystery` |
-| Predecessor | Illustrator (`visual_assets`) + all upstream keys |
-| Checks Marker | All upstream markers (`NO_DOCUMENTS_FOUND`, `INSUFFICIENT_DATA`, `NO_CONTENT`) |
-| Emits Marker | (none) |
-| Placeholders | `{collected_documents}`, `{mystery_report}`, `{creative_content}`, `{visual_assets}` |
+| モジュール | `archive_agents/agents/publisher.py` |
+| 変数名 | `publisher_agent` |
+| モデル | `gemini-3-pro-preview` |
+| 出力キー | `published_episode` |
+| ツール | `upload_images`, `publish_mystery` |
+| 前段 | Illustrator（`visual_assets`）+ 全上流キー |
+| チェックするマーカー | 全上流マーカー（`NO_DOCUMENTS_FOUND`, `INSUFFICIENT_DATA`, `NO_CONTENT`） |
+| 出力するマーカー | （なし） |
+| プレースホルダー | `{collected_documents}`, `{mystery_report}`, `{creative_content}`, `{visual_assets}` |
 
-**Eval Scenarios:**
+**Eval シナリオ:**
 
-| eval_id | Description | tool_uses | final_response keywords |
-|---------|-------------|-----------|------------------------|
-| `publisher_full_workflow` | Full publish workflow with image upload | `upload_images`, `publish_mystery` | `published_episode Firestore mystery_id` |
-| `publisher_document_structure` | Verify required Firestore fields | `publish_mystery` | `mystery_id status Firestore` |
-| `publisher_failure_handling` | Skip publish when upstream failures detected | `[]` | `INSUFFICIENT_DATA NO_CONTENT` |
+| eval_id | 説明 | tool_uses | final_response キーワード |
+|---------|------|-----------|------------------------|
+| `publisher_full_workflow` | 画像アップロード付きフル公開ワークフロー | `upload_images`, `publish_mystery` | `published_episode Firestore mystery_id` |
+| `publisher_document_structure` | Firestore 必須フィールドの検証 | `publish_mystery` | `mystery_id status Firestore` |
+| `publisher_failure_handling` | 上流失敗検出時の公開スキップ | `[]` | `INSUFFICIENT_DATA NO_CONTENT` |
 
 ---
 
 ### Curator
 
-| Property | Value |
+| プロパティ | 値 |
 |----------|-------|
-| Module | `archive_agents/agents/curator.py` |
-| Variable | `curator_agent` |
-| Model | `gemini-3-pro-preview` |
-| Output Key | `suggested_themes` |
-| Tools | (none) |
-| Predecessor | (standalone — not in sequential pipeline) |
-| Checks Marker | (none) |
-| Emits Marker | (none) |
-| Placeholders | `{existing_titles}` |
+| モジュール | `archive_agents/agents/curator.py` |
+| 変数名 | `curator_agent` |
+| モデル | `gemini-3-pro-preview` |
+| 出力キー | `suggested_themes` |
+| ツール | （なし） |
+| 前段 | （スタンドアロン — シーケンシャルパイプライン外） |
+| チェックするマーカー | （なし） |
+| 出力するマーカー | （なし） |
+| プレースホルダー | `{existing_titles}` |
 
-**Eval Scenarios:**
+**Eval シナリオ:**
 
-| eval_id | Description | tool_uses | final_response keywords |
-|---------|-------------|-----------|------------------------|
-| `curator_theme_suggestion` | Generate investigation themes | `[]` | `suggested_themes Fact Folklore` |
-| `curator_duplicate_avoidance` | Avoid suggesting existing titles | `[]` | `suggested_themes 重複なし` |
+| eval_id | 説明 | tool_uses | final_response キーワード |
+|---------|------|-----------|------------------------|
+| `curator_theme_suggestion` | 調査テーマの提案 | `[]` | `suggested_themes Fact Folklore` |
+| `curator_duplicate_avoidance` | 既存タイトルとの重複回避 | `[]` | `suggested_themes 重複なし` |
 
 ---
 
-## Podcast Pipeline (`podcast_agents/`)
+## Podcast パイプライン（`podcast_agents/`）
 
-Pipeline order: Scriptwriter → Producer
+パイプライン順序: Scriptwriter → Producer
 
 ### Scriptwriter
 
-| Property | Value |
+| プロパティ | 値 |
 |----------|-------|
-| Module | `podcast_agents/agents/scriptwriter.py` |
-| Variable | `scriptwriter_agent` |
-| Model | `gemini-3-pro-preview` |
-| Output Key | `podcast_script` |
-| Tools | (none) |
-| Predecessor | (reads `creative_content` from Firestore pre-set) |
-| Checks Marker | `NO_CONTENT` |
-| Emits Marker | `NO_SCRIPT` |
-| Placeholders | `{creative_content}` |
+| モジュール | `podcast_agents/agents/scriptwriter.py` |
+| 変数名 | `scriptwriter_agent` |
+| モデル | `gemini-3-pro-preview` |
+| 出力キー | `podcast_script` |
+| ツール | （なし） |
+| 前段 | （Firestore から `creative_content` を事前セット） |
+| チェックするマーカー | `NO_CONTENT` |
+| 出力するマーカー | `NO_SCRIPT` |
+| プレースホルダー | `{creative_content}` |
 
-**Eval Scenarios:**
+**Eval シナリオ:**
 
-| eval_id | Description | tool_uses | final_response keywords |
-|---------|-------------|-----------|------------------------|
-| `scriptwriter_complete_script` | Full podcast script generation | `[]` | `podcast_script INTRO OUTRO` |
-| `scriptwriter_segment_structure` | Verify INTRO/SEGMENTS/OUTRO structure | `[]` | `INTRO SEGMENTS OUTRO` |
-| `scriptwriter_no_content_failure` | NO_SCRIPT emission on NO_CONTENT input | `[]` | `NO_SCRIPT NO_CONTENT` |
+| eval_id | 説明 | tool_uses | final_response キーワード |
+|---------|------|-----------|------------------------|
+| `scriptwriter_complete_script` | 完全なポッドキャスト脚本生成 | `[]` | `podcast_script INTRO OUTRO` |
+| `scriptwriter_segment_structure` | INTRO/SEGMENTS/OUTRO 構成の検証 | `[]` | `INTRO SEGMENTS OUTRO` |
+| `scriptwriter_no_content_failure` | NO_CONTENT 入力時の NO_SCRIPT 出力 | `[]` | `NO_SCRIPT NO_CONTENT` |
 
 ---
 
 ### Producer
 
-| Property | Value |
+| プロパティ | 値 |
 |----------|-------|
-| Module | `podcast_agents/agents/producer.py` |
-| Variable | `producer_agent` |
-| Model | `gemini-3-pro-preview` |
-| Output Key | `audio_assets` |
-| Tools | (none) |
-| Predecessor | Scriptwriter (`podcast_script`) |
-| Checks Marker | (none) |
-| Emits Marker | (none) |
-| Placeholders | `{podcast_script}` |
+| モジュール | `podcast_agents/agents/producer.py` |
+| 変数名 | `producer_agent` |
+| モデル | `gemini-3-pro-preview` |
+| 出力キー | `audio_assets` |
+| ツール | （なし） |
+| 前段 | Scriptwriter（`podcast_script`） |
+| チェックするマーカー | （なし） |
+| 出力するマーカー | （なし） |
+| プレースホルダー | `{podcast_script}` |
 
-**Eval Scenarios:**
+**Eval シナリオ:**
 
-| eval_id | Description | tool_uses | final_response keywords |
-|---------|-------------|-----------|------------------------|
-| `producer_audio_plan` | Audio production plan generation | `[]` | `audio_assets voice SFX` |
-| `producer_bilingual_text` | Bilingual (Japanese/English) text segments | `[]` | `bilingual 日本語 English` |
-| `producer_voice_sfx_settings` | Voice and SFX configuration | `[]` | `voice SFX BGM` |
+| eval_id | 説明 | tool_uses | final_response キーワード |
+|---------|------|-----------|------------------------|
+| `producer_audio_plan` | 音声制作プランの生成 | `[]` | `audio_assets voice SFX` |
+| `producer_bilingual_text` | バイリンガル（日本語/英語）テキストセグメント | `[]` | `bilingual 日本語 English` |
+| `producer_voice_sfx_settings` | ボイスと SFX の設定 | `[]` | `voice SFX BGM` |
 
 ---
 
-## Translator Pipeline (`translator_agents/`)
+## Translator パイプライン（`translator_agents/`）
 
 ### Translator
 
-| Property | Value |
+| プロパティ | 値 |
 |----------|-------|
-| Module | `translator_agents/agents/translator.py` |
-| Variable | `translator_agent` |
-| Model | `gemini-3-pro-preview` |
-| Output Key | `translation_result` |
-| Tools | (none) |
-| Predecessor | (reads from Firestore pre-set fields) |
-| Checks Marker | `NO_CONTENT` |
-| Emits Marker | `NO_TRANSLATION` |
-| Placeholders | `{title}`, `{summary}`, `{narrative_content}`, `{discrepancy_detected}`, `{hypothesis}`, `{alternative_hypotheses}`, `{political_climate}`, `{story_hooks}` |
+| モジュール | `translator_agents/agents/translator.py` |
+| 変数名 | `translator_agent` |
+| モデル | `gemini-3-pro-preview` |
+| 出力キー | `translation_result` |
+| ツール | （なし） |
+| 前段 | （Firestore から事前セットされたフィールドを読み取り） |
+| チェックするマーカー | `NO_CONTENT` |
+| 出力するマーカー | `NO_TRANSLATION` |
+| プレースホルダー | `{title}`, `{summary}`, `{narrative_content}`, `{discrepancy_detected}`, `{hypothesis}`, `{alternative_hypotheses}`, `{political_climate}`, `{story_hooks}` |
 
-**Eval Scenarios:**
+**Eval シナリオ:**
 
-| eval_id | Description | tool_uses | final_response keywords |
-|---------|-------------|-----------|------------------------|
-| `translator_complete_translation` | Full Japanese-to-English translation | `[]` | `translation_result title_en summary_en narrative_content_en` |
-| `translator_no_content_skip` | NO_TRANSLATION emission on NO_CONTENT input | `[]` | `NO_TRANSLATION NO_CONTENT` |
-| `translator_json_output_format` | Verify JSON output structure with _en fields | `[]` | `translation_result JSON title_en` |
+| eval_id | 説明 | tool_uses | final_response キーワード |
+|---------|------|-----------|------------------------|
+| `translator_complete_translation` | 完全な日英翻訳 | `[]` | `translation_result title_en summary_en narrative_content_en` |
+| `translator_no_content_skip` | NO_CONTENT 入力時の NO_TRANSLATION 出力 | `[]` | `NO_TRANSLATION NO_CONTENT` |
+| `translator_json_output_format` | _en フィールド付き JSON 出力構造の検証 | `[]` | `translation_result JSON title_en` |
 
 ---
 
-## Maintenance
+## メンテナンス
 
-When adding a new agent to any pipeline:
+新しいエージェントをパイプラインに追加する際:
 
-1. Add the agent definition to this catalog following the same table format
-2. Run `/gen-eval` for the new agent to generate eval tests
-3. Verify all tests pass with `pytest tests/eval/ tests/integration/ -v`
+1. 同じテーブル形式でこのカタログにエージェント定義を追加する
+2. 新しいエージェントに対して `/gen-eval` を実行し eval テストを生成する
+3. `pytest tests/eval/ tests/integration/ -v` で全テストが通ることを確認する

--- a/.claude/skills/gen-eval/eval-set-format.md
+++ b/.claude/skills/gen-eval/eval-set-format.md
@@ -1,34 +1,34 @@
-# ADK Eval Set JSON Format Specification
+# ADK Eval Set JSON フォーマット仕様
 
-This document defines the exact format for Golden Dataset JSON files used by the ADK evaluation framework (`adk eval`).
+ADK 評価フレームワーク（`adk eval`）で使用する Golden Dataset JSON の正確なフォーマット定義。
 
-## File Location
+## ファイル配置
 
 ```
 tests/eval/eval_sets/{agent_name}_eval.json
 ```
 
-## Top-Level Structure
+## トップレベル構造
 
 ```json
 {
   "eval_set_id": "{agent_name}_eval_v1",
   "name": "{Agent Name} Agent Evaluation",
-  "description": "Tests {Agent Name}'s {capability description} via full pipeline execution",
+  "description": "{Agent Name} の{機能}を full pipeline 経由でテスト",
   "eval_cases": [...]
 }
 ```
 
-| Field | Format | Example |
-|-------|--------|---------|
+| フィールド | 形式 | 例 |
+|-----------|------|-----|
 | `eval_set_id` | `{agent_name}_eval_v1` | `scholar_eval_v1` |
 | `name` | `{Agent Name} Agent Evaluation` | `Scholar Agent Evaluation` |
-| `description` | Free text describing test scope | `"Tests Scholar's interdisciplinary analysis capabilities via full pipeline execution"` |
-| `eval_cases` | Array of eval case objects | See below |
+| `description` | テスト範囲を説明する自由テキスト | `"Tests Scholar's interdisciplinary analysis capabilities via full pipeline execution"` |
+| `eval_cases` | eval case オブジェクトの配列 | 下記参照 |
 
-## Eval Case Structure
+## Eval Case 構造
 
-Each item in `eval_cases`:
+`eval_cases` の各要素:
 
 ```json
 {
@@ -61,40 +61,40 @@ Each item in `eval_cases`:
 }
 ```
 
-## Field Specifications
+## フィールド仕様
 
 ### eval_id
 
-Format: `{agent_name}_{scenario_snake_case}`
+形式: `{agent_name}_{scenario_snake_case}`
 
-Examples:
+例:
 - `scholar_fact_based_analysis`
 - `librarian_no_results`
 - `publisher_full_workflow`
 
 ### invocation_id
 
-Sequential within the eval_set: `inv_001`, `inv_002`, `inv_003`, ...
+eval_set 内で連番: `inv_001`, `inv_002`, `inv_003`, ...
 
 ### user_content
 
-- `role`: Always `"user"`
-- `parts[0].text`: **Must be in Japanese.** Describe the task the pipeline receives. Write a realistic research/analysis request that triggers the target agent's specific behavior.
+- `role`: 常に `"user"`
+- `parts[0].text`: **必ず日本語で記述する。** パイプラインが受け取るタスクを記述する。対象エージェントの特定の動作をトリガーする現実的な調査・分析リクエストを書く。
 
-Good examples:
+良い例:
 ```
 "1842年3月のボストン港におけるスペイン船サンタマリア号の記録を分析してください。"
 "ニューイングランドの漁村で1850年代に複数の漁師が同じ場所で不可解な現象を報告しています。"
 ```
 
-For failure/edge-case scenarios, use obviously impossible requests:
+失敗・エッジケースシナリオでは、明らかに不可能なリクエストを使用:
 ```
 "2099年の火星植民地における歴史的事件について分析してください。"
 ```
 
 ### intermediate_data.tool_uses
 
-Array of expected tool calls. Each tool is specified with name only — `args` is always empty `{}`:
+期待されるツール呼び出しの配列。各ツールは名前のみ指定 — `args` は常に空の `{}`:
 
 ```json
 "tool_uses": [
@@ -103,46 +103,46 @@ Array of expected tool calls. Each tool is specified with name only — `args` i
 ]
 ```
 
-- For agents **without tools**: `"tool_uses": []`
-- For **failure scenarios** (even if agent has tools): `"tool_uses": []`
-- `intermediate_responses`: Always `[]`
+- **ツールなし**のエージェントの場合: `"tool_uses": []`
+- **失敗シナリオ**の場合（ツールを持つエージェントでも）: `"tool_uses": []`
+- `intermediate_responses`: 常に `[]`
 
 ### final_response
 
-- `role`: Always `"model"`
-- `parts[0].text`: Space-separated keywords that the response should contain. Evaluated using ROUGE-1 scoring (threshold: 0.5 as per `test_config.json`).
+- `role`: 常に `"model"`
+- `parts[0].text`: スペース区切りのキーワード。ROUGE-1 スコアリングで評価される（閾値: `test_config.json` の 0.5）。
 
-**Keyword selection rules:**
+**キーワード選択ルール:**
 
-| Scenario Type | Keywords to Include |
-|--------------|-------------------|
-| Success (normal) | `output_key` + domain-specific keywords + `Firestore` (if data is stored) |
-| Success (tool-using) | `output_key` + tool-related outcome keywords |
-| Failure (marker) | Failure marker(s) only (e.g., `NO_DOCUMENTS_FOUND`, `INSUFFICIENT_DATA NO_CONTENT`) |
+| シナリオ種別 | 含めるキーワード |
+|-------------|----------------|
+| 成功（通常） | `output_key` + ドメイン固有キーワード + `Firestore`（データ保存する場合） |
+| 成功（ツール使用） | `output_key` + ツール関連の結果キーワード |
+| 失敗（マーカー） | 失敗マーカーのみ（例: `NO_DOCUMENTS_FOUND`, `INSUFFICIENT_DATA NO_CONTENT`） |
 
-Examples:
+例:
 ```json
-// Scholar success
+// Scholar 成功
 "text": "mystery_report DATE_MISMATCH EVENT_OUTCOME 仮説 Firestore"
 
-// Scholar folklore
+// Scholar 民俗学
 "text": "Folkloric Context RECURRING_PATTERN LOCAL_TABOO Firestore"
 
-// Scholar failure
+// Scholar 失敗
 "text": "INSUFFICIENT_DATA NO_DOCUMENTS_FOUND"
 
-// Librarian with tools
+// Librarian（ツール使用）
 "text": "collected_documents total_found"
 
-// Publisher with tools
+// Publisher（ツール使用）
 "text": "published_episode Firestore mystery_id"
 ```
 
-## Annotated Example (Scholar)
+## Annotated Example（Scholar）
 
 ```json
 {
-  // eval_set_id follows {agent}_eval_v1 convention
+  // eval_set_id は {agent}_eval_v1 規約に従う
   "eval_set_id": "scholar_eval_v1",
   "name": "Scholar Agent Evaluation",
   "description": "Tests Scholar's interdisciplinary analysis capabilities via full pipeline execution",
@@ -152,19 +152,19 @@ Examples:
       "eval_id": "scholar_fact_based_analysis",
       "conversation": [
         {
-          // Sequential invocation ID
+          // 連番の invocation ID
           "invocation_id": "inv_001",
           "user_content": {
             "role": "user",
             "parts": [
               {
-                // MUST be Japanese — realistic analysis request
+                // 必ず日本語 — 現実的な分析リクエスト
                 "text": "1842年3月のボストン港におけるスペイン船サンタマリア号の記録を分析してください。英語の新聞記事では船が消失したと報じていますが、スペイン語の記録では同じ船が2週間後にハバナに到着したと記載されています。"
               }
             ]
           },
           "intermediate_data": {
-            // Scholar has no tools — empty array
+            // Scholar はツールなし — 空配列
             "tool_uses": [],
             "intermediate_responses": []
           },
@@ -172,7 +172,7 @@ Examples:
             "role": "model",
             "parts": [
               {
-                // output_key (mystery_report) + domain keywords
+                // output_key（mystery_report）+ ドメインキーワード
                 "text": "mystery_report DATE_MISMATCH EVENT_OUTCOME 仮説 Firestore"
               }
             ]
@@ -181,7 +181,7 @@ Examples:
       ]
     },
     {
-      // Failure scenario — agent should detect insufficient data
+      // 失敗シナリオ — エージェントはデータ不足を検出すべき
       "eval_id": "scholar_insufficient_data",
       "conversation": [
         {
@@ -190,13 +190,13 @@ Examples:
             "role": "user",
             "parts": [
               {
-                // Impossible request triggers failure path
+                // 不可能なリクエストで失敗パスをトリガー
                 "text": "2099年の火星植民地における歴史的事件について分析してください。"
               }
             ]
           },
           "intermediate_data": {
-            // No tools called in failure scenario
+            // 失敗シナリオではツール呼び出しなし
             "tool_uses": [],
             "intermediate_responses": []
           },
@@ -204,7 +204,7 @@ Examples:
             "role": "model",
             "parts": [
               {
-                // Only failure markers as keywords
+                // 失敗マーカーのみをキーワードとする
                 "text": "INSUFFICIENT_DATA NO_DOCUMENTS_FOUND"
               }
             ]
@@ -216,25 +216,25 @@ Examples:
 }
 ```
 
-## Evaluation Metrics
+## 評価メトリクス
 
-From `tests/eval/test_config.json`:
+`tests/eval/test_config.json` より:
 
-| Metric | Threshold | Method | Description |
-|--------|-----------|--------|-------------|
-| `tool_trajectory_avg_score` | 0.7 | `IN_ORDER` | Tool calls match expected sequence |
-| `response_match_score` | 0.5 | `ROUGE_1` | Response contains expected keywords |
+| メトリクス | 閾値 | 方式 | 説明 |
+|-----------|------|------|------|
+| `tool_trajectory_avg_score` | 0.7 | `IN_ORDER` | ツール呼び出しが期待される順序に一致するか |
+| `response_match_score` | 0.5 | `ROUGE_1` | レスポンスに期待されるキーワードが含まれるか |
 
-## Checklist
+## チェックリスト
 
-Before finalizing an eval_set JSON:
+eval_set JSON を確定する前の確認事項:
 
-- [ ] `eval_set_id` follows `{agent_name}_eval_v1` format
-- [ ] All `eval_id` values follow `{agent_name}_{scenario}` format
-- [ ] All `user_content` text is in Japanese
-- [ ] `tool_uses` has `"args": {}` for each tool entry
-- [ ] Failure scenarios have `"tool_uses": []`
-- [ ] `final_response` text includes the agent's `output_key` for success scenarios
-- [ ] `final_response` text includes failure marker keywords for failure scenarios
-- [ ] `invocation_id` values are sequential (`inv_001`, `inv_002`, ...)
-- [ ] JSON is valid (run through `python -m json.tool`)
+- [ ] `eval_set_id` が `{agent_name}_eval_v1` 形式であること
+- [ ] 全 `eval_id` が `{agent_name}_{scenario}` 形式であること
+- [ ] 全 `user_content` のテキストが日本語であること
+- [ ] `tool_uses` の各ツールが `"args": {}` を持つこと
+- [ ] 失敗シナリオは `"tool_uses": []` であること
+- [ ] 成功シナリオの `final_response` テキストにエージェントの `output_key` が含まれること
+- [ ] 失敗シナリオの `final_response` テキストに失敗マーカーキーワードが含まれること
+- [ ] `invocation_id` が連番（`inv_001`, `inv_002`, ...）であること
+- [ ] JSON が有効であること（`python -m json.tool` で確認）


### PR DESCRIPTION
## Summary

- `/gen-eval` スキルを `.claude/skills/gen-eval/` に追加
- エージェントモジュールパスを引数に取り、Golden Dataset・eval コンテンツ検証テスト・agent handover テストを自動生成
- 全9エージェントの定義カタログ（`agent-catalog.md`）と ADK eval_set JSON フォーマット仕様（`eval-set-format.md`）をサポートファイルとして同梱

## 関連

- PR #2 (`/gen-test` スキル) の姉妹スキル
- `/gen-test` がツール関数の Unit テストを生成するのに対し、`/gen-eval` は ADK エージェントレベルの評価テストを生成

## Test plan

- [x] 既存テストに影響なし（新規ファイル追加のみ）
- [ ] `/gen-eval archive_agents/agents/scholar.py` でテスト生成を実行し、3つの出力物が生成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)