### PR TITLE
fix: web-admin の allUsers 削除、Cloud Run IAM 認証に切り替え

### DIFF
--- a/terraform/cloud-run.tf
+++ b/terraform/cloud-run.tf
@@ -85,30 +85,6 @@ resource "google_cloud_run_v2_service" "web_admin" {
   ]
 }
 
-# Allow unauthenticated access (authentication handled by NextAuth)
-resource "google_cloud_run_v2_service_iam_member" "web_admin_public" {
-  project  = var.project_id
-  location = var.region
-  name     = google_cloud_run_v2_service.web_admin.name
-  role     = "roles/run.invoker"
-  member   = "allUsers"
-}
-
-# Domain mapping for admin subdomain
-resource "google_cloud_run_domain_mapping" "admin" {
-  location = var.region
-  name     = "${var.admin_subdomain}.${var.domain}"
-
-  metadata {
-    namespace = var.project_id
-  }
-
-  spec {
-    route_name = google_cloud_run_v2_service.web_admin.name
-  }
-
-  depends_on = [google_cloud_run_v2_service.web_admin]
-}
 
 output "web_admin_url" {
   description = "URL of the web-admin Cloud Run service"

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -9,14 +9,8 @@ resource "google_dns_managed_zone" "main" {
   depends_on = [google_project_service.apis]
 }
 
-# A record for admin subdomain -> Cloud Run
-resource "google_dns_record_set" "admin" {
-  name         = "${var.admin_subdomain}.${var.domain}."
-  type         = "CNAME"
-  ttl          = 300
-  managed_zone = google_dns_managed_zone.main.name
-  rrdatas      = ["ghs.googlehosted.com."]
-}
+# admin subdomain DNS record removed — web-admin is accessed via
+# gcloud run services proxy (Cloud Run IAM authentication)
 
 # Output nameservers for Spaceship configuration
 output "nameservers" {

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -62,11 +62,13 @@ output "next_steps" {
     5. Deploy web-public:
        gcloud builds triggers run web-public-deploy
 
-    6. Verify DNS propagation:
-       dig +short ${var.admin_subdomain}.${var.domain}
+    6. Grant Cloud Run invoker access (Google Cloud Console):
+       Cloud Run > web-admin > Security > Add Principal
+       Grant role: Cloud Run Invoker (roles/run.invoker)
 
-    7. Check SSL certificate:
-       gcloud compute ssl-certificates list
+    7. Access web-admin via authenticated proxy:
+       gcloud run services proxy web-admin --region ${var.region}
+       # Then open http://localhost:8080 in your browser
 
   EOT
 }


### PR DESCRIPTION
## Summary
- web-admin の `allUsers` invoker 権限を削除し、パブリックアクセスを遮断
- Cloud Run ドメインマッピングと admin サブドメイン DNS レコードを削除
- `gcloud run services proxy` 経由のローカルアクセスに移行

## 変更後のアクセス方法
1. Cloud Console で自分のアカウントに `roles/run.invoker` を付与
2. `gcloud run services proxy web-admin --region asia-northeast1`
3. ブラウザで `http://localhost:8080` にアクセス

## Test plan
- [ ] `terraform plan` で意図通りの destroy/change を確認
- [ ] `terraform apply` 実行
- [ ] Cloud Console で `roles/run.invoker` を付与
- [ ] `gcloud run services proxy` でアクセス確認
- [ ] Cloud Run 直接 URL がブラウザから 403 になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)