### PR TITLE
feat: パイプライン進捗トラッキング機能

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,6 +19,13 @@ from google.genai import types
 
 from archive_agents.agent import ghost_commander
 from archive_agents.utils.pipeline_logger import PipelineLogger
+from shared.pipeline_run import (
+    create_pipeline_run,
+    update_agent_started,
+    update_agent_completed,
+    complete_pipeline_run,
+    error_pipeline_run,
+)
 
 
 async def investigate(query: str) -> None:
@@ -35,6 +42,9 @@ async def investigate(query: str) -> None:
     print()
     print("-" * 70)
     print()
+
+    # Create pipeline run for progress tracking
+    run_id = create_pipeline_run("blog", query=query)
 
     # Create runner with in-memory session
     session_service = InMemorySessionService()
@@ -59,48 +69,86 @@ async def investigate(query: str) -> None:
     logger = PipelineLogger()
     current_agent_name: str | None = None
     accumulated_text: list[str] = []
+    current_log_index: int | None = None
 
-    # Run the investigation
-    async for event in runner.run_async(
-        user_id=user_id,
-        session_id=session_id,
-        new_message=types.Content(
-            role="user",
-            parts=[types.Part(text=query)],
-        ),
-    ):
-        # Detect agent transitions via event.author
-        author = getattr(event, "author", None)
-        if author and author != "ghost_commander" and author != current_agent_name:
-            # Complete previous agent
-            if current_agent_name:
-                summary = " ".join(accumulated_text)[:200]
-                logger.complete_agent(summary or "(no text output)")
-                accumulated_text = []
-            # Start new agent
-            current_agent_name = author
-            logger.start_agent(current_agent_name)
+    try:
+        # Run the investigation
+        async for event in runner.run_async(
+            user_id=user_id,
+            session_id=session_id,
+            new_message=types.Content(
+                role="user",
+                parts=[types.Part(text=query)],
+            ),
+        ):
+            # Detect agent transitions via event.author
+            author = getattr(event, "author", None)
+            if author and author != "ghost_commander" and author != current_agent_name:
+                # Complete previous agent
+                if current_agent_name:
+                    summary = " ".join(accumulated_text)[:200]
+                    logger.complete_agent(summary or "(no text output)")
+                    # Update pipeline run with completed agent
+                    completed_logs = logger.get_logs()
+                    if completed_logs:
+                        update_agent_completed(
+                            run_id, current_log_index, completed_logs[-1]
+                        )
+                    accumulated_text = []
+                # Start new agent
+                current_agent_name = author
+                logger.start_agent(current_agent_name)
+                # Update pipeline run with new agent
+                current_log_index = update_agent_started(
+                    run_id, current_agent_name, logger.get_logs()[-1]
+                )
 
-        # Print text responses from agents
-        if event.content and event.content.parts:
-            for part in event.content.parts:
-                if hasattr(part, "text") and part.text:
-                    print(part.text)
-                    accumulated_text.append(part.text[:100])
+            # Print text responses from agents
+            if event.content and event.content.parts:
+                for part in event.content.parts:
+                    if hasattr(part, "text") and part.text:
+                        print(part.text)
+                        accumulated_text.append(part.text[:100])
 
-    # Complete final agent
-    if current_agent_name:
-        summary = " ".join(accumulated_text)[:200]
-        logger.complete_agent(summary or "(no text output)")
+        # Complete final agent
+        if current_agent_name:
+            summary = " ".join(accumulated_text)[:200]
+            logger.complete_agent(summary or "(no text output)")
+            completed_logs = logger.get_logs()
+            if completed_logs:
+                update_agent_completed(
+                    run_id, current_log_index, completed_logs[-1]
+                )
 
-    # Store pipeline log in session state for Publisher
-    session = await session_service.get_session(
-        app_name="ghost_in_the_archive",
-        user_id=user_id,
-        session_id=session_id,
-    )
-    if session:
-        session.state["pipeline_log"] = logger.get_logs()
+        # Store pipeline log in session state for Publisher
+        session = await session_service.get_session(
+            app_name="ghost_in_the_archive",
+            user_id=user_id,
+            session_id=session_id,
+        )
+        if session:
+            session.state["pipeline_log"] = logger.get_logs()
+
+        # Extract mystery_id from published_episode
+        mystery_id = None
+        if session:
+            published = session.state.get("published_episode", "")
+            if isinstance(published, str) and published.startswith("{"):
+                import json
+
+                try:
+                    published_data = json.loads(published)
+                    mystery_id = published_data.get("mystery_id")
+                except (json.JSONDecodeError, AttributeError):
+                    pass
+            elif isinstance(published, dict):
+                mystery_id = published.get("mystery_id")
+
+        complete_pipeline_run(run_id, mystery_id=mystery_id)
+
+    except Exception as e:
+        error_pipeline_run(run_id, str(e))
+        raise
 
     print()
     print("=" * 70)

--- a/podcast_main.py
+++ b/podcast_main.py
@@ -27,6 +27,13 @@ from podcast_agents.tools.firestore_tools import (
     save_podcast_result,
     set_podcast_status,
 )
+from shared.pipeline_run import (
+    create_pipeline_run,
+    update_agent_started,
+    update_agent_completed,
+    complete_pipeline_run,
+    error_pipeline_run,
+)
 
 
 async def generate_podcast(mystery_id: str) -> None:
@@ -61,6 +68,9 @@ async def generate_podcast(mystery_id: str) -> None:
     # Mark as generating
     set_podcast_status(mystery_id, "generating")
 
+    # Create pipeline run for progress tracking
+    run_id = create_pipeline_run("podcast", mystery_id=mystery_id)
+
     # Create runner with session pre-loaded with creative_content
     session_service = InMemorySessionService()
     runner = Runner(
@@ -85,6 +95,12 @@ async def generate_podcast(mystery_id: str) -> None:
     # Run the podcast pipeline
     podcast_script = ""
     audio_assets = ""
+    current_agent_name: str | None = None
+    current_log_index: int | None = None
+
+    from datetime import datetime, timezone
+
+    agent_start_time: datetime | None = None
 
     try:
         async for event in runner.run_async(
@@ -95,10 +111,54 @@ async def generate_podcast(mystery_id: str) -> None:
                 parts=[types.Part(text=f"以下のブログ記事からポッドキャストを作成してください: {title}")],
             ),
         ):
+            # Track agent transitions
+            author = getattr(event, "author", None)
+            if author and author != "podcast_commander" and author != current_agent_name:
+                # Complete previous agent
+                if current_agent_name and agent_start_time:
+                    end_time = datetime.now(timezone.utc)
+                    duration = (end_time - agent_start_time).total_seconds()
+                    completed_entry = {
+                        "agent_name": current_agent_name,
+                        "status": "completed",
+                        "start_time": agent_start_time.isoformat(),
+                        "end_time": end_time.isoformat(),
+                        "duration_seconds": round(duration, 2),
+                        "output_summary": f"{current_agent_name} completed",
+                    }
+                    update_agent_completed(run_id, current_log_index, completed_entry)
+
+                # Start new agent
+                current_agent_name = author
+                agent_start_time = datetime.now(timezone.utc)
+                log_entry = {
+                    "agent_name": current_agent_name,
+                    "status": "running",
+                    "start_time": agent_start_time.isoformat(),
+                    "end_time": None,
+                    "duration_seconds": None,
+                    "output_summary": None,
+                }
+                current_log_index = update_agent_started(run_id, current_agent_name, log_entry)
+
             if event.content and event.content.parts:
                 for part in event.content.parts:
                     if hasattr(part, "text") and part.text:
                         print(part.text)
+
+        # Complete final agent
+        if current_agent_name and agent_start_time:
+            end_time = datetime.now(timezone.utc)
+            duration = (end_time - agent_start_time).total_seconds()
+            completed_entry = {
+                "agent_name": current_agent_name,
+                "status": "completed",
+                "start_time": agent_start_time.isoformat(),
+                "end_time": end_time.isoformat(),
+                "duration_seconds": round(duration, 2),
+                "output_summary": f"{current_agent_name} completed",
+            }
+            update_agent_completed(run_id, current_log_index, completed_entry)
 
         # Retrieve results from session state
         session = await session_service.get_session(
@@ -112,6 +172,7 @@ async def generate_podcast(mystery_id: str) -> None:
 
         # Save results to Firestore
         result = save_podcast_result(mystery_id, podcast_script, audio_assets)
+        complete_pipeline_run(run_id, mystery_id=mystery_id)
         print()
         print("=" * 70)
         print(f"Podcast generation complete: {result}")
@@ -120,6 +181,7 @@ async def generate_podcast(mystery_id: str) -> None:
     except Exception as e:
         print(f"Error during podcast generation: {e}")
         set_podcast_status(mystery_id, "error")
+        error_pipeline_run(run_id, str(e))
         raise
 
 

--- a/shared/pipeline_run.py
+++ b/shared/pipeline_run.py
@@ -1,0 +1,186 @@
+"""Pipeline Run Tracker - パイプライン実行進捗の Firestore 管理
+
+`pipeline_runs` コレクションを通じてパイプラインの実行状況をリアルタイムに記録し、
+管理画面からのポーリングによる進捗表示を可能にする。
+
+全書き込みは try/except で囲み、進捗トラッキングの失敗がパイプライン本体を阻害しないようにする。
+"""
+
+import logging
+from datetime import datetime, timezone
+
+from google.cloud.firestore_v1 import ArrayUnion
+
+from shared.firestore import get_firestore_client
+
+logger = logging.getLogger(__name__)
+
+COLLECTION = "pipeline_runs"
+
+
+def create_pipeline_run(
+    run_type: str,
+    *,
+    query: str | None = None,
+    mystery_id: str | None = None,
+) -> str | None:
+    """パイプライン実行ドキュメントを作成する。
+
+    Args:
+        run_type: パイプライン種別 ("blog", "translate", "podcast")
+        query: 調査テーマ (blog のみ)
+        mystery_id: 記事ID (translate/podcast)
+
+    Returns:
+        作成されたドキュメントの ID、失敗時は None
+    """
+    try:
+        db = get_firestore_client()
+        now = datetime.now(timezone.utc)
+        doc_data = {
+            "type": run_type,
+            "status": "running",
+            "query": query,
+            "mystery_id": mystery_id,
+            "current_agent": None,
+            "pipeline_log": [],
+            "started_at": now,
+            "updated_at": now,
+            "completed_at": None,
+            "error_message": None,
+        }
+        _, doc_ref = db.collection(COLLECTION).add(doc_data)
+        logger.info("Pipeline run created: %s (type=%s)", doc_ref.id, run_type)
+        return doc_ref.id
+    except Exception:
+        logger.exception("Failed to create pipeline run")
+        return None
+
+
+def update_agent_started(
+    run_id: str | None,
+    agent_name: str,
+    log_entry: dict,
+) -> int | None:
+    """エージェント開始をログに追加する。
+
+    ArrayUnion でアトミックに追加する。
+
+    Args:
+        run_id: パイプライン実行ドキュメントの ID
+        agent_name: エージェント名
+        log_entry: PipelineLogger 形式のログエントリ
+
+    Returns:
+        追加されたログエントリのインデックス（完了時の更新用）、失敗時は None
+    """
+    if not run_id:
+        return None
+    try:
+        db = get_firestore_client()
+        doc_ref = db.collection(COLLECTION).document(run_id)
+        doc_ref.update({
+            "current_agent": agent_name,
+            "pipeline_log": ArrayUnion([log_entry]),
+            "updated_at": datetime.now(timezone.utc),
+        })
+        # ArrayUnion 後のインデックスを取得するために read
+        doc = doc_ref.get()
+        if doc.exists:
+            logs = doc.to_dict().get("pipeline_log", [])
+            return len(logs) - 1
+        return None
+    except Exception:
+        logger.exception("Failed to update agent started: %s", agent_name)
+        return None
+
+
+def update_agent_completed(
+    run_id: str | None,
+    log_index: int | None,
+    updated_entry: dict,
+) -> None:
+    """エージェント完了でログエントリを更新する。
+
+    配列要素の更新は Firestore の制約上 read-then-write。
+
+    Args:
+        run_id: パイプライン実行ドキュメントの ID
+        log_index: 更新するログエントリのインデックス
+        updated_entry: 更新後のログエントリ
+    """
+    if not run_id or log_index is None:
+        return
+    try:
+        db = get_firestore_client()
+        doc_ref = db.collection(COLLECTION).document(run_id)
+        doc = doc_ref.get()
+        if not doc.exists:
+            return
+        logs = doc.to_dict().get("pipeline_log", [])
+        if log_index < len(logs):
+            logs[log_index] = updated_entry
+            doc_ref.update({
+                "current_agent": None,
+                "pipeline_log": logs,
+                "updated_at": datetime.now(timezone.utc),
+            })
+    except Exception:
+        logger.exception("Failed to update agent completed at index %s", log_index)
+
+
+def complete_pipeline_run(
+    run_id: str | None,
+    *,
+    mystery_id: str | None = None,
+) -> None:
+    """パイプライン実行を完了としてマークする。
+
+    Args:
+        run_id: パイプライン実行ドキュメントの ID
+        mystery_id: 記事ID（blog パイプラインで Publisher 完了後にセット）
+    """
+    if not run_id:
+        return
+    try:
+        db = get_firestore_client()
+        now = datetime.now(timezone.utc)
+        update_data: dict = {
+            "status": "completed",
+            "current_agent": None,
+            "updated_at": now,
+            "completed_at": now,
+        }
+        if mystery_id is not None:
+            update_data["mystery_id"] = mystery_id
+        db.collection(COLLECTION).document(run_id).update(update_data)
+        logger.info("Pipeline run completed: %s", run_id)
+    except Exception:
+        logger.exception("Failed to complete pipeline run: %s", run_id)
+
+
+def error_pipeline_run(
+    run_id: str | None,
+    error_message: str,
+) -> None:
+    """パイプライン実行をエラーとしてマークする。
+
+    Args:
+        run_id: パイプライン実行ドキュメントの ID
+        error_message: エラーメッセージ
+    """
+    if not run_id:
+        return
+    try:
+        db = get_firestore_client()
+        now = datetime.now(timezone.utc)
+        db.collection(COLLECTION).document(run_id).update({
+            "status": "error",
+            "current_agent": None,
+            "updated_at": now,
+            "completed_at": now,
+            "error_message": error_message[:500],
+        })
+        logger.info("Pipeline run errored: %s", run_id)
+    except Exception:
+        logger.exception("Failed to mark pipeline run as error: %s", run_id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,10 @@ mock_storage = MagicMock()
 sys.modules["google.cloud.firestore"] = mock_firestore
 sys.modules["google.cloud.storage"] = mock_storage
 
+# Mock google.cloud.firestore_v1 (used by shared/pipeline_run.py for ArrayUnion)
+mock_firestore_v1 = MagicMock()
+sys.modules["google.cloud.firestore_v1"] = mock_firestore_v1
+
 import json
 from datetime import datetime, timezone
 from pathlib import Path

--- a/tests/unit/test_pipeline_run.py
+++ b/tests/unit/test_pipeline_run.py
@@ -1,0 +1,388 @@
+"""Unit tests for shared/pipeline_run.py."""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+from freezegun import freeze_time
+
+
+class TestCreatePipelineRun:
+    """Tests for create_pipeline_run function."""
+
+    def test_create_blog_pipeline_run(self, mock_firestore_client):
+        """Should create a blog pipeline run with query."""
+        mock_doc_ref = MagicMock()
+        mock_doc_ref.id = "auto-generated-id"
+        mock_firestore_client.collection.return_value.add.return_value = (
+            None,
+            mock_doc_ref,
+        )
+
+        with patch(
+            "shared.pipeline_run.get_firestore_client",
+            return_value=mock_firestore_client,
+        ):
+            from shared.pipeline_run import create_pipeline_run
+
+            run_id = create_pipeline_run("blog", query="Boston mysteries")
+
+        assert run_id == "auto-generated-id"
+        mock_firestore_client.collection.assert_called_with("pipeline_runs")
+
+        call_args = mock_firestore_client.collection.return_value.add.call_args
+        doc_data = call_args[0][0]
+        assert doc_data["type"] == "blog"
+        assert doc_data["status"] == "running"
+        assert doc_data["query"] == "Boston mysteries"
+        assert doc_data["mystery_id"] is None
+        assert doc_data["current_agent"] is None
+        assert doc_data["pipeline_log"] == []
+
+    def test_create_translate_pipeline_run(self, mock_firestore_client):
+        """Should create a translate pipeline run with mystery_id."""
+        mock_doc_ref = MagicMock()
+        mock_doc_ref.id = "translate-run-id"
+        mock_firestore_client.collection.return_value.add.return_value = (
+            None,
+            mock_doc_ref,
+        )
+
+        with patch(
+            "shared.pipeline_run.get_firestore_client",
+            return_value=mock_firestore_client,
+        ):
+            from shared.pipeline_run import create_pipeline_run
+
+            run_id = create_pipeline_run(
+                "translate", mystery_id="OCC-MA-617-20260207143025"
+            )
+
+        assert run_id == "translate-run-id"
+        call_args = mock_firestore_client.collection.return_value.add.call_args
+        doc_data = call_args[0][0]
+        assert doc_data["type"] == "translate"
+        assert doc_data["mystery_id"] == "OCC-MA-617-20260207143025"
+        assert doc_data["query"] is None
+
+    def test_create_podcast_pipeline_run(self, mock_firestore_client):
+        """Should create a podcast pipeline run."""
+        mock_doc_ref = MagicMock()
+        mock_doc_ref.id = "podcast-run-id"
+        mock_firestore_client.collection.return_value.add.return_value = (
+            None,
+            mock_doc_ref,
+        )
+
+        with patch(
+            "shared.pipeline_run.get_firestore_client",
+            return_value=mock_firestore_client,
+        ):
+            from shared.pipeline_run import create_pipeline_run
+
+            run_id = create_pipeline_run(
+                "podcast", mystery_id="FLK-NY-212-20260207143025"
+            )
+
+        assert run_id == "podcast-run-id"
+
+    def test_create_pipeline_run_firestore_error_returns_none(
+        self, mock_firestore_client
+    ):
+        """Should return None if Firestore write fails."""
+        mock_firestore_client.collection.return_value.add.side_effect = Exception(
+            "Network error"
+        )
+
+        with patch(
+            "shared.pipeline_run.get_firestore_client",
+            return_value=mock_firestore_client,
+        ):
+            from shared.pipeline_run import create_pipeline_run
+
+            run_id = create_pipeline_run("blog", query="test")
+
+        assert run_id is None
+
+
+class TestUpdateAgentStarted:
+    """Tests for update_agent_started function."""
+
+    def test_update_agent_started(self, mock_firestore_client):
+        """Should update document with new agent and log entry."""
+        mock_doc = MagicMock()
+        mock_doc.exists = True
+        mock_doc.to_dict.return_value = {
+            "pipeline_log": [
+                {"agent_name": "librarian", "status": "running"}
+            ]
+        }
+        mock_doc_ref = MagicMock()
+        mock_doc_ref.get.return_value = mock_doc
+        mock_firestore_client.collection.return_value.document.return_value = (
+            mock_doc_ref
+        )
+
+        log_entry = {
+            "agent_name": "librarian",
+            "status": "running",
+            "start_time": "2024-01-15T12:00:00+00:00",
+        }
+
+        with patch(
+            "shared.pipeline_run.get_firestore_client",
+            return_value=mock_firestore_client,
+        ):
+            from shared.pipeline_run import update_agent_started
+
+            index = update_agent_started("run-123", "librarian", log_entry)
+
+        assert index == 0
+        mock_doc_ref.update.assert_called_once()
+
+    def test_update_agent_started_with_none_run_id(self):
+        """Should return None when run_id is None."""
+        from shared.pipeline_run import update_agent_started
+
+        result = update_agent_started(None, "librarian", {})
+        assert result is None
+
+    def test_update_agent_started_firestore_error(self, mock_firestore_client):
+        """Should return None on Firestore error."""
+        mock_doc_ref = MagicMock()
+        mock_doc_ref.update.side_effect = Exception("Write failed")
+        mock_firestore_client.collection.return_value.document.return_value = (
+            mock_doc_ref
+        )
+
+        with patch(
+            "shared.pipeline_run.get_firestore_client",
+            return_value=mock_firestore_client,
+        ):
+            from shared.pipeline_run import update_agent_started
+
+            result = update_agent_started("run-123", "librarian", {})
+
+        assert result is None
+
+
+class TestUpdateAgentCompleted:
+    """Tests for update_agent_completed function."""
+
+    def test_update_agent_completed(self, mock_firestore_client):
+        """Should update the log entry at given index."""
+        existing_log = {
+            "agent_name": "librarian",
+            "status": "running",
+            "start_time": "2024-01-15T12:00:00+00:00",
+            "end_time": None,
+        }
+        updated_log = {
+            "agent_name": "librarian",
+            "status": "completed",
+            "start_time": "2024-01-15T12:00:00+00:00",
+            "end_time": "2024-01-15T12:01:00+00:00",
+            "duration_seconds": 60.0,
+            "output_summary": "Found 15 documents",
+        }
+
+        mock_doc = MagicMock()
+        mock_doc.exists = True
+        mock_doc.to_dict.return_value = {"pipeline_log": [existing_log]}
+        mock_doc_ref = MagicMock()
+        mock_doc_ref.get.return_value = mock_doc
+        mock_firestore_client.collection.return_value.document.return_value = (
+            mock_doc_ref
+        )
+
+        with patch(
+            "shared.pipeline_run.get_firestore_client",
+            return_value=mock_firestore_client,
+        ):
+            from shared.pipeline_run import update_agent_completed
+
+            update_agent_completed("run-123", 0, updated_log)
+
+        call_args = mock_doc_ref.update.call_args
+        updated_data = call_args[0][0]
+        assert updated_data["pipeline_log"][0]["status"] == "completed"
+        assert updated_data["current_agent"] is None
+
+    def test_update_agent_completed_with_none_run_id(self):
+        """Should do nothing when run_id is None."""
+        from shared.pipeline_run import update_agent_completed
+
+        # Should not raise
+        update_agent_completed(None, 0, {})
+
+    def test_update_agent_completed_with_none_index(self):
+        """Should do nothing when log_index is None."""
+        from shared.pipeline_run import update_agent_completed
+
+        # Should not raise
+        update_agent_completed("run-123", None, {})
+
+    def test_update_agent_completed_doc_not_found(self, mock_firestore_client):
+        """Should do nothing when document does not exist."""
+        mock_doc = MagicMock()
+        mock_doc.exists = False
+        mock_doc_ref = MagicMock()
+        mock_doc_ref.get.return_value = mock_doc
+        mock_firestore_client.collection.return_value.document.return_value = (
+            mock_doc_ref
+        )
+
+        with patch(
+            "shared.pipeline_run.get_firestore_client",
+            return_value=mock_firestore_client,
+        ):
+            from shared.pipeline_run import update_agent_completed
+
+            update_agent_completed("run-123", 0, {})
+
+        mock_doc_ref.update.assert_not_called()
+
+
+class TestCompletePipelineRun:
+    """Tests for complete_pipeline_run function."""
+
+    def test_complete_pipeline_run(self, mock_firestore_client):
+        """Should mark pipeline run as completed."""
+        mock_doc_ref = MagicMock()
+        mock_firestore_client.collection.return_value.document.return_value = (
+            mock_doc_ref
+        )
+
+        with patch(
+            "shared.pipeline_run.get_firestore_client",
+            return_value=mock_firestore_client,
+        ):
+            from shared.pipeline_run import complete_pipeline_run
+
+            complete_pipeline_run("run-123", mystery_id="OCC-MA-617-20260207")
+
+        call_args = mock_doc_ref.update.call_args
+        update_data = call_args[0][0]
+        assert update_data["status"] == "completed"
+        assert update_data["mystery_id"] == "OCC-MA-617-20260207"
+        assert update_data["current_agent"] is None
+        assert "completed_at" in update_data
+
+    def test_complete_pipeline_run_without_mystery_id(
+        self, mock_firestore_client
+    ):
+        """Should complete without setting mystery_id."""
+        mock_doc_ref = MagicMock()
+        mock_firestore_client.collection.return_value.document.return_value = (
+            mock_doc_ref
+        )
+
+        with patch(
+            "shared.pipeline_run.get_firestore_client",
+            return_value=mock_firestore_client,
+        ):
+            from shared.pipeline_run import complete_pipeline_run
+
+            complete_pipeline_run("run-123")
+
+        call_args = mock_doc_ref.update.call_args
+        update_data = call_args[0][0]
+        assert "mystery_id" not in update_data
+
+    def test_complete_pipeline_run_with_none_run_id(self):
+        """Should do nothing when run_id is None."""
+        from shared.pipeline_run import complete_pipeline_run
+
+        # Should not raise
+        complete_pipeline_run(None)
+
+    def test_complete_pipeline_run_firestore_error(
+        self, mock_firestore_client
+    ):
+        """Should not raise when Firestore write fails."""
+        mock_doc_ref = MagicMock()
+        mock_doc_ref.update.side_effect = Exception("Write failed")
+        mock_firestore_client.collection.return_value.document.return_value = (
+            mock_doc_ref
+        )
+
+        with patch(
+            "shared.pipeline_run.get_firestore_client",
+            return_value=mock_firestore_client,
+        ):
+            from shared.pipeline_run import complete_pipeline_run
+
+            # Should not raise
+            complete_pipeline_run("run-123")
+
+
+class TestErrorPipelineRun:
+    """Tests for error_pipeline_run function."""
+
+    def test_error_pipeline_run(self, mock_firestore_client):
+        """Should mark pipeline run as error with message."""
+        mock_doc_ref = MagicMock()
+        mock_firestore_client.collection.return_value.document.return_value = (
+            mock_doc_ref
+        )
+
+        with patch(
+            "shared.pipeline_run.get_firestore_client",
+            return_value=mock_firestore_client,
+        ):
+            from shared.pipeline_run import error_pipeline_run
+
+            error_pipeline_run("run-123", "Translation failed: timeout")
+
+        call_args = mock_doc_ref.update.call_args
+        update_data = call_args[0][0]
+        assert update_data["status"] == "error"
+        assert update_data["error_message"] == "Translation failed: timeout"
+        assert update_data["current_agent"] is None
+
+    def test_error_pipeline_run_truncates_long_message(
+        self, mock_firestore_client
+    ):
+        """Should truncate error message to 500 characters."""
+        mock_doc_ref = MagicMock()
+        mock_firestore_client.collection.return_value.document.return_value = (
+            mock_doc_ref
+        )
+
+        long_message = "x" * 1000
+
+        with patch(
+            "shared.pipeline_run.get_firestore_client",
+            return_value=mock_firestore_client,
+        ):
+            from shared.pipeline_run import error_pipeline_run
+
+            error_pipeline_run("run-123", long_message)
+
+        call_args = mock_doc_ref.update.call_args
+        update_data = call_args[0][0]
+        assert len(update_data["error_message"]) == 500
+
+    def test_error_pipeline_run_with_none_run_id(self):
+        """Should do nothing when run_id is None."""
+        from shared.pipeline_run import error_pipeline_run
+
+        # Should not raise
+        error_pipeline_run(None, "some error")
+
+    def test_error_pipeline_run_firestore_error(self, mock_firestore_client):
+        """Should not raise when Firestore write fails."""
+        mock_doc_ref = MagicMock()
+        mock_doc_ref.update.side_effect = Exception("Network error")
+        mock_firestore_client.collection.return_value.document.return_value = (
+            mock_doc_ref
+        )
+
+        with patch(
+            "shared.pipeline_run.get_firestore_client",
+            return_value=mock_firestore_client,
+        ):
+            from shared.pipeline_run import error_pipeline_run
+
+            # Should not raise
+            error_pipeline_run("run-123", "some error")

--- a/translate_main.py
+++ b/translate_main.py
@@ -28,6 +28,13 @@ from translator_agents.tools.firestore_tools import (
     save_translation_result,
     set_translation_error,
 )
+from shared.pipeline_run import (
+    create_pipeline_run,
+    update_agent_started,
+    update_agent_completed,
+    complete_pipeline_run,
+    error_pipeline_run,
+)
 
 
 async def translate_mystery(mystery_id: str) -> None:
@@ -59,6 +66,9 @@ async def translate_mystery(mystery_id: str) -> None:
     print(f"Article: {title}")
     print("-" * 70)
     print()
+
+    # Create pipeline run for progress tracking
+    run_id = create_pipeline_run("translate", mystery_id=mystery_id)
 
     # Create runner with session pre-loaded with Japanese content
     session_service = InMemorySessionService()
@@ -107,6 +117,20 @@ async def translate_mystery(mystery_id: str) -> None:
     # Run the translation pipeline
     translation_result = ""
 
+    # Track translator agent start
+    from datetime import datetime, timezone
+
+    translator_log_entry = {
+        "agent_name": "translator",
+        "status": "running",
+        "start_time": datetime.now(timezone.utc).isoformat(),
+        "end_time": None,
+        "duration_seconds": None,
+        "output_summary": None,
+    }
+    log_index = update_agent_started(run_id, "translator", translator_log_entry)
+    translate_start = datetime.now(timezone.utc)
+
     try:
         async for event in runner.run_async(
             user_id=user_id,
@@ -135,10 +159,24 @@ async def translate_mystery(mystery_id: str) -> None:
             print()
             print("Translation skipped: No content to translate.")
             set_translation_error(mystery_id)
+            error_pipeline_run(run_id, "No content to translate")
             sys.exit(1)
 
         # Save results to Firestore
         result = save_translation_result(mystery_id, translation_result)
+
+        # Mark translator agent completed
+        end_time = datetime.now(timezone.utc)
+        duration = (end_time - translate_start).total_seconds()
+        translator_log_entry.update({
+            "status": "completed",
+            "end_time": end_time.isoformat(),
+            "duration_seconds": round(duration, 2),
+            "output_summary": f"Translation complete: {result}"[:200],
+        })
+        update_agent_completed(run_id, log_index, translator_log_entry)
+        complete_pipeline_run(run_id, mystery_id=mystery_id)
+
         print()
         print("=" * 70)
         print(f"Translation complete: {result}")
@@ -147,6 +185,7 @@ async def translate_mystery(mystery_id: str) -> None:
     except Exception as e:
         print(f"Error during translation: {e}")
         set_translation_error(mystery_id)
+        error_pipeline_run(run_id, str(e))
         raise
 
 

--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -9,6 +9,8 @@ import { getAllMysteries, approveMystery, archiveMystery, requestPodcast } from 
 import type { FirestoreMystery, MysteryStatus } from "@/types/mystery"
 import { PipelineSummary } from "@/components/pipeline-summary"
 import { PipelineTimeline } from "@/components/pipeline-timeline"
+import { RunningPipelines } from "@/components/running-pipelines"
+import { usePipelinePolling } from "@/hooks/use-pipeline-polling"
 import {
   Shield,
   FileText,
@@ -52,6 +54,11 @@ export default function AdminPage() {
     }
   }, [])
 
+  // Pipeline progress polling
+  const { runs: pipelineRuns, startPolling } = usePipelinePolling({
+    onPipelineCompleted: fetchMysteries,
+  })
+
   useEffect(() => {
     fetchMysteries()
   }, [fetchMysteries])
@@ -81,6 +88,7 @@ export default function AdminPage() {
       if (!res.ok) throw new Error("Translation API request failed")
       setActionFeedback(`Case ${id} approved - translation started`)
       fetchMysteries()
+      startPolling()
       setTimeout(() => setActionFeedback(null), 3000)
     } catch (error) {
       console.error("Failed to approve:", error)
@@ -111,6 +119,7 @@ export default function AdminPage() {
       if (!res.ok) throw new Error("API request failed")
       setActionFeedback(`Podcast generation started for Case ${id}`)
       fetchMysteries()
+      startPolling()
       setTimeout(() => setActionFeedback(null), 3000)
     } catch (error) {
       console.error("Failed to start podcast:", error)
@@ -132,6 +141,7 @@ export default function AdminPage() {
       setActionFeedback("調査パイプラインを開始しました")
       setThemeInput("")
       setSuggestions([])
+      startPolling()
       setTimeout(() => setActionFeedback(null), 3000)
     } catch (error) {
       console.error("Failed to start pipeline:", error)
@@ -248,6 +258,9 @@ export default function AdminPage() {
             </p>
           </div>
         )}
+
+        {/* Running pipelines */}
+        <RunningPipelines runs={pipelineRuns} />
 
         {/* TODO: 記事一覧 UI 改善（段階的対応）
          * 記事数が増えた場合の対応計画:

--- a/web/src/components/running-pipelines.tsx
+++ b/web/src/components/running-pipelines.tsx
@@ -1,0 +1,166 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { cn } from "@/lib/utils"
+import type { PipelineRun } from "@/types/mystery"
+import { AGENT_NAME_LABELS } from "@/types/mystery"
+import { PipelineSummary } from "@/components/pipeline-summary"
+import { PipelineTimeline } from "@/components/pipeline-timeline"
+import {
+  Search,
+  Languages,
+  Mic,
+  Loader2,
+  ChevronDown,
+  ChevronUp,
+  AlertCircle,
+} from "lucide-react"
+
+const TYPE_CONFIG: Record<
+  string,
+  { icon: React.ReactNode; label: string; colorClass: string }
+> = {
+  blog: {
+    icon: <Search className="w-4 h-4" />,
+    label: "調査パイプライン",
+    colorClass: "text-[#5fb3a1]",
+  },
+  translate: {
+    icon: <Languages className="w-4 h-4" />,
+    label: "翻訳パイプライン",
+    colorClass: "text-[#d4af37]",
+  },
+  podcast: {
+    icon: <Mic className="w-4 h-4" />,
+    label: "Podcast パイプライン",
+    colorClass: "text-[#8b7ec8]",
+  },
+}
+
+function ElapsedTimer({ startedAt }: { startedAt: Date }) {
+  const [elapsed, setElapsed] = useState("")
+
+  useEffect(() => {
+    const update = () => {
+      const now = Date.now()
+      const diff = Math.floor((now - startedAt.getTime()) / 1000)
+      const minutes = Math.floor(diff / 60)
+      const seconds = diff % 60
+      setElapsed(`${minutes}:${seconds.toString().padStart(2, "0")}`)
+    }
+    update()
+    const interval = setInterval(update, 1000)
+    return () => clearInterval(interval)
+  }, [startedAt])
+
+  return <span className="font-mono text-xs text-muted-foreground">{elapsed}</span>
+}
+
+interface RunningPipelineCardProps {
+  run: PipelineRun
+}
+
+function RunningPipelineCard({ run }: RunningPipelineCardProps) {
+  const [expanded, setExpanded] = useState(false)
+  const config = TYPE_CONFIG[run.type] || TYPE_CONFIG.blog
+  const currentAgentLabel = run.current_agent
+    ? AGENT_NAME_LABELS[run.current_agent] || run.current_agent
+    : null
+  const isStale =
+    run.status === "running" &&
+    Date.now() - run.updated_at.getTime() > 30 * 60 * 1000
+  const hasLogs = run.pipeline_log && run.pipeline_log.length > 0
+
+  return (
+    <div className="aged-card letterpress-border rounded-sm p-4">
+      <div className="flex items-center justify-between gap-3">
+        {/* Left: type icon + label + description */}
+        <div className="flex items-center gap-3 min-w-0 flex-1">
+          <div className={cn("flex-shrink-0", config.colorClass)}>
+            {config.icon}
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <span
+                className={cn(
+                  "text-sm font-mono uppercase tracking-wider",
+                  config.colorClass
+                )}
+              >
+                {config.label}
+              </span>
+              {isStale && (
+                <span className="flex items-center gap-1 text-xs text-[#ff6b6b]">
+                  <AlertCircle className="w-3 h-3" />
+                  応答なし
+                </span>
+              )}
+            </div>
+            <p className="text-xs text-muted-foreground truncate mt-0.5">
+              {run.query || run.mystery_id || ""}
+            </p>
+          </div>
+        </div>
+
+        {/* Right: current agent + elapsed + expand */}
+        <div className="flex items-center gap-3 flex-shrink-0">
+          {run.status === "running" && currentAgentLabel && (
+            <span className="flex items-center gap-1.5 text-xs text-[#d4af37] font-mono">
+              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+              {currentAgentLabel}
+            </span>
+          )}
+          {run.status === "error" && (
+            <span className="flex items-center gap-1 text-xs text-[#ff6b6b] font-mono">
+              <AlertCircle className="w-3.5 h-3.5" />
+              Error
+            </span>
+          )}
+          <ElapsedTimer startedAt={run.started_at} />
+          {hasLogs && (
+            <button
+              onClick={() => setExpanded(!expanded)}
+              className="p-1 hover:bg-muted/50 rounded-sm transition-colors"
+            >
+              {expanded ? (
+                <ChevronUp className="w-4 h-4 text-muted-foreground" />
+              ) : (
+                <ChevronDown className="w-4 h-4 text-muted-foreground" />
+              )}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Expanded: pipeline details */}
+      {expanded && hasLogs && (
+        <div className="mt-4 pt-4 border-t border-border/50">
+          <PipelineSummary logs={run.pipeline_log} className="mb-4" />
+          <PipelineTimeline logs={run.pipeline_log} />
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface RunningPipelinesProps {
+  runs: PipelineRun[]
+  className?: string
+}
+
+export function RunningPipelines({ runs, className }: RunningPipelinesProps) {
+  if (runs.length === 0) return null
+
+  return (
+    <div className={cn("mb-8", className)}>
+      <h2 className="font-serif text-xl text-parchment mb-4">
+        実行中のパイプライン
+      </h2>
+      <div className="space-y-3">
+        {runs.map((run) => (
+          <RunningPipelineCard key={run.id} run={run} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/web/src/hooks/use-pipeline-polling.ts
+++ b/web/src/hooks/use-pipeline-polling.ts
@@ -1,0 +1,84 @@
+"use client"
+
+import { useState, useEffect, useCallback, useRef } from "react"
+import type { PipelineRun } from "@/types/mystery"
+import { getRunningPipelineRuns } from "@/lib/firestore/pipeline-runs"
+
+const POLL_INTERVAL_MS = 5000
+
+interface UsePipelinePollingOptions {
+  onPipelineCompleted?: () => void
+}
+
+export function usePipelinePolling(options: UsePipelinePollingOptions = {}) {
+  const [runs, setRuns] = useState<PipelineRun[]>([])
+  const [isPolling, setIsPolling] = useState(false)
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const prevRunIdsRef = useRef<Set<string>>(new Set())
+  const onPipelineCompletedRef = useRef(options.onPipelineCompleted)
+
+  // Keep callback ref up to date
+  onPipelineCompletedRef.current = options.onPipelineCompleted
+
+  const fetchRuns = useCallback(async () => {
+    try {
+      const runningRuns = await getRunningPipelineRuns()
+      const currentIds = new Set(runningRuns.map((r) => r.id))
+
+      // Detect completed pipelines (was running, now gone)
+      const prevIds = prevRunIdsRef.current
+      if (prevIds.size > 0) {
+        const completedIds = [...prevIds].filter((id) => !currentIds.has(id))
+        if (completedIds.length > 0 && onPipelineCompletedRef.current) {
+          onPipelineCompletedRef.current()
+        }
+      }
+
+      prevRunIdsRef.current = currentIds
+      setRuns(runningRuns)
+
+      // Stop polling if no more running pipelines
+      if (runningRuns.length === 0 && prevIds.size > 0) {
+        stopPolling()
+      }
+    } catch (error) {
+      console.error("Failed to fetch pipeline runs:", error)
+    }
+  }, [])
+
+  const startPolling = useCallback(() => {
+    if (intervalRef.current) return // already polling
+    setIsPolling(true)
+    // Fetch immediately
+    fetchRuns()
+    intervalRef.current = setInterval(fetchRuns, POLL_INTERVAL_MS)
+  }, [fetchRuns])
+
+  const stopPolling = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current)
+      intervalRef.current = null
+    }
+    setIsPolling(false)
+  }, [])
+
+  // Check for running pipelines on mount
+  useEffect(() => {
+    const checkInitial = async () => {
+      try {
+        const runningRuns = await getRunningPipelineRuns()
+        if (runningRuns.length > 0) {
+          setRuns(runningRuns)
+          prevRunIdsRef.current = new Set(runningRuns.map((r) => r.id))
+          startPolling()
+        }
+      } catch (error) {
+        console.error("Failed initial pipeline check:", error)
+      }
+    }
+    checkInitial()
+    return () => stopPolling()
+  }, [startPolling, stopPolling])
+
+  return { runs, isPolling, startPolling, stopPolling }
+}

--- a/web/src/lib/firebase/config.ts
+++ b/web/src/lib/firebase/config.ts
@@ -105,4 +105,5 @@ export function getFirebaseStorage(): FirebaseStorage {
  */
 export const COLLECTIONS = {
   MYSTERIES: "mysteries",
+  PIPELINE_RUNS: "pipeline_runs",
 } as const;

--- a/web/src/lib/firestore/pipeline-runs.ts
+++ b/web/src/lib/firestore/pipeline-runs.ts
@@ -1,0 +1,88 @@
+/**
+ * Pipeline Runs Firestore 操作
+ * pipeline_runs コレクションの読み取り操作を提供
+ */
+
+import type { PipelineRun } from "@/types/mystery";
+import { Timestamp, DocumentData } from "firebase/firestore";
+
+/**
+ * 実行中のパイプライン一覧を取得
+ */
+export async function getRunningPipelineRuns(): Promise<PipelineRun[]> {
+  const { collection, getDocs, query, where, orderBy } = await import(
+    "firebase/firestore"
+  );
+  const { getFirestoreDb, COLLECTIONS } = await import(
+    "@/lib/firebase/config"
+  );
+
+  const db = getFirestoreDb();
+  const runsRef = collection(db, COLLECTIONS.PIPELINE_RUNS);
+
+  const q = query(
+    runsRef,
+    where("status", "==", "running"),
+    orderBy("started_at", "desc")
+  );
+
+  const snapshot = await getDocs(q);
+  return snapshot.docs.map((doc) => docToPipelineRun(doc.id, doc.data()));
+}
+
+/**
+ * 最近完了・エラーのパイプラインも含めて取得
+ * 完了後にUIで一瞬表示するために使用
+ */
+export async function getRecentPipelineRuns(
+  maxCount: number = 10
+): Promise<PipelineRun[]> {
+  const { collection, getDocs, query, orderBy, limit } = await import(
+    "firebase/firestore"
+  );
+  const { getFirestoreDb, COLLECTIONS } = await import(
+    "@/lib/firebase/config"
+  );
+
+  const db = getFirestoreDb();
+  const runsRef = collection(db, COLLECTIONS.PIPELINE_RUNS);
+
+  const q = query(runsRef, orderBy("started_at", "desc"), limit(maxCount));
+
+  const snapshot = await getDocs(q);
+  return snapshot.docs.map((doc) => docToPipelineRun(doc.id, doc.data()));
+}
+
+/**
+ * Firestore タイムスタンプを Date に変換
+ */
+function convertTimestamp(
+  timestamp: Timestamp | Date | undefined | null
+): Date {
+  if (!timestamp) return new Date();
+  if (timestamp instanceof Timestamp) {
+    return timestamp.toDate();
+  }
+  return timestamp;
+}
+
+/**
+ * Firestore ドキュメントを PipelineRun に変換
+ */
+function docToPipelineRun(id: string, data: DocumentData): PipelineRun {
+  return {
+    id,
+    type: data.type,
+    status: data.status,
+    query: data.query || null,
+    mystery_id: data.mystery_id || null,
+    current_agent: data.current_agent || null,
+    pipeline_log: data.pipeline_log || [],
+    started_at: convertTimestamp(data.started_at),
+    updated_at: convertTimestamp(data.updated_at),
+    completed_at: data.completed_at
+      ? convertTimestamp(data.completed_at)
+      : null,
+    error_message: data.error_message || null,
+  };
+}

--- a/web/src/types/mystery.ts
+++ b/web/src/types/mystery.ts
@@ -238,4 +238,40 @@ export const AGENT_NAME_LABELS: Record<string, string> = {
   illustrator: "画像生成",
   producer: "音声生成",
   publisher: "公開処理",
+  translator: "翻訳",
 };
+
+/** パイプライン実行の種別 */
+export type PipelineRunType = "blog" | "translate" | "podcast";
+
+/** パイプライン実行ステータス */
+export type PipelineRunStatus = "running" | "completed" | "error";
+
+/**
+ * パイプライン実行ドキュメント
+ * pipeline_runs コレクションのドキュメント構造
+ */
+export interface PipelineRun {
+  /** Firestore ドキュメント ID */
+  id: string;
+  /** パイプライン種別 */
+  type: PipelineRunType;
+  /** 実行状態 */
+  status: PipelineRunStatus;
+  /** 調査テーマ（blog のみ） */
+  query?: string | null;
+  /** 記事ID（translate/podcast、blog は完了時にセット） */
+  mystery_id?: string | null;
+  /** 現在実行中のエージェント名 */
+  current_agent?: string | null;
+  /** パイプライン実行ログ */
+  pipeline_log: AgentLogEntry[];
+  /** 開始時刻 */
+  started_at: Date;
+  /** 最終更新時刻 */
+  updated_at: Date;
+  /** 完了時刻 */
+  completed_at?: Date | null;
+  /** エラー時のメッセージ */
+  error_message?: string | null;
+}


### PR DESCRIPTION
## Summary

- 新規 `pipeline_runs` Firestore コレクションで調査・翻訳・Podcast パイプラインの実行進捗をリアルタイムに管理画面へ表示
- 各パイプライン（`main.py`, `translate_main.py`, `podcast_main.py`）にエージェント遷移ごとの進捗書き込みを追加
- 管理画面に「実行中のパイプライン」セクションを追加（5秒ポーリング、経過時間表示、展開で詳細タイムライン）
- パイプライン完了時に記事リストを自動再取得

## Changes

### Backend (Python)
- `shared/pipeline_run.py` (新規): `pipeline_runs` CRUD 操作。全書き込みは try/except で安全化
- `main.py`: ブログパイプラインに進捗書き込み追加
- `translate_main.py`: 翻訳パイプラインに進捗書き込み追加
- `podcast_main.py`: Podcast パイプラインに進捗書き込み追加

### Frontend (Next.js)
- `PipelineRun` 型定義、`pipeline_runs` Firestore クエリ関数
- `usePipelinePolling` フック: 5秒間隔ポーリング、完了検知コールバック
- `RunningPipelines` コンポーネント: 経過時間リアルタイム更新、30分応答なし検知
- 管理画面に統合、各アクション成功時にポーリング開始

### Tests
- `tests/unit/test_pipeline_run.py` (新規): 19件のユニットテスト
- 全113件パス（既存94件 + 新規19件）

## Test plan

- [ ] Firebase Emulator で「新規調査」実行 → `pipeline_runs` にドキュメント作成を確認
- [ ] 管理画面に「実行中のパイプライン」セクションが表示されることを確認
- [ ] パイプライン完了後、記事リストが自動更新されることを確認
- [ ] `pytest tests/unit/test_pipeline_run.py -v` でユニットテスト実行

🤖 Generated with [Claude Code](https://claude.com/claude-code)