### PR TITLE
chore: Claude Code の不要ファイル読み取りを deny ルールでブロック

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,12 +12,14 @@
       "Read(.pytest_cache/**)",
       "Read(.ruff_cache/**)",
       "Read(ghostinthearchive.egg-info/**)",
-      "Read(.adk/**)",
-      "Read(logs/**)",
-      "Read(uv.lock)",
-      "Read(package-lock.json)",
       "Read(.DS_Store)",
       "Read(*.tsbuildinfo)"
+    ],
+    "ask": [
+      "Read(logs/**)",
+      "Read(.adk/**)",
+      "Read(uv.lock)",
+      "Read(package-lock.json)"
     ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,8 @@ git config core.hooksPath .githooks
 ### Claude Code ファイル除外設定
 
 - Claude Code が読み取る必要のないファイル・フォルダは `.claude/settings.json` の `permissions.deny` で管理する
-- 新たにビルド出力、キャッシュ、大容量の生成物などが追加された場合は `.claude/settings.json` の deny ルールも合わせて更新する
+- デバッグ時に必要になりうるファイル（`logs/`、`.adk/`、ロックファイル等）は `permissions.ask` に設定し、読み取り時に確認プロンプトを表示する
+- 新たにビルド出力、キャッシュ、大容量の生成物などが追加された場合は `.claude/settings.json` の deny/ask ルールも合わせて更新する
 
 ### 共有コード管理（DRY 原則）
 


### PR DESCRIPTION
## Summary

- `.claude/settings.json` を新規作成し、`permissions.deny` で大容量ディレクトリやビルドキャッシュへの Read アクセスをブロック
- `CLAUDE.md` に「Claude Code ファイル除外設定」セクションを追加し、deny ルールの運用方針を明記

## deny 対象

| パターン | 理由 |
|---------|------|
| `node_modules/**` (670MB) | npm 依存パッケージ |
| `.venv/**` (901MB) | Python 仮想環境 |
| `terraform/.terraform/**` (229MB) | Terraform プロバイダーバイナリ |
| `web-public/out/**`, `web-public/.firebase/**` | Next.js / Firebase ビルド出力 |
| `web-admin/.next/**`, `web-public/.next/**` | Next.js ビルドキャッシュ |
| `__pycache__/**`, `.pytest_cache/**`, `.ruff_cache/**` | Python キャッシュ |
| `ghostinthearchive.egg-info/**` | Python パッケージメタデータ |
| `.adk/**`, `logs/**` | ADK 自動生成ファイル・ログ |
| `uv.lock`, `package-lock.json` | ロックファイル |
| `.DS_Store`, `*.tsbuildinfo` | OS / TypeScript メタデータ |

## Test plan

- [ ] Claude Code を再起動し、deny 対象ファイル（例: `node_modules/` 内）を Read で読み取ろうとした際にブロックされることを確認
- [ ] 通常のソースコード（`mystery_agents/`, `web-admin/src/` 等）が問題なく読み取れることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)