### PR TITLE
fix: Docker ローカル開発環境の起動失敗を修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ COPY services/ ./services/
 
 # Environment variables
 ENV PYTHONUNBUFFERED=1
+ENV PYTHONPATH=/app
 ENV GOOGLE_CLOUD_PROJECT=ghostinthearchive
 ENV GOOGLE_GENAI_USE_VERTEXAI=TRUE
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,14 +11,14 @@ services:
       - GOOGLE_CLOUD_PROJECT=ghostinthearchive
       - GOOGLE_GENAI_USE_VERTEXAI=TRUE
       - GOOGLE_APPLICATION_CREDENTIALS=/tmp/keys/adc.json
-      - FIRESTORE_EMULATOR_HOST=
+      - FIRESTORE_EMULATOR_HOST=host.docker.internal:8080
     volumes:
       - ${HOME}/.config/gcloud/application_default_credentials.json:/tmp/keys/adc.json:ro
 
-  # NOTE: Pipeline runs on port 8002 (Curator on 8001) because they are
+  # NOTE: Mystery Pipeline runs on port 8002 (Curator on 8001) because they are
   # separate services with different resource/timeout requirements.
   # See services/mystery_pipeline.py docstring for details.
-  pipeline:
+  mystery-pipeline:
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
## Summary

PR #51 のプロジェクト構成変更後、`docker compose up` でエージェントサービスが起動しなくなっていた問題を修正。

- **Dockerfile**: `ENV PYTHONPATH=/app` を追加し、`shared`・`mystery_agents` 等のモジュールを import 可能にした
- **docker-compose.yml**: Curator サービスの `FIRESTORE_EMULATOR_HOST` を `host.docker.internal:8080` に設定し、既存タイトルの重複チェックが機能するようにした
- **docker-compose.yml**: サービス名を `pipeline` → `mystery-pipeline` に変更し、PR #51 の命名規則に統一した

## Test plan

- [x] `docker compose up --build` で両サービスが正常起動（`Uvicorn running`）
- [x] `curl -X POST http://localhost:8001/suggest-theme` で 200 OK
- [x] Curator ログに `Warning: Could not fetch existing titles` が出ないことを確認
- [x] サービス名が `mystery-pipeline` に変更されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)