### PR TITLE
fix: pipelines ビルドコマンドを cloudbuild config 方式に修正

### DIFF
--- a/cloudbuild-pipelines.yaml
+++ b/cloudbuild-pipelines.yaml
@@ -1,0 +1,5 @@
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'asia-northeast1-docker.pkg.dev/ghostinthearchive/ghostinthearchive/pipelines:latest', '-f', 'Dockerfile.jobs', '.']
+images:
+  - 'asia-northeast1-docker.pkg.dev/ghostinthearchive/ghostinthearchive/pipelines:latest'

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -19,9 +19,7 @@ Terraform apply 前に、Cloud Run で使用する Docker イメージを Artifa
 # プロジェクトルートから実行
 
 # pipelines イメージ（blog-pipeline / translate-pipeline / podcast-pipeline 共通）
-gcloud builds submit \
-  --tag asia-northeast1-docker.pkg.dev/ghostinthearchive/ghostinthearchive/pipelines:latest \
-  -f Dockerfile.jobs .
+gcloud builds submit --config cloudbuild-pipelines.yaml .
 
 # web-admin イメージ
 gcloud builds submit \

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -54,7 +54,7 @@ output "next_steps" {
 
        # pipelines
        cd ..
-       gcloud builds submit --tag ${var.region}-docker.pkg.dev/${var.project_id}/ghostinthearchive/pipelines -f Dockerfile.jobs
+       gcloud builds submit --config cloudbuild-pipelines.yaml .
 
     4. Deploy web-admin:
        gcloud run services update web-admin --region ${var.region}


### PR DESCRIPTION
## Summary
- `gcloud builds submit` は `-f` フラグをサポートしないため、`Dockerfile.jobs` を指定する `cloudbuild-pipelines.yaml` を新規作成
- `terraform/README.md` と `terraform/outputs.tf` のビルドコマンドを `--config cloudbuild-pipelines.yaml .` に修正

## Test plan
- [x] `gcloud builds submit --config cloudbuild-pipelines.yaml .` でビルド成功確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)