### PR TITLE
fix: web-admin の next/image hostname エラー修正（Firebase Emulator 対応）

### DIFF
--- a/web-admin/next.config.ts
+++ b/web-admin/next.config.ts
@@ -19,6 +19,13 @@ const nextConfig: NextConfig = {
         hostname: "storage.googleapis.com",
         pathname: "/**",
       },
+      // 開発環境: Firebase Storage エミュレータ
+      {
+        protocol: "http",
+        hostname: "localhost",
+        port: "9199",
+        pathname: "/v0/b/**",
+      },
     ],
   },
 

--- a/web-admin/src/app/admin/preview/[id]/page.tsx
+++ b/web-admin/src/app/admin/preview/[id]/page.tsx
@@ -155,6 +155,7 @@ export default async function PreviewPage({
                 height={675}
                 className="w-full h-auto"
                 priority
+                unoptimized={mystery.images.hero.includes('localhost')}
               />
             </div>
           )}


### PR DESCRIPTION
## Summary
- `web-admin/next.config.ts` の `remotePatterns` に Firebase Storage エミュレータ用パターン（`localhost:9199`）を追加
- `web-admin` プレビューページの `<Image>` に `unoptimized` プロパティを追加し、エミュレータ URL 時は画像最適化をスキップ

## Test plan
- [ ] `web-admin` の開発サーバーを起動（`npm run dev -- --port 3001`）
- [ ] 管理画面プレビューで Firebase Storage エミュレータの画像が表示されることを確認
- [ ] 本番環境の画像 URL（`firebasestorage.googleapis.com`）でも正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)