### PR TITLE
fix: manual trigger の Firebase deploy を firebase カスタムイメージに変更

### DIFF
--- a/terraform/cloud-build.tf
+++ b/terraform/cloud-build.tf
@@ -33,13 +33,9 @@ resource "google_cloudbuild_trigger" "web_public" {
     }
 
     step {
-      name       = "gcr.io/google.com/cloudsdktool/cloud-sdk"
-      entrypoint = "bash"
-      args = [
-        "-c",
-        "npm install -g firebase-tools && firebase deploy --only hosting --project ${var.project_id}"
-      ]
-      dir = "web-public"
+      name = "gcr.io/${var.project_id}/firebase"
+      args = ["deploy", "--only", "hosting", "--project", var.project_id]
+      dir  = "web-public"
     }
 
     options {


### PR DESCRIPTION
## Summary

- `web-public-deploy`（manual trigger）のステップ3で `gcr.io/google.com/cloudsdktool/cloud-sdk` を使用していたが、npm が含まれないため exit code 127 で失敗していた
- `web-public-auto-deploy`（push trigger）と同じ `gcr.io/$PROJECT_ID/firebase` カスタムイメージに変更

## Test plan

- [ ] `terraform plan` で差分確認
- [ ] `terraform apply` で反映
- [ ] `gcloud builds triggers run web-public-deploy` で正常終了を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)