### PR TITLE
chore: Gemini CLI 用の .geminiignore を追加

### DIFF
--- a/.geminiignore
+++ b/.geminiignore
@@ -1,0 +1,94 @@
+# ===================================
+# .geminiignore
+# Gemini CLI がスキャン対象から除外するファイル・ディレクトリ
+# .gitignore をベースに、git 管理外のビルド成果物・キャッシュを追加
+# ===================================
+
+# ----- .gitignore と同一 -----
+
+# Environment
+.env
+.env.local
+.env.*.local
+
+# Virtual environment
+.venv/
+venv/
+env/
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+/lib/
+/lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Data directory
+data/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Logs
+*.log
+
+# ADK auto-generated
+.adk/
+
+# Node.js
+node_modules/
+
+# Next.js
+.next/
+next-env.d.ts
+
+# Firebase Emulator data
+firebase-debug.log
+firestore-debug.log
+ui-debug.log
+storage-debug.log
+
+# ----- Gemini CLI 固有の除外対象 -----
+
+# Terraform プロバイダキャッシュ
+terraform/.terraform/
+
+# Firebase キャッシュ
+web-public/.firebase/
+
+# Next.js ビルド出力
+web-public/out/
+
+# TypeScript ビルドキャッシュ
+*.tsbuildinfo
+
+# Claude Code 設定
+.claude/


### PR DESCRIPTION
## 概要
- Gemini CLI がプロジェクトをスキャンする際に不要なファイルを除外するための `.geminiignore` を新規作成
- `.gitignore` の内容をベースに、git 管理外のビルド成果物・キャッシュを追加

## 追加された除外対象（.gitignore に含まれないもの）
- `terraform/.terraform/` - Terraform プロバイダキャッシュ
- `web-public/.firebase/` - Firebase キャッシュ
- `web-public/out/` - Next.js ビルド出力
- `*.tsbuildinfo` - TypeScript ビルドキャッシュ
- `.claude/` - Claude Code 設定

## テスト計画
- [x] ファイル内容の確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)