### PR TITLE
chore: .geminiignore から .gitignore 重複エントリを削除し負のパターンを追加

### DIFF
--- a/.geminiignore
+++ b/.geminiignore
@@ -1,82 +1,10 @@
 # ===================================
 # .geminiignore
-# Gemini CLI がスキャン対象から除外するファイル・ディレクトリ
-# .gitignore をベースに、git 管理外のビルド成果物・キャッシュを追加
+# Gemini CLI 固有の除外・許可設定
+# ※ .gitignore は自動的に尊重されるため重複記載しない
 # ===================================
 
-# ----- .gitignore と同一 -----
-
-# Environment
-.env
-.env.local
-.env.*.local
-
-# Virtual environment
-.venv/
-venv/
-env/
-
-# Python
-__pycache__/
-*.py[cod]
-*$py.class
-*.so
-.Python
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-.eggs/
-/lib/
-/lib64/
-parts/
-sdist/
-var/
-wheels/
-*.egg-info/
-.installed.cfg
-*.egg
-
-# Data directory
-data/
-
-# IDE
-.idea/
-.vscode/
-*.swp
-*.swo
-*~
-
-# OS
-.DS_Store
-Thumbs.db
-
-# Testing
-.pytest_cache/
-.coverage
-htmlcov/
-
-# Logs
-*.log
-
-# ADK auto-generated
-.adk/
-
-# Node.js
-node_modules/
-
-# Next.js
-.next/
-next-env.d.ts
-
-# Firebase Emulator data
-firebase-debug.log
-firestore-debug.log
-ui-debug.log
-storage-debug.log
-
-# ----- Gemini CLI 固有の除外対象 -----
+# ----- Gemini CLI 固有の除外対象（.gitignore に含まれないもの） -----
 
 # Terraform プロバイダキャッシュ
 terraform/.terraform/
@@ -92,3 +20,11 @@ web-public/out/
 
 # Claude Code 設定
 .claude/
+
+# ----- .gitignore の除外をオーバーライド（Gemini に参照を許可） -----
+
+# ログファイル（デバッグ時に有用）
+!*.log
+
+# ADK 成果物（エージェント状態の確認に有用）
+!.adk/


### PR DESCRIPTION
## Summary

- `.gitignore` と重複していた65行のエントリを削除（Gemini CLI は `.gitignore` を自動的に尊重するため不要）
- Gemini CLI 固有の除外対象のみ残留（`terraform/.terraform/`, `web-public/.firebase/`, `web-public/out/`, `*.tsbuildinfo`, `.claude/`）
- `!*.log` と `!.adk/` の負のパターンを追加し、`.gitignore` で除外されているがデバッグ時に有用なファイルを Gemini CLI に許可

## 背景

- [Gemini CLI 公式ドキュメント](https://geminicli.com/docs/cli/gemini-ignore/) — `.geminiignore` は `.gitignore` と同じ構文で `!` による否定パターンもサポート
- [PR #11587](https://github.com/google-gemini/gemini-cli/pull/11587) — `.gitignore` と `.geminiignore` を統合し、`.geminiignore` が高優先度
- [Issue #5259](https://github.com/google-gemini/gemini-cli/issues/5259) — `.geminiignore` から `.gitignore` のルールを解除する機能（実装済み）

## Test plan

- [x] `.geminiignore` の内容が `.gitignore` と重複していないことを確認
- [ ] `!` パターンで許可したファイル（`*.log`, `.adk/`）が Gemini CLI から参照可能であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)