### PR TITLE
feat: Evidence 翻訳パイプライン対応と空 excerpt フォールバック

### DIFF
--- a/tests/unit/test_translator_tools.py
+++ b/tests/unit/test_translator_tools.py
@@ -1,0 +1,273 @@
+"""Unit tests for translator_agents/tools/firestore_tools.py.
+
+Tests for evidence extraction, loading, and saving in the translation pipeline.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from translator_agents.tools.firestore_tools import (
+    _extract_translatable_evidence,
+    load_mystery_for_translation,
+    save_translation_result,
+)
+
+FIRESTORE_CLIENT_PATH = "translator_agents.tools.firestore_tools.get_firestore_client"
+
+
+# =============================================================================
+# _extract_translatable_evidence tests
+# =============================================================================
+
+
+class TestExtractTranslatableEvidence:
+    """Tests for _extract_translatable_evidence()."""
+
+    def test_extracts_all_fields(self, sample_evidence_data):
+        """All evidence fields are extracted correctly."""
+        result = _extract_translatable_evidence(sample_evidence_data)
+
+        assert result["source_type"] == "newspaper"
+        assert result["source_language"] == "en"
+        assert result["source_title"] == "Boston Daily Advertiser"
+        assert result["source_date"] == "1842-03-15"
+        assert result["source_url"] == "https://chroniclingamerica.loc.gov/lccn/sn12345/"
+        assert result["relevant_excerpt"] == "The vessel was last seen departing the harbor..."
+        assert result["location_context"] == "Boston Harbor"
+
+    def test_empty_dict(self):
+        """Empty dict returns defaults for all fields."""
+        result = _extract_translatable_evidence({})
+
+        assert result["source_type"] == ""
+        assert result["source_language"] == ""
+        assert result["source_title"] == ""
+        assert result["source_date"] is None
+        assert result["source_url"] == ""
+        assert result["relevant_excerpt"] == ""
+        assert result["location_context"] is None
+
+    def test_missing_optional_fields(self):
+        """Optional fields (source_date, location_context) default to None."""
+        evidence = {
+            "source_type": "newspaper",
+            "source_language": "en",
+            "source_title": "Test Paper",
+            "source_url": "https://example.com",
+            "relevant_excerpt": "Some text",
+        }
+        result = _extract_translatable_evidence(evidence)
+
+        assert result["source_date"] is None
+        assert result["location_context"] is None
+        assert result["source_title"] == "Test Paper"
+        assert result["relevant_excerpt"] == "Some text"
+
+    def test_empty_relevant_excerpt(self):
+        """Empty relevant_excerpt (e.g. map/image source) is preserved."""
+        evidence = {
+            "source_type": "newspaper",
+            "source_language": "en",
+            "source_title": "Historical Map",
+            "source_url": "https://example.com/map",
+            "relevant_excerpt": "",
+        }
+        result = _extract_translatable_evidence(evidence)
+
+        assert result["relevant_excerpt"] == ""
+
+
+# =============================================================================
+# load_mystery_for_translation tests
+# =============================================================================
+
+
+class TestLoadMysteryForTranslation:
+    """Tests for load_mystery_for_translation()."""
+
+    def test_includes_evidence_fields(self, sample_mystery_report_data):
+        """Evidence fields are included in the returned dict."""
+        mock_doc = MagicMock()
+        mock_doc.exists = True
+        mock_doc.to_dict.return_value = sample_mystery_report_data
+
+        mock_client = MagicMock()
+        mock_client.collection.return_value.document.return_value.get.return_value = mock_doc
+
+        with patch(FIRESTORE_CLIENT_PATH, return_value=mock_client):
+            result = load_mystery_for_translation("TEST-ID")
+
+        assert result is not None
+        assert "evidence_a" in result
+        assert "evidence_b" in result
+        assert "additional_evidence" in result
+
+        # Verify evidence_a fields
+        assert result["evidence_a"]["source_type"] == "newspaper"
+        assert result["evidence_a"]["source_language"] == "en"
+        assert result["evidence_a"]["source_title"] == "Boston Daily Advertiser"
+
+        # Verify evidence_b fields
+        assert result["evidence_b"]["source_language"] == "es"
+        assert result["evidence_b"]["source_title"] == "Diario de la Marina"
+
+        # Verify additional_evidence is a list
+        assert isinstance(result["additional_evidence"], list)
+        assert len(result["additional_evidence"]) == 0
+
+    def test_includes_evidence_with_additional(self, sample_mystery_report_data):
+        """Additional evidence list items are extracted correctly."""
+        extra_evidence = {
+            "source_type": "newspaper",
+            "source_language": "en",
+            "source_title": "New York Herald",
+            "source_date": "1842-04-01",
+            "source_url": "https://example.com/nyh",
+            "relevant_excerpt": "Further reports confirm...",
+            "location_context": "New York",
+        }
+        sample_mystery_report_data["additional_evidence"] = [extra_evidence]
+
+        mock_doc = MagicMock()
+        mock_doc.exists = True
+        mock_doc.to_dict.return_value = sample_mystery_report_data
+
+        mock_client = MagicMock()
+        mock_client.collection.return_value.document.return_value.get.return_value = mock_doc
+
+        with patch(FIRESTORE_CLIENT_PATH, return_value=mock_client):
+            result = load_mystery_for_translation("TEST-ID")
+
+        assert len(result["additional_evidence"]) == 1
+        assert result["additional_evidence"][0]["source_title"] == "New York Herald"
+        assert result["additional_evidence"][0]["relevant_excerpt"] == "Further reports confirm..."
+
+    def test_missing_evidence_defaults_to_empty(self):
+        """Missing evidence fields default to empty structures."""
+        data_without_evidence = {
+            "title": "Test",
+            "summary": "Test summary",
+            "narrative_content": "Some content",
+            "discrepancy_detected": "",
+            "hypothesis": "",
+            "alternative_hypotheses": [],
+            "historical_context": {},
+            "story_hooks": [],
+        }
+        mock_doc = MagicMock()
+        mock_doc.exists = True
+        mock_doc.to_dict.return_value = data_without_evidence
+
+        mock_client = MagicMock()
+        mock_client.collection.return_value.document.return_value.get.return_value = mock_doc
+
+        with patch(FIRESTORE_CLIENT_PATH, return_value=mock_client):
+            result = load_mystery_for_translation("TEST-ID")
+
+        assert result["evidence_a"]["source_type"] == ""
+        assert result["evidence_b"]["source_type"] == ""
+        assert result["additional_evidence"] == []
+
+    def test_returns_none_for_missing_document(self):
+        """Returns None when document does not exist."""
+        mock_doc = MagicMock()
+        mock_doc.exists = False
+
+        mock_client = MagicMock()
+        mock_client.collection.return_value.document.return_value.get.return_value = mock_doc
+
+        with patch(FIRESTORE_CLIENT_PATH, return_value=mock_client):
+            result = load_mystery_for_translation("NONEXISTENT-ID")
+
+        assert result is None
+
+
+# =============================================================================
+# save_translation_result tests
+# =============================================================================
+
+
+class TestSaveTranslationResult:
+    """Tests for save_translation_result()."""
+
+    def test_saves_evidence_en_fields(self):
+        """Evidence_en fields are written to Firestore."""
+        translation_data = {
+            "title_en": "The Vanishing Ship",
+            "summary_en": "A ship disappeared",
+            "narrative_content_en": "Story content",
+            "discrepancy_detected_en": "Discrepancy",
+            "hypothesis_en": "Hypothesis",
+            "alternative_hypotheses_en": ["Alt 1"],
+            "political_climate_en": "Tensions",
+            "story_hooks_en": ["Hook 1"],
+            "evidence_a_en": {
+                "source_type": "newspaper",
+                "source_language": "en",
+                "source_title": "Boston Daily Advertiser",
+                "source_date": "1842-03-15",
+                "source_url": "https://example.com",
+                "relevant_excerpt": "The vessel departed...",
+                "location_context": "Boston Harbor",
+            },
+            "evidence_b_en": {
+                "source_type": "newspaper",
+                "source_language": "es",
+                "source_title": "Diario de la Marina",
+                "source_date": "1842-03-20",
+                "source_url": "https://example.com/es",
+                "relevant_excerpt": "The ship arrived...",
+                "location_context": "Havana",
+            },
+            "additional_evidence_en": [],
+        }
+        translation_json = json.dumps(translation_data)
+
+        mock_client = MagicMock()
+
+        with patch(FIRESTORE_CLIENT_PATH, return_value=mock_client), \
+             patch("translator_agents.tools.firestore_tools._trigger_revalidation"):
+            result = save_translation_result("TEST-ID", translation_json)
+
+        result_data = json.loads(result)
+        assert result_data["status"] == "success"
+
+        # Verify the update call includes evidence_en fields
+        update_call = mock_client.collection.return_value.document.return_value.update
+        update_call.assert_called_once()
+        update_data = update_call.call_args[0][0]
+
+        assert update_data["evidence_a_en"] == translation_data["evidence_a_en"]
+        assert update_data["evidence_b_en"] == translation_data["evidence_b_en"]
+        assert update_data["additional_evidence_en"] == []
+
+    def test_saves_without_evidence_en(self):
+        """Works correctly when evidence_en fields are not in translation result."""
+        translation_data = {
+            "title_en": "Test Title",
+            "summary_en": "Test Summary",
+            "narrative_content_en": "Content",
+            "discrepancy_detected_en": "",
+            "hypothesis_en": "",
+            "alternative_hypotheses_en": [],
+            "political_climate_en": "",
+            "story_hooks_en": [],
+        }
+        translation_json = json.dumps(translation_data)
+
+        mock_client = MagicMock()
+
+        with patch(FIRESTORE_CLIENT_PATH, return_value=mock_client), \
+             patch("translator_agents.tools.firestore_tools._trigger_revalidation"):
+            result = save_translation_result("TEST-ID", translation_json)
+
+        result_data = json.loads(result)
+        assert result_data["status"] == "success"
+
+        update_data = mock_client.collection.return_value.document.return_value.update.call_args[0][0]
+        # Should default to empty dict/list
+        assert update_data["evidence_a_en"] == {}
+        assert update_data["evidence_b_en"] == {}
+        assert update_data["additional_evidence_en"] == []

--- a/translate_main.py
+++ b/translate_main.py
@@ -97,6 +97,9 @@ async def translate_mystery(mystery_id: str) -> None:
             "alternative_hypotheses": alternative_hypotheses_str,
             "political_climate": mystery.get("political_climate", ""),
             "story_hooks": story_hooks_str,
+            "evidence_a": json.dumps(mystery.get("evidence_a", {}), ensure_ascii=False),
+            "evidence_b": json.dumps(mystery.get("evidence_b", {}), ensure_ascii=False),
+            "additional_evidence": json.dumps(mystery.get("additional_evidence", []), ensure_ascii=False),
             "pipeline_log": [],
         },
     )

--- a/translator_agents/agents/translator.py
+++ b/translator_agents/agents/translator.py
@@ -40,6 +40,9 @@ NO_TRANSLATION: ブログ原稿がないため、翻訳を中止します。
 - alternative_hypotheses: 代替仮説リスト → {alternative_hypotheses}
 - political_climate: 政治的背景 → {political_climate}
 - story_hooks: ナラティブフック（物語の切り口）→ {story_hooks}
+- evidence_a: 主要証拠A（JSON）→ {evidence_a}
+- evidence_b: 対比証拠B（JSON）→ {evidence_b}
+- additional_evidence: 追加証拠リスト（JSON）→ {additional_evidence}
 
 ## 翻訳ガイドライン
 
@@ -69,6 +72,12 @@ NO_TRANSLATION: ブログ原稿がないため、翻訳を中止します。
 - 引用符（>）を保持
 - リンク形式を保持
 
+### 証拠（Evidence）の翻訳
+- **翻訳対象フィールド**: `relevant_excerpt`, `source_title`, `location_context`
+- **そのまま保持するフィールド**: `source_type`, `source_language`, `source_date`, `source_url`
+- 各 evidence オブジェクトの構造をそのまま維持し、翻訳対象フィールドのみ英訳する
+- `relevant_excerpt` が空の場合はそのまま空文字列を返す
+
 ### 翻訳の正確性
 - 事実と出典を正確に翻訳すること
 - 日付、場所、人名のスペルを正確に
@@ -87,7 +96,18 @@ JSON形式で出力してください：
   "hypothesis_en": "...",
   "alternative_hypotheses_en": ["...", "..."],
   "political_climate_en": "...",
-  "story_hooks_en": ["...", "..."]
+  "story_hooks_en": ["...", "..."],
+  "evidence_a_en": {
+    "source_type": "...",
+    "source_language": "...",
+    "source_title": "... (翻訳)",
+    "source_date": "...",
+    "source_url": "...",
+    "relevant_excerpt": "... (翻訳)",
+    "location_context": "... (翻訳)"
+  },
+  "evidence_b_en": { "... (同上の構造)" },
+  "additional_evidence_en": [{ "... (同上の構造)" }]
 }
 ```
 

--- a/translator_agents/tools/firestore_tools.py
+++ b/translator_agents/tools/firestore_tools.py
@@ -36,6 +36,26 @@ def _extract_json_from_markdown(text: str) -> str:
     return text.strip()
 
 
+def _extract_translatable_evidence(evidence: dict) -> dict:
+    """Extract translatable fields from an Evidence object.
+
+    Args:
+        evidence: Evidence dictionary from Firestore.
+
+    Returns:
+        Dictionary with evidence fields for translation.
+    """
+    return {
+        "source_type": evidence.get("source_type", ""),
+        "source_language": evidence.get("source_language", ""),
+        "source_title": evidence.get("source_title", ""),
+        "source_date": evidence.get("source_date"),
+        "source_url": evidence.get("source_url", ""),
+        "relevant_excerpt": evidence.get("relevant_excerpt", ""),
+        "location_context": evidence.get("location_context"),
+    }
+
+
 def load_mystery_for_translation(mystery_id: str) -> dict | None:
     """Load a mystery document from Firestore for translation.
 
@@ -65,6 +85,12 @@ def load_mystery_for_translation(mystery_id: str) -> dict | None:
         "alternative_hypotheses": data.get("alternative_hypotheses", []),
         "political_climate": historical_context.get("political_climate", ""),
         "story_hooks": data.get("story_hooks", []),
+        "evidence_a": _extract_translatable_evidence(data.get("evidence_a", {})),
+        "evidence_b": _extract_translatable_evidence(data.get("evidence_b", {})),
+        "additional_evidence": [
+            _extract_translatable_evidence(ev)
+            for ev in data.get("additional_evidence", [])
+        ],
     }
 
 
@@ -103,6 +129,9 @@ def save_translation_result(mystery_id: str, translation_json: str) -> str:
                 "political_climate": translation.get("political_climate_en", ""),
             },
             "story_hooks_en": translation.get("story_hooks_en", []),
+            "evidence_a_en": translation.get("evidence_a_en", {}),
+            "evidence_b_en": translation.get("evidence_b_en", {}),
+            "additional_evidence_en": translation.get("additional_evidence_en", []),
             "status": "published",
             "translatedAt": now,
             "publishedAt": now,

--- a/web/src/app/admin/preview/[id]/page.tsx
+++ b/web/src/app/admin/preview/[id]/page.tsx
@@ -64,6 +64,10 @@ export default async function PreviewPage({
   const alternativeHypotheses = mystery.alternative_hypotheses_en || mystery.alternative_hypotheses
   const politicalClimate = mystery.historical_context_en?.political_climate || mystery.historical_context?.political_climate
 
+  const evidenceA = mystery.evidence_a_en || mystery.evidence_a
+  const evidenceB = mystery.evidence_b_en || mystery.evidence_b
+  const additionalEvidence = mystery.additional_evidence_en || mystery.additional_evidence
+
   const location = mystery.historical_context?.geographic_scope?.join(", ") || ""
   const timePeriod = mystery.historical_context?.time_period || ""
 
@@ -216,9 +220,9 @@ export default async function PreviewPage({
                   <h2 className="font-serif text-xl text-parchment">Sources &amp; Evidence</h2>
                 </div>
                 <div className="space-y-8">
-                  <EvidenceBlock evidence={mystery.evidence_a} label="Primary Source" />
-                  <EvidenceBlock evidence={mystery.evidence_b} label="Contrasting Source" />
-                  {mystery.additional_evidence.map((ev, i) => (
+                  <EvidenceBlock evidence={evidenceA} label="Primary Source" />
+                  <EvidenceBlock evidence={evidenceB} label="Contrasting Source" />
+                  {additionalEvidence.map((ev, i) => (
                     <EvidenceBlock key={i} evidence={ev} label={`Additional Evidence ${i + 1}`} />
                   ))}
                 </div>

--- a/web/src/app/mystery/[id]/page.tsx
+++ b/web/src/app/mystery/[id]/page.tsx
@@ -71,9 +71,12 @@ export default async function MysteryDetailPage({
   const alternativeHypotheses = mystery.alternative_hypotheses_en || mystery.alternative_hypotheses
   const politicalClimate = mystery.historical_context_en?.political_climate || mystery.historical_context?.political_climate
 
+  const evidenceA = mystery.evidence_a_en || mystery.evidence_a
+  const evidenceB = mystery.evidence_b_en || mystery.evidence_b
+  const additionalEvidence = mystery.additional_evidence_en || mystery.additional_evidence
+
   const location = mystery.historical_context?.geographic_scope?.join(", ") || ""
   const timePeriod = mystery.historical_context?.time_period || ""
-  const allEvidence = [mystery.evidence_a, mystery.evidence_b, ...mystery.additional_evidence]
 
   return (
     <div className="min-h-screen flex flex-col film-grain">
@@ -191,9 +194,9 @@ export default async function MysteryDetailPage({
                   <h2 className="font-serif text-xl text-parchment">Sources &amp; Evidence</h2>
                 </div>
                 <div className="space-y-8">
-                  <EvidenceBlock evidence={mystery.evidence_a} label="Primary Source" />
-                  <EvidenceBlock evidence={mystery.evidence_b} label="Contrasting Source" />
-                  {mystery.additional_evidence.map((ev, i) => (
+                  <EvidenceBlock evidence={evidenceA} label="Primary Source" />
+                  <EvidenceBlock evidence={evidenceB} label="Contrasting Source" />
+                  {additionalEvidence.map((ev, i) => (
                     <EvidenceBlock key={i} evidence={ev} label={`Additional Evidence ${i + 1}`} />
                   ))}
                 </div>

--- a/web/src/components/evidence-block.tsx
+++ b/web/src/components/evidence-block.tsx
@@ -47,9 +47,15 @@ export function EvidenceBlock({ evidence, label, className }: EvidenceBlockProps
         </div>
 
         {/* Evidence text */}
-        <p className="relative text-sm text-foreground/90 leading-relaxed pl-6 font-mono whitespace-pre-wrap">
-          {evidence.relevant_excerpt}
-        </p>
+        {evidence.relevant_excerpt ? (
+          <p className="relative text-sm text-foreground/90 leading-relaxed pl-6 font-mono whitespace-pre-wrap">
+            {evidence.relevant_excerpt}
+          </p>
+        ) : (
+          <p className="relative text-sm text-foreground/50 leading-relaxed pl-6 font-mono italic">
+            [No text excerpt available — see original source]
+          </p>
+        )}
       </blockquote>
 
       {/* Source citation */}

--- a/web/src/types/mystery.ts
+++ b/web/src/types/mystery.ts
@@ -184,6 +184,12 @@ export interface FirestoreMystery extends MysteryReport {
   };
   /** ナラティブフック（英語） */
   story_hooks_en?: string[];
+  /** 主要証拠A（英語） */
+  evidence_a_en?: Evidence;
+  /** 対比証拠B（英語） */
+  evidence_b_en?: Evidence;
+  /** 追加証拠（英語） */
+  additional_evidence_en?: Evidence[];
 }
 
 /**


### PR DESCRIPTION
## Summary

- 翻訳パイプラインに `evidence_a`, `evidence_b`, `additional_evidence` の翻訳を追加し、公開サイトの Sources & Evidence セクションが英訳表示されるようにした
- `relevant_excerpt` が空（地図・画像ソース等）の場合にフォールバック UI を追加
- 公開済み記事（`evidence_en` なし）は従来通り日本語 evidence を表示する後方互換性を維持

## Test plan

- [x] `pytest tests/unit/ -v` で全 92 テスト通過（新規 10 テスト含む）
- [ ] Firebase Emulator + 翻訳パイプライン手動実行で `evidence_*_en` フィールドが Firestore に保存されることを確認
- [ ] Web フロントエンドで英訳 evidence が表示されること、空 excerpt がフォールバック表示されることを確認
- [ ] 既存の公開済み記事（`evidence_en` なし）が従来通り表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)