### PR TITLE
fix: Cloud Build trigger に logging option を追加

### DIFF
--- a/terraform/cloud-build.tf
+++ b/terraform/cloud-build.tf
@@ -42,6 +42,10 @@ resource "google_cloudbuild_trigger" "web_public" {
       dir = "web-public"
     }
 
+    options {
+      logging = "CLOUD_LOGGING_ONLY"
+    }
+
     timeout = "600s"
   }
 


### PR DESCRIPTION
## Summary

- `web-public-deploy` trigger の `build` ブロックに `options { logging = "CLOUD_LOGGING_ONLY" }` を追加
- `service_account` 指定時に必須の logging 設定が未設定だったため `gcloud builds triggers run` 実行時にエラーが発生していた
- `web_public_on_push` trigger は `cloudbuild.yaml` 側で設定済みのため修正不要

## Test plan

- [ ] `terraform plan` で差分確認
- [ ] `terraform apply` で反映
- [ ] `gcloud builds triggers run web-public-deploy --region=global --branch=main --project=ghostinthearchive` でエラーなく実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)