### PR TITLE
fix: cloud-build-sa に logging.logWriter ロールを付与

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -80,3 +80,9 @@ resource "google_project_iam_member" "cloud_build_firestore" {
   role    = "roles/datastore.viewer"
   member  = "serviceAccount:${google_service_account.cloud_build.email}"
 }
+
+resource "google_project_iam_member" "cloud_build_log_writer" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.cloud_build.email}"
+}


### PR DESCRIPTION
## Summary

- `cloud-build-sa` サービスアカウントに `roles/logging.logWriter` を付与
- `CLOUD_LOGGING_ONLY` 設定時に Cloud Logging へのログ書き込み権限が不足していた warning を解消

## Test plan

- [ ] `terraform plan` で差分確認
- [ ] `terraform apply` で反映
- [ ] `gcloud builds triggers run web-public-deploy` 実行時に logWriter の warning が出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)