### PR TITLE
feat(web): トップページに AI ディスクレーマーセクションを追加

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -4,7 +4,7 @@ import { Footer } from "@/components/footer"
 import { Hero } from "@/components/hero"
 import { MysteryCard } from "@/components/mystery-card"
 import { getPublishedMysteries } from "@/lib/firestore/mysteries"
-import { FileStack, Search } from "lucide-react"
+import { FileStack, Search, ShieldAlert } from "lucide-react"
 
 export const revalidate = 86400
 
@@ -85,22 +85,52 @@ export default function HomePage() {
           </div>
         </section>
 
-        {/* Methodology note */}
+        {/* Operational Disclosure */}
         <section className="py-16 border-t border-border/50">
           <div className="container mx-auto px-4">
-            <div className="max-w-3xl mx-auto text-center">
-              <h3 className="font-serif text-xl text-parchment mb-4">
-                Research Methodology
-              </h3>
-              <p className="text-sm text-muted-foreground leading-relaxed mb-6">
-                AI agents systematically analyze public information, identifying discrepancies, temporal anomalies, and patterns that correlate with documented folklore.
-              </p>
-              <div className="flex items-center justify-center gap-4 text-xs font-mono text-muted-foreground">
-                <span>Sources verified</span>
-                <span className="text-border">•</span>
-                <span>Cross-referenced</span>
-                <span className="text-border">•</span>
-                <span>Peer reviewed</span>
+            <div className="max-w-3xl mx-auto">
+              <div className="border border-gold/20 bg-gold/5 rounded-sm p-6 md:p-8">
+                <div className="flex items-center gap-3 mb-6 justify-center">
+                  <ShieldAlert className="w-5 h-5 text-gold" aria-hidden="true" />
+                  <h3 className="font-serif text-xl text-parchment">
+                    Operational Disclosure
+                  </h3>
+                </div>
+
+                <div className="space-y-4 text-sm text-muted-foreground leading-relaxed">
+                  <p>
+                    <span className="font-mono text-xs text-gold/80">NOTICE —</span>{" "}
+                    The investigative unit behind this archive is not human. It is an autonomous AI agent
+                    system built on{" "}
+                    <span className="text-parchment">Google Agent Development Kit (ADK)</span>,
+                    operating under codename <span className="font-mono text-parchment">GHOST IN THE ARCHIVE</span>.
+                  </p>
+                  <p>
+                    All source materials are retrieved exclusively from public digital archives — the Library
+                    of Congress, DPLA, NYPL, Internet Archive, and similar institutions. No classified
+                    information is used in any investigation.{" "}
+                    <span className="italic">(We do not have clearance. We have not applied for clearance.)</span>
+                  </p>
+                  <p>
+                    Be advised: AI agents are capable of presenting erroneous conclusions with
+                    remarkable confidence.{" "}
+                    <span className="text-parchment">
+                      Readers are encouraged to verify all claims independently.
+                    </span>{" "}
+                    The archive makes no warranty, express or implied, regarding the accuracy
+                    of any paranormal, folkloric, or historical assertion contained herein.
+                  </p>
+                </div>
+
+                <div className="mt-6 pt-4 border-t border-border/30">
+                  <div className="flex items-center justify-center gap-4 text-xs font-mono text-muted-foreground">
+                    <span>Sources verified</span>
+                    <span className="text-border">•</span>
+                    <span>Cross-referenced</span>
+                    <span className="text-border">•</span>
+                    <span>Accuracy not guaranteed</span>
+                  </div>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary

- トップページの「Research Methodology」セクションを「Operational Disclosure」セクションに置き換え
- ADK ベースの AI エージェントシステムが運営するサイトであることを明記
- 公開デジタルアーカイブのみを使用し、機密情報は使用していないことを記載
- AI の出力には誤りが含まれる可能性があり、読者に独自検証を推奨
- サイトの「闘のアーカイブ諜報機関」的世界観に合わせた "classified briefing" 風の文体

## Test plan

- [ ] `cd web && npm run dev` でローカル起動し、トップページ下部に Operational Disclosure セクションが表示されることを確認
- [ ] ShieldAlert アイコン、gold ボーダー、セクション内テキストが正しく表示されることを確認
- [ ] モバイル表示（レスポンシブ）で崩れがないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)