### PR TITLE
fix: additional_evidence の source_url 欠落を修正

### DIFF
--- a/mystery_agents/agents/scholar.py
+++ b/mystery_agents/agents/scholar.py
@@ -55,8 +55,9 @@ load_dotenv(Path(__file__).parent.parent / ".env")
 #
 # ## 構造化レポートの保存（必須）
 # 分析完了後、`save_structured_report` ツールを必ず呼び出す。
-# classification, state_code, area_code, title, summary, evidence_a/b,
+# classification, state_code, area_code, title, summary, evidence_a/b, additional_evidence,
 # hypothesis, alternative_hypotheses 等の構造化JSONを渡す。
+# additional_evidence の各アイテムは evidence_a/b と同じ構造（source_url を含む）で記述する。
 # これにより下流エージェント（Translator, Publisher）が正確な構造化データを受け取れる。
 #
 # （以下、英語プロンプトの日本語訳は英語版と等価）
@@ -238,7 +239,17 @@ accurate structured data without relying on text parsing.
     "location_context": "Location"
   },
   "evidence_b": { "..." },
-  "additional_evidence": [],
+  "additional_evidence": [
+    {
+      "source_type": "newspaper",
+      "source_language": "en",
+      "source_title": "Source name",
+      "source_date": "YYYY-MM-DD",
+      "source_url": "URL",
+      "relevant_excerpt": "Excerpt",
+      "location_context": "Location"
+    }
+  ],
   "hypothesis": "Primary hypothesis in English",
   "alternative_hypotheses": ["Alt 1", "Alt 2"],
   "confidence_level": "high|medium|low",

--- a/mystery_agents/tools/publisher_tools.py
+++ b/mystery_agents/tools/publisher_tools.py
@@ -291,6 +291,11 @@ def publish_mystery(
         # Ensure required list fields exist
         data.setdefault("additional_evidence", [])
         data["additional_evidence"] = data["additional_evidence"][:5]
+
+        # additional_evidence の source_url 欠落チェック
+        for i, ev in enumerate(data.get("additional_evidence", [])):
+            if not ev.get("source_url"):
+                logger.warning("additional_evidence[%d] missing source_url, title=%s", i, ev.get("source_title", "unknown"))
         data.setdefault("alternative_hypotheses", [])
         data.setdefault("research_questions", [])
         data.setdefault("story_hooks", [])


### PR DESCRIPTION
## Summary

- Scholar instruction の `save_structured_report` JSON 例で `additional_evidence` が空配列 `[]` のみだったため、LLM が `source_url` フィールドを省略する可能性があった
- `evidence_a` / `evidence_b` と同じ Evidence 構造の具体例を追加し、`source_url` の出力を促すように修正
- Publisher ツールに `additional_evidence` の `source_url` 欠落時の warning ログを追加（防御的チェック）

## Test plan

- [x] `pytest tests/unit/ -v` で既存テスト 188件 全パス確認済み
- [ ] ローカルでパイプラインを実行し、生成された `additional_evidence` アイテムに `source_url` が含まれることを確認
- [ ] web-public の記事詳細ページで Additional Evidence に「View」リンクが表示されることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)