### PR TITLE
fix: レスポンシブ画像バリアントが適用されない問題を修正

### DIFF
--- a/archive_agents/tools/illustrator_tools.py
+++ b/archive_agents/tools/illustrator_tools.py
@@ -4,11 +4,14 @@ Generates images using Imagen 3 and saves them to local storage.
 """
 
 import json
+import logging
 import os
 import time
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 from google import genai
 from google.genai import types
@@ -163,6 +166,7 @@ def _get_variants(filepath: str) -> list:
     resize_result = json.loads(resize_image_variants(filepath))
     if resize_result.get("status") == "success":
         return resize_result["variants"]
+    logger.warning("Variant generation failed for %s: %s", filepath, resize_result.get("error"))
     return []
 
 

--- a/archive_agents/tools/publisher_tools.py
+++ b/archive_agents/tools/publisher_tools.py
@@ -160,15 +160,34 @@ def upload_images(mystery_id: str, image_paths: str) -> str:
 
             uploaded.append({
                 "path": local_path,
+                "label": variant_suffix.lstrip("_") if variant_suffix else "original",
                 "status": "success",
                 "storage_path": f"gs://{bucket.name}/{blob_name}",
                 "public_url": public_url,
             })
 
+        # Build structured images object for direct use in Firestore
+        images = {}
+        variants = {}
+        for entry in uploaded:
+            if entry["status"] != "success":
+                continue
+            lbl = entry["label"]
+            if lbl == "original":
+                images["hero"] = entry["public_url"]
+            else:
+                variants[lbl] = entry["public_url"]
+        if variants:
+            # Use lg variant as hero if available (higher quality)
+            if "lg" in variants:
+                images["hero"] = variants["lg"]
+            images["variants"] = variants
+
         return json.dumps({
             "status": "success",
             "mystery_id": mystery_id,
             "uploaded": uploaded,
+            "images": images,
         }, ensure_ascii=False)
 
     except Exception as e:

--- a/tests/unit/test_illustrator_tools.py
+++ b/tests/unit/test_illustrator_tools.py
@@ -11,6 +11,7 @@ from archive_agents.tools.illustrator_tools import (
     MAX_RETRIES,
     FALLBACK_IMAGE_PATH,
     FALLBACK_VARIANTS,
+    _get_variants,
     _sanitize_prompt,
     generate_image,
     resize_image_variants,
@@ -469,3 +470,24 @@ class TestGenerateImageWithVariants:
         assert len(result_data["variants"]) == 4
         labels = {v["label"] for v in result_data["variants"]}
         assert labels == {"sm", "md", "lg", "xl"}
+
+
+class TestGetVariantsLogging:
+    """Tests for _get_variants warning log on failure."""
+
+    @patch("archive_agents.tools.illustrator_tools.resize_image_variants")
+    def test_get_variants_logs_warning_on_failure(self, mock_resize, caplog):
+        """Should log a warning when variant generation fails."""
+        mock_resize.return_value = json.dumps({
+            "status": "error",
+            "error": "Pillow not installed",
+            "variants": [],
+        })
+
+        import logging
+        with caplog.at_level(logging.WARNING, logger="archive_agents.tools.illustrator_tools"):
+            result = _get_variants("/tmp/test.png")
+
+        assert result == []
+        assert "Variant generation failed" in caplog.text
+        assert "Pillow not installed" in caplog.text

--- a/tests/unit/test_publisher_tools.py
+++ b/tests/unit/test_publisher_tools.py
@@ -115,3 +115,107 @@ class TestUploadImagesRenaming:
         assert result_data["status"] == "success"
         expected_blob = f"images/{mystery_id}/{mystery_id}.jpg"
         mock_bucket.blob.assert_called_once_with(expected_blob)
+
+
+class TestUploadImagesLabel:
+    """Tests for upload_images label field."""
+
+    @patch("archive_agents.tools.publisher_tools.get_storage_bucket")
+    def test_upload_returns_label_for_original(self, mock_get_bucket, tmp_path):
+        """Should return label 'original' for the original image."""
+        mock_bucket = MagicMock()
+        mock_blob = MagicMock()
+        mock_bucket.blob.return_value = mock_blob
+        mock_bucket.name = "test-bucket"
+        mock_get_bucket.return_value = mock_bucket
+
+        png_file = tmp_path / "header_20260208.png"
+        png_file.write_bytes(b"fake png data")
+
+        result = upload_images("TEST-001", json.dumps([str(png_file)]))
+        result_data = json.loads(result)
+
+        assert result_data["status"] == "success"
+        assert result_data["uploaded"][0]["label"] == "original"
+
+    @patch("archive_agents.tools.publisher_tools.get_storage_bucket")
+    def test_upload_returns_label_for_variant(self, mock_get_bucket, tmp_path):
+        """Should return label 'sm' for a _sm variant image."""
+        mock_bucket = MagicMock()
+        mock_blob = MagicMock()
+        mock_bucket.blob.return_value = mock_blob
+        mock_bucket.name = "test-bucket"
+        mock_get_bucket.return_value = mock_bucket
+
+        webp_file = tmp_path / "header_20260208_sm.webp"
+        webp_file.write_bytes(b"fake webp data")
+
+        result = upload_images("TEST-001", json.dumps([str(webp_file)]))
+        result_data = json.loads(result)
+
+        assert result_data["status"] == "success"
+        assert result_data["uploaded"][0]["label"] == "sm"
+
+
+class TestUploadImagesStructured:
+    """Tests for upload_images structured images object."""
+
+    @patch("archive_agents.tools.publisher_tools.get_storage_bucket")
+    def test_upload_returns_structured_images(self, mock_get_bucket, tmp_path):
+        """Should return structured images object with hero and variants."""
+        mock_bucket = MagicMock()
+        mock_blob = MagicMock()
+        mock_bucket.blob.return_value = mock_blob
+        mock_bucket.name = "test-bucket"
+        mock_get_bucket.return_value = mock_bucket
+
+        # Create original + all 4 variants
+        files = [
+            tmp_path / "header.png",
+            tmp_path / "header_sm.webp",
+            tmp_path / "header_md.webp",
+            tmp_path / "header_lg.webp",
+            tmp_path / "header_xl.webp",
+        ]
+        for f in files:
+            f.write_bytes(b"fake data")
+
+        mystery_id = "OCC-MA-617-20260208143025"
+        result = upload_images(mystery_id, json.dumps([str(f) for f in files]))
+        result_data = json.loads(result)
+
+        assert result_data["status"] == "success"
+        images = result_data["images"]
+        assert "hero" in images
+        assert "variants" in images
+        assert "sm" in images["variants"]
+        assert "md" in images["variants"]
+        assert "lg" in images["variants"]
+        assert "xl" in images["variants"]
+
+    @patch("archive_agents.tools.publisher_tools.get_storage_bucket")
+    def test_upload_images_hero_prefers_lg(self, mock_get_bucket, tmp_path):
+        """Should use lg variant URL as hero when lg variant exists."""
+        mock_bucket = MagicMock()
+        mock_blob = MagicMock()
+        mock_bucket.blob.return_value = mock_blob
+        mock_bucket.name = "test-bucket"
+        mock_get_bucket.return_value = mock_bucket
+
+        # Create original + lg variant
+        original = tmp_path / "header.png"
+        original.write_bytes(b"fake png")
+        lg_variant = tmp_path / "header_lg.webp"
+        lg_variant.write_bytes(b"fake lg webp")
+
+        mystery_id = "OCC-MA-617-20260208143025"
+        result = upload_images(mystery_id, json.dumps([str(original), str(lg_variant)]))
+        result_data = json.loads(result)
+
+        images = result_data["images"]
+        # hero should be the lg variant URL, not the original
+        lg_url = next(
+            e["public_url"] for e in result_data["uploaded"]
+            if e["label"] == "lg"
+        )
+        assert images["hero"] == lg_url


### PR DESCRIPTION
## Summary

- `_get_variants()` のバリアント生成失敗が黙殺されていた問題に warning ログを追加
- `upload_images` の返却に `label` フィールドと構造化 `images` オブジェクトを追加し、Publisher が Firestore にそのまま格納可能に
- Publisher instruction を `images` オブジェクト直接利用に更新

## Test plan

- [x] `pytest tests/unit/test_illustrator_tools.py -v` — warning ログテスト含む全28テスト PASS
- [x] `pytest tests/unit/test_publisher_tools.py -v` — label/images テスト含む全9テスト PASS
- [x] `pytest tests/unit/ -v` — 全132テスト PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)