### PR TITLE
fix: WebP バリアント生成のサイレント失敗を防止

### DIFF
--- a/archive_agents/tools/illustrator_tools.py
+++ b/archive_agents/tools/illustrator_tools.py
@@ -250,13 +250,21 @@ def _get_client() -> genai.Client:
     return genai.Client()
 
 
-def _get_variants(filepath: str) -> list:
-    """Generate variants and return the list, or empty list on failure."""
+def _get_variants(filepath: str) -> tuple[list, str | None]:
+    """Generate variants and return (variants, error_message).
+
+    Returns:
+        Tuple of (variants_list, error_string_or_None).
+    """
     resize_result = json.loads(resize_image_variants(filepath))
     if resize_result.get("status") == "success":
-        return resize_result["variants"]
-    logger.warning("Variant generation failed for %s: %s", filepath, resize_result.get("error"))
-    return []
+        return resize_result["variants"], None
+    error_msg = resize_result.get("error", "Unknown error")
+    logger.error(
+        "WebP variant generation FAILED for %s: %s",
+        filepath, error_msg,
+    )
+    return [], error_msg
 
 
 def generate_image(
@@ -350,7 +358,7 @@ def generate_image(
                 image.save(str(filepath))
 
                 # Generate responsive variants
-                variants = _get_variants(str(filepath))
+                variants, variant_error = _get_variants(str(filepath))
 
                 return json.dumps({
                     "status": "success",
@@ -363,6 +371,7 @@ def generate_image(
                     "attempt": attempt + 1,
                     "prompt_sanitized": prompt_sanitized,
                     "variants": variants,
+                    "variant_error": variant_error,
                 }, ensure_ascii=False)
 
             # No images generated - likely safety filter

--- a/tests/unit/test_illustrator_tools.py
+++ b/tests/unit/test_illustrator_tools.py
@@ -462,12 +462,13 @@ class TestGenerateImageWithVariants:
         assert result_data["status"] == "success"
         assert "variants" in result_data
         assert len(result_data["variants"]) == 1
+        assert result_data["variant_error"] is None
         mock_resize.assert_called_once()
 
     @patch("archive_agents.tools.illustrator_tools.resize_image_variants")
     @patch("archive_agents.tools.illustrator_tools._get_client")
     def test_resize_failure_returns_empty_variants(self, mock_get_client, mock_resize):
-        """Should return empty variants when resize fails (graceful degradation)."""
+        """Should return empty variants with variant_error when resize fails."""
         mock_client = MagicMock()
         mock_get_client.return_value = mock_client
 
@@ -487,6 +488,7 @@ class TestGenerateImageWithVariants:
 
         assert result_data["status"] == "success"
         assert result_data["variants"] == []
+        assert result_data["variant_error"] == "Pillow not installed"
 
     @patch("archive_agents.tools.illustrator_tools._get_client")
     @patch("archive_agents.tools.illustrator_tools.time.sleep")
@@ -508,11 +510,11 @@ class TestGenerateImageWithVariants:
 
 
 class TestGetVariantsLogging:
-    """Tests for _get_variants warning log on failure."""
+    """Tests for _get_variants error log on failure."""
 
     @patch("archive_agents.tools.illustrator_tools.resize_image_variants")
-    def test_get_variants_logs_warning_on_failure(self, mock_resize, caplog):
-        """Should log a warning when variant generation fails."""
+    def test_get_variants_logs_error_on_failure(self, mock_resize, caplog):
+        """Should log an ERROR when variant generation fails."""
         mock_resize.return_value = json.dumps({
             "status": "error",
             "error": "Pillow not installed",
@@ -520,12 +522,28 @@ class TestGetVariantsLogging:
         })
 
         import logging
-        with caplog.at_level(logging.WARNING, logger="archive_agents.tools.illustrator_tools"):
-            result = _get_variants("/tmp/test.png")
+        with caplog.at_level(logging.ERROR, logger="archive_agents.tools.illustrator_tools"):
+            variants, error_msg = _get_variants("/tmp/test.png")
 
-        assert result == []
-        assert "Variant generation failed" in caplog.text
+        assert variants == []
+        assert error_msg == "Pillow not installed"
+        assert "WebP variant generation FAILED" in caplog.text
         assert "Pillow not installed" in caplog.text
+
+    @patch("archive_agents.tools.illustrator_tools.resize_image_variants")
+    def test_get_variants_returns_none_error_on_success(self, mock_resize):
+        """Should return None as error_msg on success."""
+        mock_resize.return_value = json.dumps({
+            "status": "success",
+            "variants": [
+                {"label": "sm", "width": 640, "height": 360, "filepath": "/tmp/sm.webp", "filename": "sm.webp"},
+            ],
+        })
+
+        variants, error_msg = _get_variants("/tmp/test.png")
+
+        assert len(variants) == 1
+        assert error_msg is None
 
 
 class TestBuildSafeFallbackPrompt:


### PR DESCRIPTION
## Summary

- `.venv` に Pillow がインストールされておらず `from PIL import Image` が `ImportError` → `_get_variants` が WARNING ログのみで空リストを返し、`generate_image` が `"status": "success"` + `"variants": []` を返していた（サイレント失敗）
- `_get_variants` のログを WARNING → ERROR に昇格し、エラーメッセージも戻り値で返すよう変更
- `generate_image` のレスポンスに `variant_error` フィールドを追加（失敗理由の可視化）

## Test plan

- [x] `pytest tests/unit/test_illustrator_tools.py -v -k "variant"` → 11 passed
- [x] `pytest tests/unit/ -v` → 164 passed（リグレッションなし）
- [ ] `.venv/bin/python -c "from PIL import Image; print('OK')"` → OK 確認済み
- [ ] 管理画面からパイプライン実行し WebP バリアントが生成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)