### PR TITLE
chore: .gitignore に不足パターンを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ Thumbs.db
 
 # Testing
 .pytest_cache/
+.mypy_cache/
 .coverage
 htmlcov/
 
@@ -61,9 +62,17 @@ node_modules/
 # Next.js
 .next/
 next-env.d.ts
+out/
+*.tsbuildinfo
 
 # Firebase Emulator data
 firebase-debug.log
 firestore-debug.log
 ui-debug.log
 storage-debug.log
+
+# Terraform
+.terraform/
+
+# Firebase cache
+.firebase/


### PR DESCRIPTION
## Summary

- `.mypy_cache/`、`out/`、`*.tsbuildinfo`、`.terraform/`、`.firebase/` を `.gitignore` に追加
- `git status` に表示されていた未追跡ファイル4件を解消

## 変更内容

| セクション | 追加パターン |
|-----------|------------|
| Testing | `.mypy_cache/` |
| Next.js | `out/`, `*.tsbuildinfo` |
| Terraform (新規) | `.terraform/` |
| Firebase cache (新規) | `.firebase/` |

## Test plan

- [x] `git status` で未追跡ファイルが表示されないことを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)