### PR TITLE
test: ThemeAnalyzer / Armchair Polymath / Translator の Golden Dataset 追加

### DIFF
--- a/.claude/skills/gen-eval/agent-catalog.md
+++ b/.claude/skills/gen-eval/agent-catalog.md
@@ -2,25 +2,50 @@
 
 プロジェクト内の全 ADK エージェントのプロパティと期待される eval シナリオの一覧。
 
-## Archive パイプライン（`archive_agents/`）
+## ブログ作成パイプライン（`mystery_agents/`）
 
-パイプライン順序: Librarian → Scholar → Storyteller → Illustrator → Publisher
+パイプライン順序: ThemeAnalyzer → ParallelLibrarians → [ScholarGate] → ParallelScholars(分析) → DebateLoop(討論) → [PolymathGate] → ArmchairPolymath → [StorytellerGate] → Storyteller → [PostStoryGate] → Illustrator → Translator → Publisher
 
 Curator はスタンドアロンエージェント（シーケンシャルパイプラインには含まれない）。
+
+### ThemeAnalyzer
+
+| プロパティ | 値 |
+|----------|-------|
+| モジュール | `mystery_agents/agents/theme_analyzer.py` |
+| 変数名 | `theme_analyzer_agent` |
+| モデル | `gemini-2.5-flash` |
+| 出力キー | `theme_analysis` |
+| ツール | `save_language_selection` |
+| 前段 | （なし — パイプライン最初のエージェント） |
+| チェックするマーカー | （なし） |
+| 出力するマーカー | （なし） |
+| プレースホルダー | （なし） |
+
+**Eval シナリオ:**
+
+| eval_id | 説明 | tool_uses | final_response キーワード |
+|---------|------|-----------|------------------------|
+| `theme_analyzer_geographic_selection` | 地理的手がかりに基づく言語選択（ニューオーリンズ → en, fr, es） | `save_language_selection` | `theme_analysis selected_languages en fr es` |
+| `theme_analyzer_cultural_selection` | 文化的手がかりに基づく言語選択（ペンシルベニア独系 → en, de） | `save_language_selection` | `theme_analysis selected_languages en de` |
+| `theme_analyzer_default_fallback` | デフォルトフォールバック（南部一般 → en, es） | `save_language_selection` | `theme_analysis selected_languages en es` |
+| `theme_analyzer_single_language` | 単一言語選択（西部開拓 → en のみ） | `save_language_selection` | `theme_analysis selected_languages en` |
+
+---
 
 ### Librarian
 
 | プロパティ | 値 |
 |----------|-------|
-| モジュール | `archive_agents/agents/librarian.py` |
-| 変数名 | `librarian_agent` |
-| モデル | `gemini-3-pro-preview` |
-| 出力キー | `collected_documents` |
-| ツール | `search_newspapers`, `search_archives`, `get_available_keywords` |
-| 前段 | （なし — 最初のエージェント） |
+| モジュール | `mystery_agents/agents/language_librarians.py` |
+| 変数名 | `create_librarian(lang_code)` ファクトリ関数 |
+| モデル | `gemini-2.5-flash` |
+| 出力キー | `collected_documents_{lang}` |
+| ツール | EN: `search_newspapers`, `search_archives`, `get_available_keywords` / 他言語: `search_archives` のみ |
+| 前段 | ThemeAnalyzer（言語選択） |
 | チェックするマーカー | （なし） |
 | 出力するマーカー | `NO_DOCUMENTS_FOUND` |
-| プレースホルダー | （なし） |
+| プレースホルダー | `{language_name}`, `{lang_code}`, `{cultural_context}`, `{sources_hint}`, `{newspaper_instruction}` |
 
 **Eval シナリオ:**
 
@@ -37,15 +62,15 @@ Curator はスタンドアロンエージェント（シーケンシャルパイ
 
 | プロパティ | 値 |
 |----------|-------|
-| モジュール | `archive_agents/agents/scholar.py` |
-| 変数名 | `scholar_agent` |
+| モジュール | `mystery_agents/agents/language_scholars.py` |
+| 変数名 | `create_scholar(lang_code, mode)` ファクトリ関数 |
 | モデル | `gemini-3-pro-preview` |
-| 出力キー | `mystery_report` |
-| ツール | （なし） |
-| 前段 | Librarian（`collected_documents`） |
+| 出力キー | `scholar_analysis_{lang}` |
+| ツール | 分析モード: （なし）/ 討論モード: `append_to_whiteboard` |
+| 前段 | Librarian（`collected_documents_{lang}`） |
 | チェックするマーカー | `NO_DOCUMENTS_FOUND` |
 | 出力するマーカー | `INSUFFICIENT_DATA` |
-| プレースホルダー | `{collected_documents}` |
+| プレースホルダー | 分析: `{collected_documents_{lang}}`, `{collected_documents_en}` / 討論: `{scholar_analysis_*}`, `{debate_whiteboard}` |
 
 **Eval シナリオ:**
 
@@ -59,16 +84,41 @@ Curator はスタンドアロンエージェント（シーケンシャルパイ
 
 ---
 
+### Armchair Polymath
+
+| プロパティ | 値 |
+|----------|-------|
+| モジュール | `mystery_agents/agents/armchair_polymath.py` |
+| 変数名 | `armchair_polymath_agent` |
+| モデル | `gemini-3-pro-preview` |
+| 出力キー | `mystery_report` |
+| ツール | `save_structured_report` |
+| 前段 | Scholar（`scholar_analysis_{lang}`）+ DebateLoop（`debate_whiteboard`） |
+| チェックするマーカー | 全 Scholar 分析が空 → `INSUFFICIENT_DATA` |
+| 出力するマーカー | `INSUFFICIENT_DATA` |
+| プレースホルダー | `{scholar_analysis_en}`, `{scholar_analysis_de}`, `{scholar_analysis_es}`, `{scholar_analysis_fr}`, `{scholar_analysis_nl}`, `{scholar_analysis_pt}`, `{debate_whiteboard}` |
+
+**Eval シナリオ:**
+
+| eval_id | 説明 | tool_uses | final_response キーワード |
+|---------|------|-----------|------------------------|
+| `armchair_polymath_cross_language` | 3言語統合分析（en+de+nl）ニューアムステルダム | `save_structured_report` | `mystery_report classification discrepancy hypothesis cross_reference` |
+| `armchair_polymath_single_language` | 単一言語分析（en）ボストン幽霊屋敷 | `save_structured_report` | `mystery_report hypothesis evidence historical_context` |
+| `armchair_polymath_debate_integration` | 討論ホワイトボード統合、ルイジアナ奴隷反乱 | `save_structured_report` | `mystery_report debate discrepancy cross_reference cultural_bias` |
+| `armchair_polymath_insufficient_data` | 全分析空 → 失敗 | `[]` | `INSUFFICIENT_DATA` |
+
+---
+
 ### Storyteller
 
 | プロパティ | 値 |
 |----------|-------|
-| モジュール | `archive_agents/agents/storyteller.py` |
+| モジュール | `mystery_agents/agents/storyteller.py` |
 | 変数名 | `storyteller_agent` |
 | モデル | `gemini-3-pro-preview` |
 | 出力キー | `creative_content` |
 | ツール | （なし） |
-| 前段 | Scholar（`mystery_report`） |
+| 前段 | Armchair Polymath（`mystery_report`） |
 | チェックするマーカー | `INSUFFICIENT_DATA` |
 | 出力するマーカー | `NO_CONTENT` |
 | プレースホルダー | `{mystery_report}` |
@@ -88,7 +138,7 @@ Curator はスタンドアロンエージェント（シーケンシャルパイ
 
 | プロパティ | 値 |
 |----------|-------|
-| モジュール | `archive_agents/agents/illustrator.py` |
+| モジュール | `mystery_agents/agents/illustrator.py` |
 | 変数名 | `illustrator_agent` |
 | モデル | `gemini-3-pro-preview` |
 | 出力キー | `visual_assets` |
@@ -112,15 +162,15 @@ Curator はスタンドアロンエージェント（シーケンシャルパイ
 
 | プロパティ | 値 |
 |----------|-------|
-| モジュール | `archive_agents/agents/publisher.py` |
+| モジュール | `mystery_agents/agents/publisher.py` |
 | 変数名 | `publisher_agent` |
-| モデル | `gemini-3-pro-preview` |
+| モデル | `gemini-2.5-flash` |
 | 出力キー | `published_episode` |
-| ツール | `upload_images`, `publish_mystery` |
-| 前段 | Illustrator（`visual_assets`）+ 全上流キー |
-| チェックするマーカー | 全上流マーカー（`NO_DOCUMENTS_FOUND`, `INSUFFICIENT_DATA`, `NO_CONTENT`） |
+| ツール | `publish_mystery` |
+| 前段 | Illustrator（`visual_assets`）+ Translator（`translation_result`）+ 全上流キー |
+| チェックするマーカー | 全上流マーカー（`NO_DOCUMENTS_FOUND`, `INSUFFICIENT_DATA`, `NO_CONTENT`, `NO_TRANSLATION`） |
 | 出力するマーカー | （なし） |
-| プレースホルダー | `{collected_documents}`, `{mystery_report}`, `{creative_content}`, `{visual_assets}` |
+| プレースホルダー | `{collected_documents_en}`, `{mystery_report}`, `{creative_content}`, `{visual_assets}`, `{translation_result}` |
 
 **Eval シナリオ:**
 
@@ -136,7 +186,7 @@ Curator はスタンドアロンエージェント（シーケンシャルパイ
 
 | プロパティ | 値 |
 |----------|-------|
-| モジュール | `archive_agents/agents/curator.py` |
+| モジュール | `curator_agents/agents/curator.py` |
 | 変数名 | `curator_agent` |
 | モデル | `gemini-3-pro-preview` |
 | 出力キー | `suggested_themes` |
@@ -209,27 +259,30 @@ Curator はスタンドアロンエージェント（シーケンシャルパイ
 
 ## Translator パイプライン（`translator_agents/`）
 
+ブログパイプライン内で Illustrator → Translator → Publisher の順で実行される。
+また、Curator のテーマ提案翻訳にも使用される汎用翻訳エージェント。
+
 ### Translator
 
 | プロパティ | 値 |
 |----------|-------|
 | モジュール | `translator_agents/agents/translator.py` |
 | 変数名 | `translator_agent` |
-| モデル | `gemini-3-pro-preview` |
+| モデル | `gemini-2.5-flash` |
 | 出力キー | `translation_result` |
 | ツール | （なし） |
-| 前段 | （Firestore から事前セットされたフィールドを読み取り） |
-| チェックするマーカー | `NO_CONTENT` |
+| 前段 | Storyteller（`creative_content`）経由で入力 |
+| チェックするマーカー | `NO_CONTENT`, `INSUFFICIENT_DATA` |
 | 出力するマーカー | `NO_TRANSLATION` |
-| プレースホルダー | `{title}`, `{summary}`, `{narrative_content}`, `{discrepancy_detected}`, `{hypothesis}`, `{alternative_hypotheses}`, `{political_climate}`, `{story_hooks}` |
+| プレースホルダー | （入力は user message JSON として受け取る） |
 
 **Eval シナリオ:**
 
 | eval_id | 説明 | tool_uses | final_response キーワード |
 |---------|------|-----------|------------------------|
-| `translator_complete_translation` | 完全な日英翻訳 | `[]` | `translation_result title_en summary_en narrative_content_en` |
+| `translator_complete_translation` | 全フィールド EN→JA 翻訳 | `[]` | `translation_result title_ja summary_ja narrative_content_ja discrepancy_detected_ja hypothesis_ja` |
 | `translator_no_content_skip` | NO_CONTENT 入力時の NO_TRANSLATION 出力 | `[]` | `NO_TRANSLATION NO_CONTENT` |
-| `translator_json_output_format` | _en フィールド付き JSON 出力構造の検証 | `[]` | `translation_result JSON title_en` |
+| `translator_json_output_format` | `_ja` フィールド付き JSON 出力構造の検証 | `[]` | `translation_result title_ja summary_ja hypothesis_ja alternative_hypotheses_ja story_hooks_ja` |
 
 ---
 

--- a/tests/eval/eval_sets/armchair_polymath_eval.json
+++ b/tests/eval/eval_sets/armchair_polymath_eval.json
@@ -1,0 +1,125 @@
+{
+  "eval_set_id": "armchair_polymath_eval_v1",
+  "name": "Armchair Polymath Agent Evaluation",
+  "description": "Tests Armchair Polymath's cross-language synthesis and structured report generation",
+  "eval_cases": [
+    {
+      "eval_id": "armchair_polymath_cross_language",
+      "conversation": [
+        {
+          "invocation_id": "inv_001",
+          "user_content": {
+            "role": "user",
+            "parts": [
+              {
+                "text": "17世紀のニューアムステルダム（現ニューヨーク）におけるオランダ植民地の記録を統合分析してください。英語・ドイツ語・オランダ語の3言語の学者分析が利用可能です。オランダ語の記録では存在しないはずの集落が記載されており、英語の記録ではその集落の住民が突然消失したと報じています。ドイツ語圏の旅行記には異なる日付で同じ事件が記録されています。"
+              }
+            ]
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {"name": "save_structured_report", "args": {}}
+            ],
+            "intermediate_responses": []
+          },
+          "final_response": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "mystery_report classification discrepancy hypothesis cross_reference"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "eval_id": "armchair_polymath_single_language",
+      "conversation": [
+        {
+          "invocation_id": "inv_002",
+          "user_content": {
+            "role": "user",
+            "parts": [
+              {
+                "text": "1880年代のボストンにおける幽霊屋敷の報告を分析してください。英語の学者分析のみが利用可能です。新聞記事と不動産記録の間に矛盾があり、建物の所有者が公式記録から消去されている可能性があります。"
+              }
+            ]
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {"name": "save_structured_report", "args": {}}
+            ],
+            "intermediate_responses": []
+          },
+          "final_response": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "mystery_report hypothesis evidence historical_context"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "eval_id": "armchair_polymath_debate_integration",
+      "conversation": [
+        {
+          "invocation_id": "inv_003",
+          "user_content": {
+            "role": "user",
+            "parts": [
+              {
+                "text": "ルイジアナ州における1811年の奴隷反乱について統合分析してください。英語・フランス語・スペイン語の学者分析と討論ホワイトボードの記録が利用可能です。討論では各言語の学者が文化的バイアスについて議論しており、フランス語の学者は英語記録の信頼性に疑問を呈しています。"
+              }
+            ]
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {"name": "save_structured_report", "args": {}}
+            ],
+            "intermediate_responses": []
+          },
+          "final_response": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "mystery_report debate discrepancy cross_reference cultural_bias"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "eval_id": "armchair_polymath_insufficient_data",
+      "conversation": [
+        {
+          "invocation_id": "inv_004",
+          "user_content": {
+            "role": "user",
+            "parts": [
+              {
+                "text": "2099年の火星植民地における歴史的事件について統合分析してください。学者分析は全て空です。"
+              }
+            ]
+          },
+          "intermediate_data": {
+            "tool_uses": [],
+            "intermediate_responses": []
+          },
+          "final_response": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "INSUFFICIENT_DATA"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/eval/eval_sets/theme_analyzer_eval.json
+++ b/tests/eval/eval_sets/theme_analyzer_eval.json
@@ -1,0 +1,127 @@
+{
+  "eval_set_id": "theme_analyzer_eval_v1",
+  "name": "ThemeAnalyzer Agent Evaluation",
+  "description": "Tests ThemeAnalyzer's language selection capabilities based on investigation themes",
+  "eval_cases": [
+    {
+      "eval_id": "theme_analyzer_geographic_selection",
+      "conversation": [
+        {
+          "invocation_id": "inv_001",
+          "user_content": {
+            "role": "user",
+            "parts": [
+              {
+                "text": "ニューオーリンズのフレンチクォーターにおけるブードゥー信仰と19世紀のクレオール文化の交差について調査してください。フランス植民地時代とスペイン統治時代の記録に矛盾がないか探してください。"
+              }
+            ]
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {"name": "save_language_selection", "args": {}}
+            ],
+            "intermediate_responses": []
+          },
+          "final_response": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "theme_analysis selected_languages en fr es"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "eval_id": "theme_analyzer_cultural_selection",
+      "conversation": [
+        {
+          "invocation_id": "inv_002",
+          "user_content": {
+            "role": "user",
+            "parts": [
+              {
+                "text": "ペンシルベニア州のドイツ系移民コミュニティにおける「パウワウ」民間療法と魔術信仰について調査してください。ドイツ語の文献と英語の公式記録の間の乖離を分析してください。"
+              }
+            ]
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {"name": "save_language_selection", "args": {}}
+            ],
+            "intermediate_responses": []
+          },
+          "final_response": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "theme_analysis selected_languages en de"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "eval_id": "theme_analyzer_default_fallback",
+      "conversation": [
+        {
+          "invocation_id": "inv_003",
+          "user_content": {
+            "role": "user",
+            "parts": [
+              {
+                "text": "アメリカ南部の田舎町で繰り返し報告される怪火現象について調査してください。地元の伝承と科学的記録を照合してください。"
+              }
+            ]
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {"name": "save_language_selection", "args": {}}
+            ],
+            "intermediate_responses": []
+          },
+          "final_response": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "theme_analysis selected_languages en es"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "eval_id": "theme_analyzer_single_language",
+      "conversation": [
+        {
+          "invocation_id": "inv_004",
+          "user_content": {
+            "role": "user",
+            "parts": [
+              {
+                "text": "19世紀の西部開拓時代におけるオレゴン・トレイルの失踪者記録について調査してください。英語の一次資料のみで検証可能な歴史的矛盾を探してください。"
+              }
+            ]
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {"name": "save_language_selection", "args": {}}
+            ],
+            "intermediate_responses": []
+          },
+          "final_response": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "theme_analysis selected_languages en"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/eval/eval_sets/translator_eval.json
+++ b/tests/eval/eval_sets/translator_eval.json
@@ -1,0 +1,91 @@
+{
+  "eval_set_id": "translator_eval_v1",
+  "name": "Translator Agent Evaluation",
+  "description": "Tests Translator's English-to-Japanese translation with _ja suffix JSON output",
+  "eval_cases": [
+    {
+      "eval_id": "translator_complete_translation",
+      "conversation": [
+        {
+          "invocation_id": "inv_001",
+          "user_content": {
+            "role": "user",
+            "parts": [
+              {
+                "text": "以下の英語記事データを日本語に翻訳してください。\n\n{\"title\": \"The Vanishing Settlers of New Amsterdam\", \"summary\": \"Dutch colonial records reveal a mysterious settlement that appears and disappears from official documents between 1645 and 1650.\", \"narrative_content\": \"In the autumn of 1645, a small Dutch settlement on the banks of the Hudson River was recorded in the colonial ledger...\", \"discrepancy_detected\": \"The settlement appears in Dutch records but is absent from English surveys conducted just two years later.\", \"hypothesis\": \"The settlement may have been deliberately erased from records during the English takeover.\", \"alternative_hypotheses\": [\"Natural disaster destroyed the settlement\", \"Residents relocated voluntarily\"], \"historical_context\": {\"political_climate\": \"Tensions between Dutch and English colonial powers were escalating in the 1640s.\"}, \"story_hooks\": [\"Why would an entire settlement vanish from history?\", \"What secrets did the Hudson Valley hold?\"]}"
+              }
+            ]
+          },
+          "intermediate_data": {
+            "tool_uses": [],
+            "intermediate_responses": []
+          },
+          "final_response": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "translation_result title_ja summary_ja narrative_content_ja discrepancy_detected_ja hypothesis_ja"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "eval_id": "translator_no_content_skip",
+      "conversation": [
+        {
+          "invocation_id": "inv_002",
+          "user_content": {
+            "role": "user",
+            "parts": [
+              {
+                "text": "以下のコンテンツを翻訳してください。\n\nNO_CONTENT"
+              }
+            ]
+          },
+          "intermediate_data": {
+            "tool_uses": [],
+            "intermediate_responses": []
+          },
+          "final_response": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "NO_TRANSLATION NO_CONTENT"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "eval_id": "translator_json_output_format",
+      "conversation": [
+        {
+          "invocation_id": "inv_003",
+          "user_content": {
+            "role": "user",
+            "parts": [
+              {
+                "text": "以下の Bell Witch 伝説に関する英語記事データを日本語に翻訳してください。\n\n{\"title\": \"The Bell Witch: Tennessee's Most Enduring Terror\", \"summary\": \"Between 1817 and 1821, the Bell family of Adams, Tennessee experienced a haunting that would become America's most documented supernatural case.\", \"narrative_content\": \"John Bell first noticed something strange in the fields surrounding his farm in Robertson County...\", \"discrepancy_detected\": \"Official county records make no mention of any disturbances at the Bell farm, despite extensive newspaper coverage.\", \"hypothesis\": \"The Bell Witch legend may have originated from a land dispute that was deliberately obscured.\", \"alternative_hypotheses\": [\"Mass hysteria amplified by frontier isolation\", \"Deliberate hoax for commercial purposes\"], \"historical_context\": {\"political_climate\": \"Post-War of 1812 Tennessee was experiencing rapid expansion and land speculation.\"}, \"story_hooks\": [\"What really happened on the Bell farm?\", \"Why did Andrew Jackson himself allegedly investigate?\"]}"
+              }
+            ]
+          },
+          "intermediate_data": {
+            "tool_uses": [],
+            "intermediate_responses": []
+          },
+          "final_response": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "translation_result title_ja summary_ja hypothesis_ja alternative_hypotheses_ja story_hooks_ja"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/eval/test_adk_eval.py
+++ b/tests/eval/test_adk_eval.py
@@ -91,6 +91,21 @@ class TestADKEvaluationSetup:
         producer_eval = EVAL_SETS_DIR / "producer_eval.json"
         assert producer_eval.exists()
 
+    def test_theme_analyzer_eval_exists(self):
+        """theme_analyzer_eval.json should exist."""
+        theme_analyzer_eval = EVAL_SETS_DIR / "theme_analyzer_eval.json"
+        assert theme_analyzer_eval.exists()
+
+    def test_armchair_polymath_eval_exists(self):
+        """armchair_polymath_eval.json should exist."""
+        armchair_polymath_eval = EVAL_SETS_DIR / "armchair_polymath_eval.json"
+        assert armchair_polymath_eval.exists()
+
+    def test_translator_eval_exists(self):
+        """translator_eval.json should exist."""
+        translator_eval = EVAL_SETS_DIR / "translator_eval.json"
+        assert translator_eval.exists()
+
     def test_librarian_eval_valid_structure(self):
         """librarian_eval.json should have valid ADK eval structure."""
         with open(EVAL_SETS_DIR / "librarian_eval.json") as f:
@@ -327,3 +342,87 @@ class TestEvalSetContent:
 
         # Should have bilingual test
         assert any("bilingual" in eid.lower() for eid in eval_ids)
+
+    def test_theme_analyzer_eval_covers_key_scenarios(self):
+        """ThemeAnalyzer eval should cover geographic, cultural, and fallback scenarios."""
+        with open(EVAL_SETS_DIR / "theme_analyzer_eval.json") as f:
+            data = json.load(f)
+
+        eval_ids = [e["eval_id"] for e in data["eval_cases"]]
+
+        # 地理的手がかりに基づく言語選択
+        assert any("geographic" in eid.lower() for eid in eval_ids)
+
+        # 文化的手がかりに基づく言語選択
+        assert any("cultural" in eid.lower() for eid in eval_ids)
+
+        # デフォルトフォールバック
+        assert any("fallback" in eid.lower() or "default" in eid.lower() for eid in eval_ids)
+
+    def test_theme_analyzer_eval_covers_tool_usage(self):
+        """ThemeAnalyzer eval should test save_language_selection tool usage."""
+        with open(EVAL_SETS_DIR / "theme_analyzer_eval.json") as f:
+            data = json.load(f)
+
+        # 全シナリオで save_language_selection を呼び出すこと
+        for eval_case in data["eval_cases"]:
+            for turn in eval_case.get("conversation", []):
+                intermediate_data = turn.get("intermediate_data", {})
+                tool_uses = intermediate_data.get("tool_uses", [])
+                tool_names = [t.get("name", "") for t in tool_uses]
+                assert "save_language_selection" in tool_names, (
+                    f"Eval {eval_case['eval_id']} should use save_language_selection tool"
+                )
+
+    def test_armchair_polymath_eval_covers_key_scenarios(self):
+        """Armchair Polymath eval should cover cross-language, single, debate, and insufficient scenarios."""
+        with open(EVAL_SETS_DIR / "armchair_polymath_eval.json") as f:
+            data = json.load(f)
+
+        eval_ids = [e["eval_id"] for e in data["eval_cases"]]
+
+        # 多言語統合分析
+        assert any("cross_language" in eid.lower() for eid in eval_ids)
+
+        # 単一言語分析
+        assert any("single_language" in eid.lower() or "single" in eid.lower() for eid in eval_ids)
+
+        # 討論ホワイトボード統合
+        assert any("debate" in eid.lower() for eid in eval_ids)
+
+        # データ不足
+        assert any("insufficient" in eid.lower() for eid in eval_ids)
+
+    def test_armchair_polymath_eval_covers_tool_usage(self):
+        """Armchair Polymath eval should test save_structured_report tool usage."""
+        with open(EVAL_SETS_DIR / "armchair_polymath_eval.json") as f:
+            data = json.load(f)
+
+        # 成功シナリオでは save_structured_report を呼び出すこと
+        has_tool_test = False
+        for eval_case in data["eval_cases"]:
+            for turn in eval_case.get("conversation", []):
+                intermediate_data = turn.get("intermediate_data", {})
+                tool_uses = intermediate_data.get("tool_uses", [])
+                for tool in tool_uses:
+                    if tool.get("name", "") == "save_structured_report":
+                        has_tool_test = True
+                        break
+
+        assert has_tool_test, "Armchair Polymath eval should test save_structured_report tool usage"
+
+    def test_translator_eval_covers_key_scenarios(self):
+        """Translator eval should cover complete, no_content, and json_format scenarios."""
+        with open(EVAL_SETS_DIR / "translator_eval.json") as f:
+            data = json.load(f)
+
+        eval_ids = [e["eval_id"] for e in data["eval_cases"]]
+
+        # 全フィールド翻訳
+        assert any("complete" in eid.lower() for eid in eval_ids)
+
+        # NO_CONTENT スキップ
+        assert any("no_content" in eid.lower() for eid in eval_ids)
+
+        # JSON 出力形式検証
+        assert any("json" in eid.lower() or "format" in eid.lower() for eid in eval_ids)


### PR DESCRIPTION
## Summary

- ThemeAnalyzer / Armchair Polymath / Translator の3エージェントに Golden Dataset を追加し、eval カバレッジを 100%（10/10 エージェント）に到達
- `test_adk_eval.py` に存在テスト3件 + コンテンツ品質テスト5件を追加
- `agent-catalog.md` を現行パイプライン構成に全面更新（`archive_agents/` → `mystery_agents/`、ThemeAnalyzer/Armchair Polymath 追加、Translator `_en` → `_ja` 修正、モデル・パス修正）

### 新規作成ファイル
| ファイル | eval_cases 数 |
|---------|--------------|
| `theme_analyzer_eval.json` | 4（地理的選択、文化的選択、デフォルトフォールバック、単一言語） |
| `armchair_polymath_eval.json` | 4（多言語統合、単一言語、討論WB統合、データ不足） |
| `translator_eval.json` | 3（全フィールド翻訳、NO_CONTENT スキップ、_ja JSON 出力形式） |

## Test plan

- [x] JSON バリデーション通過（`python -m json.tool`）
- [x] `TestADKEvaluationSetup` 全15件 PASSED
- [x] `TestEvalSetContent` 全13件 PASSED
- [x] 日本語チェック（`test_eval_conversations_are_in_japanese`）PASSED
- [ ] `test_agent_handover.py` の既存失敗6件は変更前と同一（MagicMock モデル比較の既知問題）

🤖 Generated with [Claude Code](https://claude.com/claude-code)