### PR TITLE
refactor: 管理画面フッター削除と両サイトヘッダー簡素化

### DIFF
--- a/web-admin/src/app/(main)/layout.tsx
+++ b/web-admin/src/app/(main)/layout.tsx
@@ -1,5 +1,4 @@
 import { Header } from "@/components/header"
-import { Footer } from "@ghost/shared/src/components/footer"
 
 export default function AdminLayout({
   children,
@@ -10,7 +9,6 @@ export default function AdminLayout({
     <div className="min-h-screen flex flex-col">
       <Header />
       <main className="flex-1">{children}</main>
-      <Footer />
     </div>
   )
 }

--- a/web-admin/src/components/header.tsx
+++ b/web-admin/src/components/header.tsx
@@ -1,13 +1,13 @@
 "use client"
 
 import Link from "next/link"
-import { Archive, Search, Menu } from "lucide-react"
+import { Archive } from "lucide-react"
 
 export function Header() {
   return (
     <header className="sticky top-0 z-50 border-b border-border/50 bg-background/80 backdrop-blur-sm">
       <div className="container mx-auto px-4">
-        <div className="flex items-center justify-between h-16">
+        <div className="flex items-center h-16">
           {/* Logo */}
           <Link href="/" className="flex items-center gap-3 group">
             <div className="relative">
@@ -18,24 +18,6 @@ export function Header() {
               Ghost in the Archive
             </span>
           </Link>
-
-          {/* Navigation */}
-          <nav className="hidden md:flex items-center gap-6">
-            <Link
-              href="/"
-              className="text-sm text-muted-foreground hover:text-parchment transition-colors font-mono uppercase tracking-wide"
-            >
-              Discoveries
-            </Link>
-            <button className="p-2 text-muted-foreground hover:text-parchment transition-colors" aria-label="Search archives">
-              <Search className="w-4 h-4" />
-            </button>
-          </nav>
-
-          {/* Mobile menu button */}
-          <button className="md:hidden p-2 text-muted-foreground hover:text-parchment transition-colors" aria-label="Open menu">
-            <Menu className="w-5 h-5" />
-          </button>
         </div>
       </div>
     </header>

--- a/web-public/src/components/header.tsx
+++ b/web-public/src/components/header.tsx
@@ -1,13 +1,13 @@
 "use client"
 
 import Link from "next/link"
-import { Archive, Search, Menu } from "lucide-react"
+import { Archive } from "lucide-react"
 
 export function Header() {
   return (
     <header className="sticky top-0 z-50 border-b border-border/50 bg-background/80 backdrop-blur-sm">
       <div className="container mx-auto px-4">
-        <div className="flex items-center justify-between h-16">
+        <div className="flex items-center h-16">
           {/* Logo */}
           <Link href="/" className="flex items-center gap-3 group">
             <div className="relative">
@@ -18,24 +18,6 @@ export function Header() {
               Ghost in the Archive
             </span>
           </Link>
-
-          {/* Navigation */}
-          <nav className="hidden md:flex items-center gap-6">
-            <Link
-              href="/"
-              className="text-sm text-muted-foreground hover:text-parchment transition-colors font-mono uppercase tracking-wide"
-            >
-              Discoveries
-            </Link>
-            <button className="p-2 text-muted-foreground hover:text-parchment transition-colors" aria-label="Search archives">
-              <Search className="w-4 h-4" />
-            </button>
-          </nav>
-
-          {/* Mobile menu button */}
-          <button className="md:hidden p-2 text-muted-foreground hover:text-parchment transition-colors" aria-label="Open menu">
-            <Menu className="w-5 h-5" />
-          </button>
         </div>
       </div>
     </header>


### PR DESCRIPTION
## 概要

- 管理画面（web-admin）から不要なフッターを削除
- 両サイト（web-admin / web-public）のヘッダーから冗長なナビゲーションを削除
  - 「Discoveries」リンク: ロゴと同じ `/` への遷移で冗長
  - 検索ボタン: 未実装のため削除

## 変更ファイル

- `web-admin/src/app/(main)/layout.tsx` — Footer コンポーネント削除
- `web-admin/src/components/header.tsx` — Navigation セクション・モバイルメニューボタン削除
- `web-public/src/components/header.tsx` — 同上

## 変更しないもの

- `packages/shared/src/components/footer.tsx` — web-public で引き続き使用

## テスト

- [x] web-admin `npm run build` 成功
- [x] web-public `npm run build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)