### PR TITLE
feat: approve/archive 時に web-public の SSG リビルドを自動発火

### DIFF
--- a/terraform/cloud-run.tf
+++ b/terraform/cloud-run.tf
@@ -76,6 +76,11 @@ resource "google_cloud_run_v2_service" "web_admin" {
         value = google_cloud_run_v2_service.pipeline.uri
       }
 
+      env {
+        name  = "CLOUD_BUILD_TRIGGER_ID"
+        value = google_cloudbuild_trigger.web_public.trigger_id
+      }
+
       resources {
         limits = {
           cpu    = "1"

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -37,6 +37,12 @@ resource "google_project_iam_member" "web_admin_secrets" {
   member  = "serviceAccount:${google_service_account.web_admin.email}"
 }
 
+resource "google_project_iam_member" "web_admin_cloudbuild" {
+  project = var.project_id
+  role    = "roles/cloudbuild.builds.editor"
+  member  = "serviceAccount:${google_service_account.web_admin.email}"
+}
+
 # IAM roles for pipelines
 resource "google_project_iam_member" "pipelines_firestore" {
   project = var.project_id

--- a/web-admin/src/app/(main)/page.tsx
+++ b/web-admin/src/app/(main)/page.tsx
@@ -69,11 +69,21 @@ export default function AdminPage() {
     error: mysteries.filter((m) => m.status === "error").length,
   }
 
+  // リビルド失敗は approve/archive の成否に影響しない（fire-and-forget）
+  const triggerRebuild = async () => {
+    try {
+      await fetch("/api/rebuild-public", { method: "POST" })
+    } catch (error) {
+      console.error("Failed to trigger rebuild:", error)
+    }
+  }
+
   const handleApprove = async (id: string) => {
     try {
       await approveMystery(id)
       setActionFeedback(`Case ${id} approved and published`)
       fetchMysteries()
+      triggerRebuild()
       setTimeout(() => setActionFeedback(null), 3000)
     } catch (error) {
       console.error("Failed to approve:", error)
@@ -87,6 +97,7 @@ export default function AdminPage() {
       await archiveMystery(id)
       setActionFeedback(`Case ${id} archived`)
       fetchMysteries()
+      triggerRebuild()
       setTimeout(() => setActionFeedback(null), 3000)
     } catch (error) {
       console.error("Failed to archive:", error)

--- a/web-admin/src/app/api/rebuild-public/route.ts
+++ b/web-admin/src/app/api/rebuild-public/route.ts
@@ -1,0 +1,70 @@
+/**
+ * POST /api/rebuild-public
+ *
+ * approve/archive 後に web-public の SSG リビルドを発火する。
+ * - 本番: google-auth-library で access token を取得し、Cloud Build triggers.run を呼び出す
+ * - ローカル: 何もしない（dev モードでは Firestore 更新が即座に反映されるため不要）
+ */
+
+import { NextResponse } from "next/server";
+
+const projectId = process.env.GOOGLE_CLOUD_PROJECT;
+const triggerId = process.env.CLOUD_BUILD_TRIGGER_ID;
+const isProduction = process.env.NODE_ENV === "production";
+
+export async function POST() {
+  // ローカル開発ではリビルドをスキップ
+  if (!isProduction) {
+    return NextResponse.json({ status: "skipped", reason: "not production" });
+  }
+
+  if (!projectId || !triggerId) {
+    console.error("Missing GOOGLE_CLOUD_PROJECT or CLOUD_BUILD_TRIGGER_ID");
+    return NextResponse.json(
+      { error: "Missing configuration" },
+      { status: 500 }
+    );
+  }
+
+  try {
+    const { GoogleAuth } = await import("google-auth-library");
+    const auth = new GoogleAuth({
+      scopes: ["https://www.googleapis.com/auth/cloud-platform"],
+    });
+    const client = await auth.getClient();
+    const { token } = await client.getAccessToken();
+
+    const url = `https://cloudbuild.googleapis.com/v1/projects/${projectId}/triggers/${triggerId}:run`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ branchName: "main" }),
+      signal: AbortSignal.timeout(15000),
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      console.error(`Cloud Build API error (${response.status}):`, errorBody);
+      return NextResponse.json(
+        { error: "Failed to trigger rebuild" },
+        { status: 500 }
+      );
+    }
+
+    const data = await response.json();
+    console.log("Cloud Build triggered:", data.metadata?.build?.id);
+    return NextResponse.json({
+      status: "triggered",
+      buildId: data.metadata?.build?.id,
+    });
+  } catch (error) {
+    console.error("Failed to trigger Cloud Build:", error);
+    return NextResponse.json(
+      { error: "Failed to trigger rebuild" },
+      { status: 500 }
+    );
+  }
+}

--- a/web-public/package.json
+++ b/web-public/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "npx serve out",
+    "preview": "next build && npx serve out",
     "lint": "eslint"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

- web-admin で approve/archive した際に Cloud Build API を直接呼び出し、web-public の SSG リビルド・再デプロイを自動実行する
- Pipeline Service を経由せず、web-admin → Cloud Build REST API の直接呼び出しで軽量に実装
- ローカル開発環境では Cloud Build をスキップ（`next dev` の動的レンダリングで Firestore 更新が即座に反映されるため不要）

## 変更内容

| ファイル | 変更 |
|---------|------|
| `terraform/iam.tf` | web-admin SA に `roles/cloudbuild.builds.editor` 付与 |
| `terraform/cloud-run.tf` | web-admin に `CLOUD_BUILD_TRIGGER_ID` env var 追加 |
| `web-admin/src/app/api/rebuild-public/route.ts` | **新規** — Cloud Build triggers.run を呼び出す API ルート |
| `web-admin/src/app/(main)/page.tsx` | handleApprove/handleArchive に fire-and-forget で triggerRebuild 追加 |
| `web-public/package.json` | `preview` スクリプト追加（`next build && npx serve out`） |

## 設計判断

- **fire-and-forget**: リビルド失敗は approve/archive の成否に影響しない。Firestore は既に更新済みで、次回リビルド時に最新状態が反映される
- **ローカル skip**: `NODE_ENV !== "production"` のとき `{ status: "skipped" }` を返す。ローカルの `next dev` は動的レンダリングのため SSG リビルド不要
- **Pipeline Service 不使用**: 単一 REST API コールのために 2CPU/2Gi のサービスを起こす必要はない

## Test plan

- [ ] ローカル: `npm run dev` で web-admin 起動 → approve → コンソールに Cloud Build エラーが出ないこと（dev では skip）
- [ ] ローカル: `npm run dev` で web-admin 起動 → archive → コンソールに Cloud Build エラーが出ないこと（dev では skip）
- [ ] `terraform plan` で `web_admin_cloudbuild` IAM リソースと `CLOUD_BUILD_TRIGGER_ID` env var の追加を確認
- [ ] 本番: approve → Cloud Build コンソールで `web-public-deploy` ビルドが起動すること
- [ ] 本番: ビルド完了後 → 公開サイトに記事が表示されること
- [ ] 本番: archive → 同様にビルドが起動し、公開サイトから記事が消えること

🤖 Generated with [Claude Code](https://claude.com/claude-code)