### PR TITLE
chore: web-admin に .gitignore を追加

### DIFF
--- a/web-admin/.gitignore
+++ b/web-admin/.gitignore
@@ -1,0 +1,37 @@
+# dependencies
+/node_modules
+/.pnp
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# env files
+.env*
+!.env.example
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts


### PR DESCRIPTION
## Summary
- `web-admin/.gitignore` を追加し、`node_modules/`、`.next/` 等を除外
- Cloud Build アップロード時に不要ファイル（40,090ファイル / 889.6 MiB）が含まれビルドが遅延する問題を解決

## Test plan
- [ ] `gcloud builds submit --tag ... ./web-admin/` でアップロードサイズが大幅に削減されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)