### PR TITLE
fix: Storage アップロードのエラーハンドリングと検証

### DIFF
--- a/archive_agents/tools/publisher_tools.py
+++ b/archive_agents/tools/publisher_tools.py
@@ -5,11 +5,14 @@ Supports both Firebase emulator (local dev) and production environments.
 """
 
 import json
+import logging
 import os
 from datetime import datetime, timezone
 from pathlib import Path
 
 from shared.firestore import get_firestore_client, get_storage_bucket
+
+logger = logging.getLogger(__name__)
 
 
 def _generate_mystery_id(classification: str, state_code: str, area_code: str) -> str:
@@ -46,13 +49,18 @@ def _upload_images_internal(mystery_id: str, image_paths: list[str]) -> dict:
     bucket = get_storage_bucket()
     images = {}
     variants = {}
+    total_files = 0
+    successful_uploads = 0
 
     for local_path in image_paths:
         p = Path(local_path)
         if not p.is_absolute():
             p = Path(__file__).parent.parent / p
         if not p.exists():
+            logger.warning("File not found, skipping: %s", p)
             continue
+
+        total_files += 1
 
         # Rename file to mystery_id-based name
         variant_suffix = ""
@@ -69,10 +77,22 @@ def _upload_images_internal(mystery_id: str, image_paths: list[str]) -> dict:
             p.rename(new_local_path)
             p = new_local_path
 
-        blob = bucket.blob(blob_name)
-        content_type_map = {".png": "image/png", ".webp": "image/webp", ".jpg": "image/jpeg", ".jpeg": "image/jpeg"}
-        content_type = content_type_map.get(p.suffix.lower(), "image/png")
-        blob.upload_from_filename(str(p), content_type=content_type)
+        try:
+            blob = bucket.blob(blob_name)
+            content_type_map = {".png": "image/png", ".webp": "image/webp", ".jpg": "image/jpeg", ".jpeg": "image/jpeg"}
+            content_type = content_type_map.get(p.suffix.lower(), "image/png")
+            blob.upload_from_filename(str(p), content_type=content_type)
+
+            # Verify upload succeeded
+            if not blob.exists():
+                logger.warning("Upload verification failed for %s", blob_name)
+                continue
+
+            logger.info("Uploaded successfully: %s", blob_name)
+            successful_uploads += 1
+        except Exception as e:
+            logger.error("Failed to upload %s: %s", blob_name, e)
+            continue
 
         # Build public URL
         storage_host = os.environ.get("STORAGE_EMULATOR_HOST", "")
@@ -92,6 +112,7 @@ def _upload_images_internal(mystery_id: str, image_paths: list[str]) -> dict:
             images["hero"] = variants["lg"]
         images["variants"] = variants
 
+    logger.info("Image upload complete: %d/%d files uploaded successfully", successful_uploads, total_files)
     return images
 
 
@@ -161,7 +182,9 @@ def publish_mystery(mystery_json: str, visual_assets_json: str = "") -> str:
                         if images:
                             data["images"] = images
             except (json.JSONDecodeError, KeyError):
-                pass  # Skip image upload on parse errors
+                logger.warning("Failed to parse visual_assets_json, skipping image upload")
+            except Exception as e:
+                logger.error("Image upload failed, continuing without images: %s", e)
 
         now = datetime.now(timezone.utc)
 

--- a/tests/integration/test_publisher_tools.py
+++ b/tests/integration/test_publisher_tools.py
@@ -219,3 +219,58 @@ class TestPublisherToolsWithEmulator:
         assert doc.exists
         data = doc.to_dict()
         assert data["title"] == sample_mystery_report_data["title"]
+
+
+@pytest.mark.integration
+class TestStorageEmulatorUpload:
+    """Integration tests for Cloud Storage upload via Firebase Storage Emulator.
+
+    Run these with:
+        FIRESTORE_EMULATOR_HOST=localhost:8080 \
+        STORAGE_EMULATOR_HOST=http://localhost:9199 \
+        pytest tests/integration/test_publisher_tools.py::TestStorageEmulatorUpload -v -m integration
+    """
+
+    @pytest.fixture(autouse=True)
+    def check_storage_emulator(self):
+        """Skip if Storage Emulator is not running."""
+        if not os.environ.get("STORAGE_EMULATOR_HOST"):
+            pytest.skip("Storage Emulator not running (STORAGE_EMULATOR_HOST not set)")
+
+    def test_upload_single_image_to_emulator(self, tmp_path):
+        """Should upload a single image to Storage Emulator successfully."""
+        from archive_agents.tools.publisher_tools import _upload_images_internal
+
+        png_file = tmp_path / "header.png"
+        png_file.write_bytes(b"fake png data for emulator test")
+
+        mystery_id = "TEST-EMU-001"
+        result = _upload_images_internal(mystery_id, [str(png_file)])
+
+        assert "hero" in result
+        assert mystery_id in result["hero"]
+
+    def test_upload_with_variants_to_emulator(self, tmp_path):
+        """Should upload original + 4 variants to Storage Emulator."""
+        from archive_agents.tools.publisher_tools import _upload_images_internal
+
+        # Create original + all 4 variants
+        original = tmp_path / "header.png"
+        original.write_bytes(b"fake original png")
+
+        variant_files = []
+        for label in ("sm", "md", "lg", "xl"):
+            vpath = tmp_path / f"header_{label}.webp"
+            vpath.write_bytes(f"fake {label} webp".encode())
+            variant_files.append(str(vpath))
+
+        all_paths = [str(original)] + variant_files
+        mystery_id = "TEST-EMU-002"
+        result = _upload_images_internal(mystery_id, all_paths)
+
+        assert "hero" in result
+        assert "variants" in result
+        assert "sm" in result["variants"]
+        assert "md" in result["variants"]
+        assert "lg" in result["variants"]
+        assert "xl" in result["variants"]

--- a/tests/unit/test_publisher_tools.py
+++ b/tests/unit/test_publisher_tools.py
@@ -1,6 +1,7 @@
 """Unit tests for Publisher tools."""
 
 import json
+import logging
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
@@ -561,3 +562,177 @@ class TestLocalFileRename:
         assert (tmp_path / f"{mystery_id}_md.webp").exists()
         assert (tmp_path / f"{mystery_id}_lg.webp").exists()
         assert (tmp_path / f"{mystery_id}_xl.webp").exists()
+
+
+class TestUploadErrorHandling:
+    """Tests for _upload_images_internal error handling and logging."""
+
+    @patch("archive_agents.tools.publisher_tools.get_storage_bucket")
+    @patch("archive_agents.tools.publisher_tools.get_firestore_client")
+    def test_publish_mystery_saves_to_firestore_when_image_upload_fails(
+        self, mock_get_db, mock_get_bucket, tmp_path
+    ):
+        """Should save to Firestore even when image upload fails completely."""
+        mock_db = MagicMock()
+        mock_get_db.return_value = mock_db
+
+        mock_bucket = MagicMock()
+        mock_blob = MagicMock()
+        mock_blob.upload_from_filename.side_effect = Exception("Storage unavailable")
+        mock_bucket.blob.return_value = mock_blob
+        mock_bucket.name = "test-bucket"
+        mock_get_bucket.return_value = mock_bucket
+
+        mystery_json = _make_mystery_json()
+        visual_assets_json = _make_visual_assets_json(tmp_path)
+
+        result = publish_mystery(mystery_json, visual_assets_json)
+        result_data = json.loads(result)
+
+        assert result_data["status"] == "success"
+        # Firestore set() should still have been called
+        mock_db.collection.return_value.document.return_value.set.assert_called_once()
+        # images should not be in saved data since all uploads failed
+        saved_data = mock_db.collection.return_value.document.return_value.set.call_args[0][0]
+        assert "images" not in saved_data
+
+    @patch("archive_agents.tools.publisher_tools.get_storage_bucket")
+    def test_upload_images_internal_logs_on_failure(self, mock_get_bucket, tmp_path, caplog):
+        """Should log an error when upload_from_filename fails."""
+        from archive_agents.tools.publisher_tools import _upload_images_internal
+
+        mock_bucket = MagicMock()
+        mock_blob = MagicMock()
+        mock_blob.upload_from_filename.side_effect = Exception("Network error")
+        mock_bucket.blob.return_value = mock_blob
+        mock_bucket.name = "test-bucket"
+        mock_get_bucket.return_value = mock_bucket
+
+        png_file = tmp_path / "header.png"
+        png_file.write_bytes(b"fake png data")
+
+        with caplog.at_level(logging.ERROR, logger="archive_agents.tools.publisher_tools"):
+            _upload_images_internal("TEST-001", [str(png_file)])
+
+        assert any("Network error" in record.message for record in caplog.records)
+
+    @patch("archive_agents.tools.publisher_tools.get_storage_bucket")
+    def test_upload_images_internal_logs_success(self, mock_get_bucket, tmp_path, caplog):
+        """Should log INFO on successful upload."""
+        from archive_agents.tools.publisher_tools import _upload_images_internal
+
+        mock_bucket = MagicMock()
+        mock_blob = MagicMock()
+        mock_blob.exists.return_value = True
+        mock_bucket.blob.return_value = mock_blob
+        mock_bucket.name = "test-bucket"
+        mock_get_bucket.return_value = mock_bucket
+
+        png_file = tmp_path / "header.png"
+        png_file.write_bytes(b"fake png data")
+
+        with caplog.at_level(logging.INFO, logger="archive_agents.tools.publisher_tools"):
+            _upload_images_internal("TEST-001", [str(png_file)])
+
+        assert any("uploaded successfully" in record.message.lower() for record in caplog.records)
+
+    @patch("archive_agents.tools.publisher_tools.get_storage_bucket")
+    def test_upload_verifies_blob_exists(self, mock_get_bucket, tmp_path):
+        """Should call blob.exists() after upload to verify."""
+        from archive_agents.tools.publisher_tools import _upload_images_internal
+
+        mock_bucket = MagicMock()
+        mock_blob = MagicMock()
+        mock_blob.exists.return_value = True
+        mock_bucket.blob.return_value = mock_blob
+        mock_bucket.name = "test-bucket"
+        mock_get_bucket.return_value = mock_bucket
+
+        png_file = tmp_path / "header.png"
+        png_file.write_bytes(b"fake png data")
+
+        _upload_images_internal("TEST-001", [str(png_file)])
+
+        mock_blob.exists.assert_called_once()
+
+    @patch("archive_agents.tools.publisher_tools.get_storage_bucket")
+    def test_upload_logs_warning_when_blob_not_found_after_upload(
+        self, mock_get_bucket, tmp_path, caplog
+    ):
+        """Should log a warning when blob.exists() returns False after upload."""
+        from archive_agents.tools.publisher_tools import _upload_images_internal
+
+        mock_bucket = MagicMock()
+        mock_blob = MagicMock()
+        mock_blob.exists.return_value = False
+        mock_bucket.blob.return_value = mock_blob
+        mock_bucket.name = "test-bucket"
+        mock_get_bucket.return_value = mock_bucket
+
+        png_file = tmp_path / "header.png"
+        png_file.write_bytes(b"fake png data")
+
+        with caplog.at_level(logging.WARNING, logger="archive_agents.tools.publisher_tools"):
+            result = _upload_images_internal("TEST-001", [str(png_file)])
+
+        assert any("verification failed" in record.message.lower() for record in caplog.records)
+        # Should not include the file in results since verification failed
+        assert result == {}
+
+    @patch("archive_agents.tools.publisher_tools.get_storage_bucket")
+    def test_partial_upload_failure_does_not_block_others(self, mock_get_bucket, tmp_path):
+        """When one file fails to upload, other files should still succeed."""
+        from archive_agents.tools.publisher_tools import _upload_images_internal
+
+        mock_bucket = MagicMock()
+
+        call_count = 0
+
+        def upload_side_effect(path, content_type=None):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise Exception("First file fails")
+
+        mock_blob_fail = MagicMock()
+        mock_blob_fail.upload_from_filename.side_effect = upload_side_effect
+        mock_blob_success = MagicMock()
+        mock_blob_success.exists.return_value = True
+
+        # First call returns failing blob, second returns successful
+        mock_bucket.blob.side_effect = [mock_blob_fail, mock_blob_success]
+        mock_bucket.name = "test-bucket"
+        mock_get_bucket.return_value = mock_bucket
+
+        file1 = tmp_path / "header.png"
+        file1.write_bytes(b"fake png data")
+        file2 = tmp_path / "header_sm.webp"
+        file2.write_bytes(b"fake webp data")
+
+        result = _upload_images_internal("TEST-001", [str(file1), str(file2)])
+
+        # Second file should have been uploaded successfully
+        assert result != {}
+
+    @patch("archive_agents.tools.publisher_tools.get_storage_bucket")
+    def test_upload_summary_log(self, mock_get_bucket, tmp_path, caplog):
+        """Should log a summary with count of successful uploads."""
+        from archive_agents.tools.publisher_tools import _upload_images_internal
+
+        mock_bucket = MagicMock()
+        mock_blob = MagicMock()
+        mock_blob.exists.return_value = True
+        mock_bucket.blob.return_value = mock_blob
+        mock_bucket.name = "test-bucket"
+        mock_get_bucket.return_value = mock_bucket
+
+        files = []
+        for name in ("header.png", "header_sm.webp", "header_md.webp"):
+            f = tmp_path / name
+            f.write_bytes(b"fake data")
+            files.append(str(f))
+
+        with caplog.at_level(logging.INFO, logger="archive_agents.tools.publisher_tools"):
+            _upload_images_internal("TEST-001", files)
+
+        assert any("3/3" in record.message for record in caplog.records)


### PR DESCRIPTION
## Summary

- `_upload_images_internal()` にファイル単位の try-except を追加し、1ファイルの失敗が他に波及しないようにした
- アップロード後に `blob.exists()` で検証し、失敗時は WARNING ログを出力
- `publish_mystery()` で画像アップロード失敗時も Firestore 保存を継続（graceful degradation）
- `logging.getLogger(__name__)` によるロガーを追加（`illustrator_tools.py` と同パターン）

## Test plan

- [x] 新規ユニットテスト 7 件追加（`TestUploadErrorHandling`）
- [x] 新規統合テスト 2 件追加（`TestStorageEmulatorUpload`）
- [x] 既存テスト 167 件の回帰なし確認（全 174 件 pass）
- [ ] Storage Emulator での統合テスト実行確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)