### PR TITLE
fix: 無限ループ防止の強化（RunConfig + timeout + callback）

### DIFF
--- a/archive_agents/agents/illustrator.py
+++ b/archive_agents/agents/illustrator.py
@@ -12,10 +12,38 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 from google.adk.agents import LlmAgent
+from google.adk.tools.base_tool import BaseTool
+from google.adk.tools.tool_context import ToolContext
 
 from ..tools import generate_image
 
 load_dotenv(Path(__file__).parent.parent / ".env")
+
+MAX_GENERATE_IMAGE_CALLS = 3
+_STATE_KEY = "generate_image_call_count"
+
+
+def _limit_generate_image_calls(
+    tool: BaseTool, args: dict, tool_context: ToolContext
+) -> dict | None:
+    """generate_image の呼び出し回数を制限する before_tool_callback.
+
+    セッション状態でカウントを管理し、MAX_GENERATE_IMAGE_CALLS を超えた場合は
+    エラーを返して呼び出しをブロックする。
+    """
+    if tool.name == "generate_image":
+        count = tool_context.state.get(_STATE_KEY, 0) + 1
+        tool_context.state[_STATE_KEY] = count
+        if count > MAX_GENERATE_IMAGE_CALLS:
+            return {
+                "status": "error",
+                "error": (
+                    f"generate_image の呼び出し上限 ({MAX_GENERATE_IMAGE_CALLS}回) "
+                    "に達しました。フォールバック画像を使用してください。"
+                ),
+            }
+    return None
+
 
 ILLUSTRATOR_INSTRUCTION = """
 あなたは「Ghost in the Archive」プロジェクトのイラストレーター（Illustrator Agent）です。
@@ -115,4 +143,5 @@ illustrator_agent = LlmAgent(
     instruction=ILLUSTRATOR_INSTRUCTION,
     tools=[generate_image],
     output_key="visual_assets",
+    before_tool_callback=_limit_generate_image_calls,
 )

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ from dotenv import load_dotenv
 # Load environment variables
 load_dotenv(Path(__file__).parent / ".env")
 
+from google.adk.agents.run_config import RunConfig
 from google.adk.runners import Runner
 from google.adk.sessions import InMemorySessionService
 from google.genai import types
@@ -26,6 +27,9 @@ from shared.pipeline_run import (
     complete_pipeline_run,
     error_pipeline_run,
 )
+
+
+PIPELINE_TIMEOUT_SECONDS = 1800  # 30 minutes
 
 
 async def investigate(query: str) -> None:
@@ -71,44 +75,48 @@ async def investigate(query: str) -> None:
     accumulated_text: list[str] = []
     current_log_index: int | None = None
 
-    try:
-        # Run the investigation
-        async for event in runner.run_async(
-            user_id=user_id,
-            session_id=session_id,
-            new_message=types.Content(
-                role="user",
-                parts=[types.Part(text=query)],
-            ),
-        ):
-            # Detect agent transitions via event.author
-            author = getattr(event, "author", None)
-            if author and author != "ghost_commander" and author != current_agent_name:
-                # Complete previous agent
-                if current_agent_name:
-                    summary = " ".join(accumulated_text)[:200]
-                    logger.complete_agent(summary or "(no text output)")
-                    # Update pipeline run with completed agent
-                    completed_logs = logger.get_logs()
-                    if completed_logs:
-                        update_agent_completed(
-                            run_id, current_log_index, completed_logs[-1]
-                        )
-                    accumulated_text = []
-                # Start new agent
-                current_agent_name = author
-                logger.start_agent(current_agent_name)
-                # Update pipeline run with new agent
-                current_log_index = update_agent_started(
-                    run_id, current_agent_name, logger.get_logs()[-1]
-                )
+    run_config = RunConfig(max_llm_calls=50)
 
-            # Print text responses from agents
-            if event.content and event.content.parts:
-                for part in event.content.parts:
-                    if hasattr(part, "text") and part.text:
-                        print(part.text)
-                        accumulated_text.append(part.text[:100])
+    try:
+        async with asyncio.timeout(PIPELINE_TIMEOUT_SECONDS):
+            # Run the investigation
+            async for event in runner.run_async(
+                user_id=user_id,
+                session_id=session_id,
+                new_message=types.Content(
+                    role="user",
+                    parts=[types.Part(text=query)],
+                ),
+                run_config=run_config,
+            ):
+                # Detect agent transitions via event.author
+                author = getattr(event, "author", None)
+                if author and author != "ghost_commander" and author != current_agent_name:
+                    # Complete previous agent
+                    if current_agent_name:
+                        summary = " ".join(accumulated_text)[:200]
+                        logger.complete_agent(summary or "(no text output)")
+                        # Update pipeline run with completed agent
+                        completed_logs = logger.get_logs()
+                        if completed_logs:
+                            update_agent_completed(
+                                run_id, current_log_index, completed_logs[-1]
+                            )
+                        accumulated_text = []
+                    # Start new agent
+                    current_agent_name = author
+                    logger.start_agent(current_agent_name)
+                    # Update pipeline run with new agent
+                    current_log_index = update_agent_started(
+                        run_id, current_agent_name, logger.get_logs()[-1]
+                    )
+
+                # Print text responses from agents
+                if event.content and event.content.parts:
+                    for part in event.content.parts:
+                        if hasattr(part, "text") and part.text:
+                            print(part.text)
+                            accumulated_text.append(part.text[:100])
 
         # Complete final agent
         if current_agent_name:
@@ -146,6 +154,9 @@ async def investigate(query: str) -> None:
 
         complete_pipeline_run(run_id, mystery_id=mystery_id)
 
+    except TimeoutError:
+        error_pipeline_run(run_id, f"Pipeline timed out after {PIPELINE_TIMEOUT_SECONDS}s")
+        raise
     except Exception as e:
         error_pipeline_run(run_id, str(e))
         raise

--- a/podcast_main.py
+++ b/podcast_main.py
@@ -17,6 +17,7 @@ from dotenv import load_dotenv
 
 load_dotenv(Path(__file__).parent / ".env")
 
+from google.adk.agents.run_config import RunConfig
 from google.adk.runners import Runner
 from google.adk.sessions import InMemorySessionService
 from google.genai import types
@@ -34,6 +35,9 @@ from shared.pipeline_run import (
     complete_pipeline_run,
     error_pipeline_run,
 )
+
+
+PIPELINE_TIMEOUT_SECONDS = 1200  # 20 minutes
 
 
 async def generate_podcast(mystery_id: str) -> None:
@@ -102,49 +106,53 @@ async def generate_podcast(mystery_id: str) -> None:
 
     agent_start_time: datetime | None = None
 
+    run_config = RunConfig(max_llm_calls=30)
+
     try:
-        async for event in runner.run_async(
-            user_id=user_id,
-            session_id=session_id,
-            new_message=types.Content(
-                role="user",
-                parts=[types.Part(text=f"以下のブログ記事からポッドキャストを作成してください: {title}")],
-            ),
-        ):
-            # Track agent transitions
-            author = getattr(event, "author", None)
-            if author and author != "podcast_commander" and author != current_agent_name:
-                # Complete previous agent
-                if current_agent_name and agent_start_time:
-                    end_time = datetime.now(timezone.utc)
-                    duration = (end_time - agent_start_time).total_seconds()
-                    completed_entry = {
+        async with asyncio.timeout(PIPELINE_TIMEOUT_SECONDS):
+            async for event in runner.run_async(
+                user_id=user_id,
+                session_id=session_id,
+                new_message=types.Content(
+                    role="user",
+                    parts=[types.Part(text=f"以下のブログ記事からポッドキャストを作成してください: {title}")],
+                ),
+                run_config=run_config,
+            ):
+                # Track agent transitions
+                author = getattr(event, "author", None)
+                if author and author != "podcast_commander" and author != current_agent_name:
+                    # Complete previous agent
+                    if current_agent_name and agent_start_time:
+                        end_time = datetime.now(timezone.utc)
+                        duration = (end_time - agent_start_time).total_seconds()
+                        completed_entry = {
+                            "agent_name": current_agent_name,
+                            "status": "completed",
+                            "start_time": agent_start_time.isoformat(),
+                            "end_time": end_time.isoformat(),
+                            "duration_seconds": round(duration, 2),
+                            "output_summary": f"{current_agent_name} completed",
+                        }
+                        update_agent_completed(run_id, current_log_index, completed_entry)
+
+                    # Start new agent
+                    current_agent_name = author
+                    agent_start_time = datetime.now(timezone.utc)
+                    log_entry = {
                         "agent_name": current_agent_name,
-                        "status": "completed",
+                        "status": "running",
                         "start_time": agent_start_time.isoformat(),
-                        "end_time": end_time.isoformat(),
-                        "duration_seconds": round(duration, 2),
-                        "output_summary": f"{current_agent_name} completed",
+                        "end_time": None,
+                        "duration_seconds": None,
+                        "output_summary": None,
                     }
-                    update_agent_completed(run_id, current_log_index, completed_entry)
+                    current_log_index = update_agent_started(run_id, current_agent_name, log_entry)
 
-                # Start new agent
-                current_agent_name = author
-                agent_start_time = datetime.now(timezone.utc)
-                log_entry = {
-                    "agent_name": current_agent_name,
-                    "status": "running",
-                    "start_time": agent_start_time.isoformat(),
-                    "end_time": None,
-                    "duration_seconds": None,
-                    "output_summary": None,
-                }
-                current_log_index = update_agent_started(run_id, current_agent_name, log_entry)
-
-            if event.content and event.content.parts:
-                for part in event.content.parts:
-                    if hasattr(part, "text") and part.text:
-                        print(part.text)
+                if event.content and event.content.parts:
+                    for part in event.content.parts:
+                        if hasattr(part, "text") and part.text:
+                            print(part.text)
 
         # Complete final agent
         if current_agent_name and agent_start_time:
@@ -178,6 +186,11 @@ async def generate_podcast(mystery_id: str) -> None:
         print(f"Podcast generation complete: {result}")
         print("=" * 70)
 
+    except TimeoutError:
+        print(f"Error: Pipeline timed out after {PIPELINE_TIMEOUT_SECONDS}s")
+        set_podcast_status(mystery_id, "error")
+        error_pipeline_run(run_id, f"Pipeline timed out after {PIPELINE_TIMEOUT_SECONDS}s")
+        raise
     except Exception as e:
         print(f"Error during podcast generation: {e}")
         set_podcast_status(mystery_id, "error")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,9 +14,15 @@ mock_adk.agents.LlmAgent = MagicMock
 mock_adk.agents.SequentialAgent = MagicMock
 mock_adk.tools = MagicMock()
 mock_adk.tools.FunctionTool = MagicMock
+mock_adk.tools.base_tool = MagicMock()
+mock_adk.tools.tool_context = MagicMock()
+mock_adk.agents.run_config = MagicMock()
 sys.modules["google.adk"] = mock_adk
 sys.modules["google.adk.agents"] = mock_adk.agents
+sys.modules["google.adk.agents.run_config"] = mock_adk.agents.run_config
 sys.modules["google.adk.tools"] = mock_adk.tools
+sys.modules["google.adk.tools.base_tool"] = mock_adk.tools.base_tool
+sys.modules["google.adk.tools.tool_context"] = mock_adk.tools.tool_context
 
 mock_genai = MagicMock()
 mock_genai.Client = MagicMock

--- a/tests/unit/test_illustrator_callback.py
+++ b/tests/unit/test_illustrator_callback.py
@@ -1,0 +1,93 @@
+"""Unit tests for Illustrator before_tool_callback (generate_image call limiter)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from archive_agents.agents.illustrator import (
+    MAX_GENERATE_IMAGE_CALLS,
+    _STATE_KEY,
+    _limit_generate_image_calls,
+)
+
+
+@pytest.fixture
+def mock_tool_context():
+    """Create a mock ToolContext with a dict-like state."""
+    ctx = MagicMock()
+    ctx.state = {}
+    return ctx
+
+
+@pytest.fixture
+def mock_generate_image_tool():
+    """Create a mock BaseTool with name='generate_image'."""
+    tool = MagicMock()
+    tool.name = "generate_image"
+    return tool
+
+
+@pytest.fixture
+def mock_other_tool():
+    """Create a mock BaseTool with a non-generate_image name."""
+    tool = MagicMock()
+    tool.name = "some_other_tool"
+    return tool
+
+
+class TestLimitGenerateImageCalls:
+    """Tests for _limit_generate_image_calls callback."""
+
+    def test_allows_first_call(self, mock_generate_image_tool, mock_tool_context):
+        """Should allow the first generate_image call."""
+        result = _limit_generate_image_calls(mock_generate_image_tool, {}, mock_tool_context)
+        assert result is None
+        assert mock_tool_context.state[_STATE_KEY] == 1
+
+    def test_allows_calls_up_to_limit(self, mock_generate_image_tool, mock_tool_context):
+        """Should allow calls up to MAX_GENERATE_IMAGE_CALLS."""
+        for i in range(MAX_GENERATE_IMAGE_CALLS):
+            result = _limit_generate_image_calls(mock_generate_image_tool, {}, mock_tool_context)
+            assert result is None
+        assert mock_tool_context.state[_STATE_KEY] == MAX_GENERATE_IMAGE_CALLS
+
+    def test_blocks_call_exceeding_limit(self, mock_generate_image_tool, mock_tool_context):
+        """Should block the call that exceeds MAX_GENERATE_IMAGE_CALLS."""
+        # Exhaust the limit
+        for _ in range(MAX_GENERATE_IMAGE_CALLS):
+            _limit_generate_image_calls(mock_generate_image_tool, {}, mock_tool_context)
+
+        # Next call should be blocked
+        result = _limit_generate_image_calls(mock_generate_image_tool, {}, mock_tool_context)
+        assert result is not None
+        assert result["status"] == "error"
+        assert str(MAX_GENERATE_IMAGE_CALLS) in result["error"]
+
+    def test_ignores_other_tools(self, mock_other_tool, mock_tool_context):
+        """Should not limit calls to tools other than generate_image."""
+        for _ in range(10):
+            result = _limit_generate_image_calls(mock_other_tool, {}, mock_tool_context)
+            assert result is None
+        assert _STATE_KEY not in mock_tool_context.state
+
+    def test_counter_persists_in_state(self, mock_generate_image_tool, mock_tool_context):
+        """Should correctly increment counter across calls."""
+        _limit_generate_image_calls(mock_generate_image_tool, {}, mock_tool_context)
+        assert mock_tool_context.state[_STATE_KEY] == 1
+
+        _limit_generate_image_calls(mock_generate_image_tool, {}, mock_tool_context)
+        assert mock_tool_context.state[_STATE_KEY] == 2
+
+        _limit_generate_image_calls(mock_generate_image_tool, {}, mock_tool_context)
+        assert mock_tool_context.state[_STATE_KEY] == 3
+
+    def test_pre_existing_count_respected(self, mock_generate_image_tool, mock_tool_context):
+        """Should respect a pre-existing count in state."""
+        mock_tool_context.state[_STATE_KEY] = MAX_GENERATE_IMAGE_CALLS
+        result = _limit_generate_image_calls(mock_generate_image_tool, {}, mock_tool_context)
+        assert result is not None
+        assert result["status"] == "error"
+
+    def test_max_calls_constant_is_3(self):
+        """MAX_GENERATE_IMAGE_CALLS should be 3."""
+        assert MAX_GENERATE_IMAGE_CALLS == 3

--- a/translate_main.py
+++ b/translate_main.py
@@ -18,6 +18,7 @@ from dotenv import load_dotenv
 
 load_dotenv(Path(__file__).parent / ".env")
 
+from google.adk.agents.run_config import RunConfig
 from google.adk.runners import Runner
 from google.adk.sessions import InMemorySessionService
 from google.genai import types
@@ -35,6 +36,9 @@ from shared.pipeline_run import (
     complete_pipeline_run,
     error_pipeline_run,
 )
+
+
+PIPELINE_TIMEOUT_SECONDS = 600  # 10 minutes
 
 
 async def translate_mystery(mystery_id: str) -> None:
@@ -131,19 +135,23 @@ async def translate_mystery(mystery_id: str) -> None:
     log_index = update_agent_started(run_id, "translator", translator_log_entry)
     translate_start = datetime.now(timezone.utc)
 
+    run_config = RunConfig(max_llm_calls=20)
+
     try:
-        async for event in runner.run_async(
-            user_id=user_id,
-            session_id=session_id,
-            new_message=types.Content(
-                role="user",
-                parts=[types.Part(text=f"以下の日本語記事を英語に翻訳してください: {title}")],
-            ),
-        ):
-            if event.content and event.content.parts:
-                for part in event.content.parts:
-                    if hasattr(part, "text") and part.text:
-                        print(part.text)
+        async with asyncio.timeout(PIPELINE_TIMEOUT_SECONDS):
+            async for event in runner.run_async(
+                user_id=user_id,
+                session_id=session_id,
+                new_message=types.Content(
+                    role="user",
+                    parts=[types.Part(text=f"以下の日本語記事を英語に翻訳してください: {title}")],
+                ),
+                run_config=run_config,
+            ):
+                if event.content and event.content.parts:
+                    for part in event.content.parts:
+                        if hasattr(part, "text") and part.text:
+                            print(part.text)
 
         # Retrieve results from session state
         session = await session_service.get_session(
@@ -182,6 +190,11 @@ async def translate_mystery(mystery_id: str) -> None:
         print(f"Translation complete: {result}")
         print("=" * 70)
 
+    except TimeoutError:
+        print(f"Error: Pipeline timed out after {PIPELINE_TIMEOUT_SECONDS}s")
+        set_translation_error(mystery_id)
+        error_pipeline_run(run_id, f"Pipeline timed out after {PIPELINE_TIMEOUT_SECONDS}s")
+        raise
     except Exception as e:
         print(f"Error during translation: {e}")
         set_translation_error(mystery_id)


### PR DESCRIPTION
## Summary

- **RunConfig で LLM 呼び出し上限を明示的に設定**: ADK デフォルトの `max_llm_calls=500` に依存せず、各パイプラインに適切な上限を設定（blog:50, podcast:30, translate:20）
- **asyncio.timeout でパイプライン全体の実行時間を制限**: 外部APIの応答待ちで永久にブロックするリスクを排除（blog:30分, podcast:20分, translate:10分）
- **before_tool_callback で generate_image の呼び出し回数をコードレベルで制限**: LLM がプロンプト指示を無視して `generate_image` を無限に呼ぶリスクを排除（最大3回、セッション状態でカウント管理）

## Test plan

- [x] `_limit_generate_image_calls` の単体テスト7件追加（上限内許可、上限超過ブロック、他ツール無視等）
- [x] 既存テスト157件全パス確認（リグレッションなし）
- [ ] `adk web` で Illustrator エージェントを実行し、`generate_image` が上限を超えないことを手動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)