### PR TITLE
fix: Evidence 表示改善（フラットリスト・空ブロック非表示・黒三角削除）

### DIFF
--- a/web/src/app/admin/preview/[id]/page.tsx
+++ b/web/src/app/admin/preview/[id]/page.tsx
@@ -64,9 +64,11 @@ export default async function PreviewPage({
   const alternativeHypotheses = mystery.alternative_hypotheses_en || mystery.alternative_hypotheses
   const politicalClimate = mystery.historical_context_en?.political_climate || mystery.historical_context?.political_climate
 
-  const evidenceA = mystery.evidence_a_en || mystery.evidence_a
-  const evidenceB = mystery.evidence_b_en || mystery.evidence_b
-  const additionalEvidence = mystery.additional_evidence_en || mystery.additional_evidence
+  const allEvidence = [
+    mystery.evidence_a_en || mystery.evidence_a,
+    mystery.evidence_b_en || mystery.evidence_b,
+    ...(mystery.additional_evidence_en || mystery.additional_evidence),
+  ].filter(ev => ev?.relevant_excerpt).slice(0, 10)
 
   const location = mystery.historical_context?.geographic_scope?.join(", ") || ""
   const timePeriod = mystery.historical_context?.time_period || ""
@@ -220,10 +222,8 @@ export default async function PreviewPage({
                   <h2 className="font-serif text-xl text-parchment">Sources &amp; Evidence</h2>
                 </div>
                 <div className="space-y-8">
-                  <EvidenceBlock evidence={evidenceA} label="Primary Source" />
-                  <EvidenceBlock evidence={evidenceB} label="Contrasting Source" />
-                  {additionalEvidence.map((ev, i) => (
-                    <EvidenceBlock key={i} evidence={ev} label={`Additional Evidence ${i + 1}`} />
+                  {allEvidence.map((ev, i) => (
+                    <EvidenceBlock key={i} evidence={ev} label={`Source ${i + 1}`} />
                   ))}
                 </div>
                 {sourcesMarkdown && (

--- a/web/src/app/mystery/[id]/page.tsx
+++ b/web/src/app/mystery/[id]/page.tsx
@@ -71,9 +71,11 @@ export default async function MysteryDetailPage({
   const alternativeHypotheses = mystery.alternative_hypotheses_en || mystery.alternative_hypotheses
   const politicalClimate = mystery.historical_context_en?.political_climate || mystery.historical_context?.political_climate
 
-  const evidenceA = mystery.evidence_a_en || mystery.evidence_a
-  const evidenceB = mystery.evidence_b_en || mystery.evidence_b
-  const additionalEvidence = mystery.additional_evidence_en || mystery.additional_evidence
+  const allEvidence = [
+    mystery.evidence_a_en || mystery.evidence_a,
+    mystery.evidence_b_en || mystery.evidence_b,
+    ...(mystery.additional_evidence_en || mystery.additional_evidence),
+  ].filter(ev => ev?.relevant_excerpt).slice(0, 10)
 
   const location = mystery.historical_context?.geographic_scope?.join(", ") || ""
   const timePeriod = mystery.historical_context?.time_period || ""
@@ -194,10 +196,8 @@ export default async function MysteryDetailPage({
                   <h2 className="font-serif text-xl text-parchment">Sources &amp; Evidence</h2>
                 </div>
                 <div className="space-y-8">
-                  <EvidenceBlock evidence={evidenceA} label="Primary Source" />
-                  <EvidenceBlock evidence={evidenceB} label="Contrasting Source" />
-                  {additionalEvidence.map((ev, i) => (
-                    <EvidenceBlock key={i} evidence={ev} label={`Additional Evidence ${i + 1}`} />
+                  {allEvidence.map((ev, i) => (
+                    <EvidenceBlock key={i} evidence={ev} label={`Source ${i + 1}`} />
                   ))}
                 </div>
                 {sourcesMarkdown && (

--- a/web/src/components/evidence-block.tsx
+++ b/web/src/components/evidence-block.tsx
@@ -26,14 +26,6 @@ export function EvidenceBlock({ evidence, label, className }: EvidenceBlockProps
         {/* Top edge wear effect */}
         <div className="absolute top-0 left-0 right-0 h-1 bg-gradient-to-b from-parchment/10 to-transparent" />
 
-        {/* Corner fold effect */}
-        <div
-          className="absolute top-0 right-0 w-6 h-6"
-          style={{
-            background: "linear-gradient(135deg, transparent 50%, #1A1A1A 50%)",
-          }}
-        />
-
         {/* Date badge + Quote marks row */}
         <div className="flex items-start justify-between mb-1">
           <div className="text-4xl text-parchment/20 font-serif leading-none" aria-hidden="true">
@@ -47,13 +39,9 @@ export function EvidenceBlock({ evidence, label, className }: EvidenceBlockProps
         </div>
 
         {/* Evidence text */}
-        {evidence.relevant_excerpt ? (
+        {evidence.relevant_excerpt && (
           <p className="relative text-sm text-foreground/90 leading-relaxed pl-6 font-mono whitespace-pre-wrap">
             {evidence.relevant_excerpt}
-          </p>
-        ) : (
-          <p className="relative text-sm text-foreground/50 leading-relaxed pl-6 font-mono italic">
-            [No text excerpt available — see original source]
           </p>
         )}
       </blockquote>


### PR DESCRIPTION
## Summary

- `evidence_a` / `evidence_b` / `additional_evidence` を統合し `Source 1, 2, ...` のフラットリストで表示
- `relevant_excerpt` が空の証拠ブロックを非表示に（フィルタで除外）
- 最大10件まで表示
- blockquote 右上の corner fold effect（黒い三角）を削除

## Test plan

- [ ] 公開記事で Sources & Evidence が `Source 1`, `Source 2`, ... のフラットリストで表示されること
- [ ] `relevant_excerpt` が空のブロックが表示されないこと
- [ ] 右上の黒三角が消えていること
- [ ] `/admin/preview/[id]` で同様に確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)