### PR TITLE
fix: Firebase deploy イメージを GCP 公式イメージに変更

### DIFF
--- a/terraform/cloud-build.tf
+++ b/terraform/cloud-build.tf
@@ -33,7 +33,7 @@ resource "google_cloudbuild_trigger" "web_public" {
     }
 
     step {
-      name = "gcr.io/${var.project_id}/firebase"
+      name = "us-docker.pkg.dev/firebase-cli/us/firebase"
       args = ["deploy", "--only", "hosting", "--project", var.project_id]
       dir  = "web-public"
     }

--- a/web-public/cloudbuild.yaml
+++ b/web-public/cloudbuild.yaml
@@ -18,7 +18,7 @@ steps:
       - 'NEXT_PUBLIC_GTM_ID=$_GTM_ID'
 
   # Deploy to Firebase Hosting
-  - name: 'gcr.io/$PROJECT_ID/firebase'
+  - name: 'us-docker.pkg.dev/firebase-cli/us/firebase'
     args: ['deploy', '--only', 'hosting:public', '--project', '$PROJECT_ID']
     dir: 'web-public'
 


### PR DESCRIPTION
## Summary

- Cloud Build の Firebase deploy ステップが `gcr.io/$PROJECT_ID/firebase`（存在しないカスタムイメージ）を参照しており FAILURE していた
- GCP 公式の `us-docker.pkg.dev/firebase-cli/us/firebase` イメージに変更
- manual trigger（`terraform/cloud-build.tf`）と auto-deploy trigger（`web-public/cloudbuild.yaml`）の両方を修正

## Test plan

- [ ] `terraform apply` で manual trigger を更新
- [ ] `gcloud builds triggers run web-public-deploy --region=global --branch=main` で動作確認
- [ ] main push 時の auto-deploy trigger も SUCCESS になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)