### PR TITLE
feat: Cloud IAP + HTTPS LB で admin を認証付き公開

### DIFF
--- a/terraform/cloud-build.tf
+++ b/terraform/cloud-build.tf
@@ -33,7 +33,7 @@ resource "google_cloudbuild_trigger" "web_public" {
     }
 
     step {
-      name = "gcr.io/google.com/cloudsdktool/cloud-sdk"
+      name       = "gcr.io/google.com/cloudsdktool/cloud-sdk"
       entrypoint = "bash"
       args = [
         "-c",

--- a/terraform/cloud-run-jobs.tf
+++ b/terraform/cloud-run-jobs.tf
@@ -52,7 +52,7 @@ resource "google_cloud_run_v2_job" "blog_pipeline" {
         }
       }
 
-      timeout = "1800s" # 30 minutes
+      timeout     = "1800s" # 30 minutes
       max_retries = 1
     }
   }
@@ -101,7 +101,7 @@ resource "google_cloud_run_v2_job" "translate_pipeline" {
         }
       }
 
-      timeout = "600s" # 10 minutes
+      timeout     = "600s" # 10 minutes
       max_retries = 1
     }
   }
@@ -144,7 +144,7 @@ resource "google_cloud_run_v2_job" "podcast_pipeline" {
         }
       }
 
-      timeout = "1800s" # 30 minutes
+      timeout     = "1800s" # 30 minutes
       max_retries = 1
     }
   }

--- a/terraform/cloud-run.tf
+++ b/terraform/cloud-run.tf
@@ -3,6 +3,7 @@
 resource "google_cloud_run_v2_service" "web_admin" {
   name     = "web-admin"
   location = var.region
+  ingress  = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
 
   template {
     service_account = google_service_account.web_admin.email

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -9,8 +9,14 @@ resource "google_dns_managed_zone" "main" {
   depends_on = [google_project_service.apis]
 }
 
-# admin subdomain DNS record removed — web-admin is accessed via
-# gcloud run services proxy (Cloud Run IAM authentication)
+# admin subdomain → HTTPS LB static IP (IAP-protected)
+resource "google_dns_record_set" "admin" {
+  name         = "${var.admin_subdomain}.${var.domain}."
+  managed_zone = google_dns_managed_zone.main.name
+  type         = "A"
+  ttl          = 300
+  rrdatas      = [google_compute_global_address.web_admin.address]
+}
 
 # Output nameservers for Spaceship configuration
 output "nameservers" {

--- a/terraform/iap.tf
+++ b/terraform/iap.tf
@@ -1,0 +1,112 @@
+# Cloud IAP + HTTPS Load Balancer for web-admin
+# Provides authenticated access to admin.ghostinthearchive.ai
+
+# Project data for project number
+data "google_project" "current" {}
+
+# Static IP for the load balancer
+resource "google_compute_global_address" "web_admin" {
+  name = "web-admin-ip"
+
+  depends_on = [google_project_service.apis]
+}
+
+# Serverless NEG to connect Cloud Run to the load balancer
+resource "google_compute_region_network_endpoint_group" "web_admin" {
+  name                  = "web-admin-neg"
+  network_endpoint_type = "SERVERLESS"
+  region                = var.region
+
+  cloud_run {
+    service = google_cloud_run_v2_service.web_admin.name
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
+# Backend service with IAP enabled
+resource "google_compute_backend_service" "web_admin" {
+  name                  = "web-admin-backend"
+  protocol              = "HTTPS"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+
+  backend {
+    group = google_compute_region_network_endpoint_group.web_admin.id
+  }
+
+  iap {
+    oauth2_client_id     = " "
+    oauth2_client_secret = " "
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
+# URL map
+resource "google_compute_url_map" "web_admin" {
+  name            = "web-admin-url-map"
+  default_service = google_compute_backend_service.web_admin.id
+}
+
+# Managed SSL certificate
+resource "google_compute_managed_ssl_certificate" "web_admin" {
+  name = "web-admin-cert"
+
+  managed {
+    domains = ["${var.admin_subdomain}.${var.domain}"]
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
+# HTTPS proxy
+resource "google_compute_target_https_proxy" "web_admin" {
+  name             = "web-admin-https-proxy"
+  url_map          = google_compute_url_map.web_admin.id
+  ssl_certificates = [google_compute_managed_ssl_certificate.web_admin.id]
+}
+
+# HTTPS forwarding rule
+resource "google_compute_global_forwarding_rule" "web_admin_https" {
+  name                  = "web-admin-https-rule"
+  target                = google_compute_target_https_proxy.web_admin.id
+  port_range            = "443"
+  ip_address            = google_compute_global_address.web_admin.id
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+
+  depends_on = [google_project_service.apis]
+}
+
+# HTTP → HTTPS redirect
+resource "google_compute_url_map" "web_admin_redirect" {
+  name = "web-admin-http-redirect"
+
+  default_url_redirect {
+    https_redirect         = true
+    strip_query            = false
+    redirect_response_code = "MOVED_PERMANENTLY_DEFAULT"
+  }
+}
+
+resource "google_compute_target_http_proxy" "web_admin_redirect" {
+  name    = "web-admin-http-proxy"
+  url_map = google_compute_url_map.web_admin_redirect.id
+}
+
+resource "google_compute_global_forwarding_rule" "web_admin_http" {
+  name                  = "web-admin-http-rule"
+  target                = google_compute_target_http_proxy.web_admin_redirect.id
+  port_range            = "80"
+  ip_address            = google_compute_global_address.web_admin.id
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+
+  depends_on = [google_project_service.apis]
+}
+
+# Grant IAP service agent permission to invoke Cloud Run
+resource "google_cloud_run_v2_service_iam_member" "iap_invoker" {
+  name     = google_cloud_run_v2_service.web_admin.name
+  location = var.region
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:service-${data.google_project.current.number}@gcp-sa-iap.iam.gserviceaccount.com"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -41,6 +41,8 @@ resource "google_project_service" "apis" {
     "artifactregistry.googleapis.com",
     "firestore.googleapis.com",
     "aiplatform.googleapis.com",
+    "compute.googleapis.com",
+    "iap.googleapis.com",
   ])
 
   service            = each.value

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -62,13 +62,18 @@ output "next_steps" {
     5. Deploy web-public:
        gcloud builds triggers run web-public-deploy
 
-    6. Grant Cloud Run invoker access (Google Cloud Console):
-       Cloud Run > web-admin > Security > Add Principal
-       Grant role: Cloud Run Invoker (roles/run.invoker)
+    6. Create IAP service agent (if not exists):
+       gcloud beta services identity create --service=iap.googleapis.com --project=${var.project_id}
 
-    7. Access web-admin via authenticated proxy:
-       gcloud run services proxy web-admin --region ${var.region}
-       # Then open http://localhost:8080 in your browser
+    7. Grant IAP access (Google Cloud Console):
+       Security > Identity-Aware Proxy > web-admin-backend
+       Add principal with role: IAP-secured Web App User
+
+    8. Access web-admin:
+       https://${var.admin_subdomain}.${var.domain}
+       (Google login required via IAP)
+
+    NOTE: SSL certificate provisioning may take up to 30 minutes.
 
   EOT
 }


### PR DESCRIPTION
## Summary

- Cloud IAP + HTTPS ロードバランサで `admin.ghostinthearchive.ai` を認証付きで再公開
- `gcloud run services proxy` 経由のローカルアクセスを廃止し、ブラウザから直接アクセス可能に
- Cloud Run の ingress を `INTERNAL_LOAD_BALANCER` に制限し、`run.app` URL への直接アクセスを遮断

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `terraform/iap.tf` | 新規: 静的 IP、サーバーレス NEG、バックエンドサービス（IAP）、SSL 証明書、HTTPS/HTTP プロキシ、HTTP→HTTPS リダイレクト、IAP invoker IAM |
| `terraform/main.tf` | `compute.googleapis.com` と `iap.googleapis.com` API 追加 |
| `terraform/cloud-run.tf` | `ingress = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"` 追加 |
| `terraform/dns.tf` | `admin` サブドメインの A レコード復活（静的 IP 向き） |
| `terraform/outputs.tf` | next_steps を IAP アクセス手順に更新 |

## Architecture

```
Browser → admin.ghostinthearchive.ai
         → Cloud DNS (A record → static IP)
         → HTTPS LB (managed SSL cert)
         → Cloud IAP (Google login required)
         → Serverless NEG
         → Cloud Run (web-admin, ingress: internal LB only)
```

## Post-apply steps

1. `gcloud beta services identity create --service=iap.googleapis.com`（IAP サービスエージェント作成）
2. GCP Console > Security > IAP でユーザー追加
3. SSL 証明書のプロビジョニング完了を待つ（最大 30 分）

## Test plan

- [ ] `terraform plan` で意図通りのリソース作成を確認
- [ ] `terraform apply` 実行
- [ ] GCP コンソールで IAP ユーザー追加
- [ ] `admin.ghostinthearchive.ai` にアクセスし Google ログイン → 管理画面表示を確認
- [ ] `run.app` URL への直接アクセスが 403 になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)