### PR TITLE
fix: 未選択言語の Debater が KeyError で落ちるバグを修正

### DIFF
--- a/mystery_agents/tools/theme_analyzer_tools.py
+++ b/mystery_agents/tools/theme_analyzer_tools.py
@@ -60,6 +60,18 @@ def save_language_selection(
 
     tool_context.state["selected_languages"] = valid
 
+    # 未選択言語のセッション変数にデフォルト値を設定
+    # Debater の instruction が全言語の {scholar_analysis_*} を参照するため、
+    # 未設定だと ADK の template 展開で KeyError になる
+    unselected = ALLOWED_LANGUAGES - set(valid)
+    for lang in unselected:
+        tool_context.state[f"collected_documents_{lang}"] = (
+            f"Not available: {lang} was not selected for this investigation."
+        )
+        tool_context.state[f"scholar_analysis_{lang}"] = (
+            f"Not available: {lang} was not selected for this investigation."
+        )
+
     return json.dumps(
         {
             "status": "success",

--- a/tests/unit/test_theme_analyzer.py
+++ b/tests/unit/test_theme_analyzer.py
@@ -99,6 +99,35 @@ class TestSaveLanguageSelection:
         assert "fr" in selected
 
 
+    def test_unselected_languages_get_default_state(self):
+        """未選択言語の collected_documents_* と scholar_analysis_* にデフォルト値が設定される。"""
+        ctx = self._make_tool_context()
+        save_language_selection('["en", "es"]', ctx)
+
+        # 選択された言語にはデフォルト値が設定されない
+        assert "collected_documents_en" not in ctx.state
+        assert "collected_documents_es" not in ctx.state
+        assert "scholar_analysis_en" not in ctx.state
+        assert "scholar_analysis_es" not in ctx.state
+
+        # 未選択言語にはデフォルト値が設定される
+        for lang in ("de", "fr", "nl", "pt"):
+            assert f"collected_documents_{lang}" in ctx.state
+            assert f"scholar_analysis_{lang}" in ctx.state
+            assert "Not available" in ctx.state[f"collected_documents_{lang}"]
+            assert "Not available" in ctx.state[f"scholar_analysis_{lang}"]
+
+    def test_all_languages_selected_no_defaults(self):
+        """全言語選択時（MAX_LANGUAGES制限後）、制限外のみデフォルト値が設定される。"""
+        ctx = self._make_tool_context()
+        save_language_selection('["en", "de", "es", "fr", "nl", "pt"]', ctx)
+
+        selected = ctx.state["selected_languages"]
+        unselected = ALLOWED_LANGUAGES - set(selected)
+        for lang in unselected:
+            assert f"scholar_analysis_{lang}" in ctx.state
+
+
 class TestAllowedLanguages:
     """Tests for language configuration constants."""
 


### PR DESCRIPTION
## 概要

- ThemeAnalyzer が全言語を選択しなかった場合、Debater の instruction 内の `{scholar_analysis_*}` テンプレート変数が未定義となり、ADK の展開時に `KeyError` が発生してパイプラインがクラッシュしていた
- `save_language_selection` で未選択言語の `collected_documents_*` / `scholar_analysis_*` にデフォルト値（`"Not available: ..."`）を設定することで解決

## テスト計画

- [x] 既存ユニットテスト 11件パス
- [x] 新規テスト 2件追加（未選択言語のデフォルト値設定、全言語選択時の挙動）
- [ ] `adk web` で2言語以下のテーマで Debater がクラッシュしないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)