### PR TITLE
パイプライン進捗リアルタイム表示 — Firestore onSnapshot + ActivePipelinePanel

### DIFF
--- a/packages/shared/src/lib/firebase/config.ts
+++ b/packages/shared/src/lib/firebase/config.ts
@@ -105,4 +105,5 @@ export function getFirebaseStorage(): FirebaseStorage {
  */
 export const COLLECTIONS = {
   MYSTERIES: "mysteries",
+  PIPELINE_RUNS: "pipeline_runs",
 } as const;

--- a/packages/shared/src/types/mystery.ts
+++ b/packages/shared/src/types/mystery.ts
@@ -254,14 +254,62 @@ export const CONFIDENCE_LEVEL_LABELS: Record<ConfidenceLevel, string> = {
 };
 
 /**
+ * パイプライン実行ステータス
+ */
+export type PipelineRunStatus = "running" | "completed" | "error";
+
+/**
+ * パイプライン種別
+ */
+export type PipelineRunType = "blog" | "translate" | "podcast";
+
+/**
+ * パイプライン実行ドキュメント
+ * Python 側 shared/pipeline_run.py と同期
+ */
+export interface PipelineRun {
+  id: string;
+  type: PipelineRunType;
+  status: PipelineRunStatus;
+  query: string | null;
+  mystery_id: string | null;
+  current_agent: string | null;
+  pipeline_log: AgentLogEntry[];
+  started_at: Date;
+  updated_at: Date;
+  completed_at: Date | null;
+  error_message: string | null;
+}
+
+/**
  * エージェント名の日本語ラベルマッピング
  */
 export const AGENT_NAME_LABELS: Record<string, string> = {
   theme_analyzer: "テーマ分析",
   librarian: "資料収集",
+  librarian_en: "資料収集（英語）",
+  librarian_es: "資料収集（スペイン語）",
+  librarian_de: "資料収集（ドイツ語）",
+  librarian_fr: "資料収集（フランス語）",
+  librarian_nl: "資料収集（オランダ語）",
+  librarian_pt: "資料収集（ポルトガル語）",
   scholar: "学際分析",
+  scholar_en: "学際分析（英語）",
+  scholar_es: "学際分析（スペイン語）",
+  scholar_de: "学際分析（ドイツ語）",
+  scholar_fr: "学際分析（フランス語）",
+  scholar_nl: "学際分析（オランダ語）",
+  scholar_pt: "学際分析（ポルトガル語）",
+  scholar_en_debate: "討論（英語）",
+  scholar_es_debate: "討論（スペイン語）",
+  scholar_de_debate: "討論（ドイツ語）",
+  scholar_fr_debate: "討論（フランス語）",
+  scholar_nl_debate: "討論（オランダ語）",
+  scholar_pt_debate: "討論（ポルトガル語）",
+  armchair_polymath: "統合分析",
   cross_reference_scholar: "統合分析",
   storyteller: "物語生成",
+  translator: "翻訳",
   scriptwriter: "脚本作成",
   illustrator: "画像生成",
   producer: "音声生成",

--- a/web-admin/src/app/(main)/page.tsx
+++ b/web-admin/src/app/(main)/page.tsx
@@ -1,14 +1,17 @@
 "use client"
 
-import { useEffect, useState, useCallback } from "react"
+import { useEffect, useState, useCallback, useRef, useMemo } from "react"
 import Link from "next/link"
 import { StatusBadge } from "@/components/status-badge"
 import { cn } from "@ghost/shared/src/lib/utils"
 import { Button } from "@ghost/shared/src/components/ui/button"
 import { getAllMysteries, approveMystery, archiveMystery, requestPodcast } from "@/lib/firestore/mysteries"
-import type { FirestoreMystery, MysteryStatus } from "@ghost/shared/src/types/mystery"
+import type { FirestoreMystery, MysteryStatus, PipelineRun } from "@ghost/shared/src/types/mystery"
 import { PipelineSummary } from "@/components/pipeline-summary"
 import { PipelineTimeline } from "@/components/pipeline-timeline"
+import { ActivePipelinePanel } from "@/components/active-pipeline-panel"
+import { usePipelineRuns } from "@/hooks/use-pipeline-runs"
+import { usePipelineRun } from "@/hooks/use-pipeline-run"
 import {
   Shield,
   FileText,
@@ -40,6 +43,15 @@ export default function AdminPage() {
   const [suggestions, setSuggestions] = useState<{ theme: string; description: string; theme_ja?: string; description_ja?: string }[]>([])
   const [suggestLoading, setSuggestLoading] = useState(false)
   const [pipelineLoading, setPipelineLoading] = useState(false)
+  const [currentRunId, setCurrentRunId] = useState<string | null>(null)
+  const [dismissedRunIds, setDismissedRunIds] = useState<Set<string>>(new Set())
+
+  // パイプライン進捗監視フック
+  const { runs: runningPipelines, dismiss: dismissRunning } = usePipelineRuns()
+  const currentRun = usePipelineRun(currentRunId)
+
+  // running → completed/error を検知して記事一覧を自動更新
+  const prevStatusRef = useRef<string | null>(null)
 
   const fetchMysteries = useCallback(async () => {
     try {
@@ -55,6 +67,38 @@ export default function AdminPage() {
   useEffect(() => {
     fetchMysteries()
   }, [fetchMysteries])
+
+  // パイプライン完了時に記事一覧を自動更新
+  useEffect(() => {
+    const status = currentRun?.status ?? null
+    if (prevStatusRef.current === "running" && (status === "completed" || status === "error")) {
+      fetchMysteries()
+    }
+    prevStatusRef.current = status
+  }, [currentRun?.status, fetchMysteries])
+
+  // running パイプライン + currentRun をマージ（ID 重複排除、currentRun 優先）
+  const mergedRuns = useMemo(() => {
+    const runsMap = new Map<string, PipelineRun>()
+    for (const r of runningPipelines) {
+      if (!dismissedRunIds.has(r.id)) {
+        runsMap.set(r.id, r)
+      }
+    }
+    // currentRun は完了/エラー後も表示するため優先
+    if (currentRun && !dismissedRunIds.has(currentRun.id)) {
+      runsMap.set(currentRun.id, currentRun)
+    }
+    return Array.from(runsMap.values())
+  }, [runningPipelines, currentRun, dismissedRunIds])
+
+  const handleDismissRun = useCallback((runId: string) => {
+    dismissRunning(runId)
+    setDismissedRunIds((prev) => new Set(prev).add(runId))
+    if (runId === currentRunId) {
+      setCurrentRunId(null)
+    }
+  }, [dismissRunning, currentRunId])
 
   const filteredMysteries = filter === "all"
     ? mysteries
@@ -113,6 +157,10 @@ export default function AdminPage() {
         body: JSON.stringify({ mysteryId: id }),
       })
       if (!res.ok) throw new Error("API request failed")
+      const data = await res.json()
+      if (data.run_id) {
+        setCurrentRunId(data.run_id)
+      }
       setActionFeedback(`Podcast generation started for Case ${id}`)
       fetchMysteries()
       setTimeout(() => setActionFeedback(null), 3000)
@@ -123,9 +171,6 @@ export default function AdminPage() {
     }
   }
 
-  // TODO: 調査パイプラインの進捗表示が現在機能していない。
-  // 以前は実行中の進捗がUIに表示されていたが、API のローカル/本番分岐修正時に失われた。
-  // 後日、パイプライン実行中のリアルタイム進捗表示を復旧すること（技術的負債）。
   const handleStartPipeline = async () => {
     if (!themeInput.trim()) return
     setPipelineLoading(true)
@@ -136,6 +181,10 @@ export default function AdminPage() {
         body: JSON.stringify({ query: themeInput.trim() }),
       })
       if (!res.ok) throw new Error("API request failed")
+      const data = await res.json()
+      if (data.run_id) {
+        setCurrentRunId(data.run_id)
+      }
       setActionFeedback("調査パイプラインを開始しました")
       setThemeInput("")
       setSuggestions([])
@@ -256,6 +305,19 @@ export default function AdminPage() {
             <p className="text-sm text-[#5fb3a1] font-mono">
               {actionFeedback}
             </p>
+          </div>
+        )}
+
+        {/* 実行中のパイプライン */}
+        {mergedRuns.length > 0 && (
+          <div className="space-y-3 mb-8">
+            {mergedRuns.map((run) => (
+              <ActivePipelinePanel
+                key={run.id}
+                run={run}
+                onDismiss={() => handleDismissRun(run.id)}
+              />
+            ))}
           </div>
         )}
 

--- a/web-admin/src/components/active-pipeline-panel.tsx
+++ b/web-admin/src/components/active-pipeline-panel.tsx
@@ -1,0 +1,164 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import Link from "next/link"
+import { cn } from "@ghost/shared/src/lib/utils"
+import { AGENT_NAME_LABELS } from "@ghost/shared/src/types/mystery"
+import type { PipelineRun } from "@ghost/shared/src/types/mystery"
+import { PipelineSummary } from "@/components/pipeline-summary"
+import { PipelineTimeline } from "@/components/pipeline-timeline"
+import {
+  Loader2,
+  CheckCircle,
+  XCircle,
+  ChevronDown,
+  ChevronUp,
+  X,
+  Eye,
+  Clock,
+} from "lucide-react"
+
+/**
+ * 経過時間を「Xm Ys」形式でフォーマットする
+ */
+function formatElapsed(seconds: number): string {
+  const m = Math.floor(seconds / 60)
+  const s = seconds % 60
+  if (m === 0) return `${s}s`
+  return `${m}m ${s}s`
+}
+
+interface ActivePipelinePanelProps {
+  run: PipelineRun
+  onDismiss: () => void
+}
+
+export function ActivePipelinePanel({ run, onDismiss }: ActivePipelinePanelProps) {
+  const [expanded, setExpanded] = useState(false)
+  const [elapsed, setElapsed] = useState(0)
+
+  // running 中のみ毎秒経過時間を更新
+  useEffect(() => {
+    if (run.status !== "running") return
+
+    const updateElapsed = () => {
+      const diff = Math.floor((Date.now() - run.started_at.getTime()) / 1000)
+      setElapsed(diff)
+    }
+    updateElapsed()
+    const interval = setInterval(updateElapsed, 1000)
+    return () => clearInterval(interval)
+  }, [run.status, run.started_at])
+
+  const agentLabel = run.current_agent
+    ? (AGENT_NAME_LABELS[run.current_agent] || run.current_agent)
+    : null
+
+  const typeLabel = run.type === "blog" ? "ブログ調査" : run.type === "podcast" ? "Podcast 生成" : "翻訳"
+
+  return (
+    <div className={cn(
+      "aged-card letterpress-border rounded-sm p-4 transition-colors",
+      run.status === "running" && "border-gold/40",
+      run.status === "completed" && "border-teal/40",
+      run.status === "error" && "border-blood-red/40",
+    )}>
+      {/* ヘッダー */}
+      <div className="flex items-center justify-between gap-3 mb-2">
+        <div className="flex items-center gap-3">
+          {run.status === "running" && (
+            <Loader2 className="w-5 h-5 text-[#d4af37] animate-spin flex-shrink-0" />
+          )}
+          {run.status === "completed" && (
+            <CheckCircle className="w-5 h-5 text-[#5fb3a1] flex-shrink-0" />
+          )}
+          {run.status === "error" && (
+            <XCircle className="w-5 h-5 text-[#ff6b6b] flex-shrink-0" />
+          )}
+
+          <div>
+            <div className="flex items-center gap-2">
+              <span className="font-mono text-sm uppercase tracking-wider text-parchment">
+                {typeLabel}
+              </span>
+              {run.status === "running" && (
+                <span className="flex items-center gap-1 text-xs text-muted-foreground font-mono">
+                  <Clock className="w-3 h-3" />
+                  {formatElapsed(elapsed)}
+                </span>
+              )}
+            </div>
+            {run.query && (
+              <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1">
+                {run.query}
+              </p>
+            )}
+          </div>
+        </div>
+
+        {/* 右側: 現在のエージェント + dismiss/close */}
+        <div className="flex items-center gap-3">
+          {run.status === "running" && agentLabel && (
+            <span className="text-xs font-mono text-[#d4af37] bg-gold/10 px-2 py-1 rounded-sm">
+              {agentLabel}
+            </span>
+          )}
+          {run.status !== "running" && (
+            <button
+              onClick={onDismiss}
+              className="p-1 text-muted-foreground hover:text-parchment transition-colors"
+              title="閉じる"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* 完了時: 記事プレビューリンク */}
+      {run.status === "completed" && run.mystery_id && (
+        <div className="flex items-center gap-2 mb-2">
+          <Link
+            href={`/preview/${run.mystery_id}`}
+            className="inline-flex items-center gap-1.5 text-sm text-gold hover:text-parchment transition-colors no-underline"
+          >
+            <Eye className="w-4 h-4" />
+            記事プレビュー
+          </Link>
+        </div>
+      )}
+
+      {/* エラー時: エラーメッセージ */}
+      {run.status === "error" && run.error_message && (
+        <div className="bg-blood-red/10 border border-blood-red/20 rounded-sm p-2 mb-2">
+          <p className="text-xs text-[#ff6b6b] font-mono">
+            {run.error_message}
+          </p>
+        </div>
+      )}
+
+      {/* Pipeline Summary + Timeline (展開/折りたたみ) */}
+      {run.pipeline_log.length > 0 && (
+        <div className="pt-2 border-t border-border/50">
+          <button
+            onClick={() => setExpanded(!expanded)}
+            className="w-full flex items-center justify-between hover:bg-muted/50 transition-colors p-1 -mx-1 rounded-sm"
+          >
+            <PipelineSummary logs={run.pipeline_log} />
+            {expanded ? (
+              <ChevronUp className="w-4 h-4 text-muted-foreground" />
+            ) : (
+              <ChevronDown className="w-4 h-4 text-muted-foreground" />
+            )}
+          </button>
+
+          {expanded && (
+            <div className="mt-3 pt-3 border-t border-border/50">
+              <PipelineTimeline logs={run.pipeline_log} />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web-admin/src/components/pipeline-timeline.tsx
+++ b/web-admin/src/components/pipeline-timeline.tsx
@@ -14,16 +14,36 @@ import {
   Palette,
   Mic,
   Upload,
+  Compass,
+  Brain,
+  Languages,
 } from "lucide-react"
 
 const AGENT_ICONS: Record<string, React.ReactNode> = {
+  theme_analyzer: <Compass className="w-4 h-4" />,
   librarian: <FileSearch className="w-4 h-4" />,
   scholar: <BookOpen className="w-4 h-4" />,
+  armchair_polymath: <Brain className="w-4 h-4" />,
   storyteller: <Pen className="w-4 h-4" />,
+  translator: <Languages className="w-4 h-4" />,
   scriptwriter: <FileText className="w-4 h-4" />,
   illustrator: <Palette className="w-4 h-4" />,
   producer: <Mic className="w-4 h-4" />,
   publisher: <Upload className="w-4 h-4" />,
+}
+
+/**
+ * エージェント名からベース名を解決してアイコンを返す
+ * 例: "librarian_en" → "librarian", "scholar_de_debate" → "scholar"
+ */
+function getAgentIcon(agentName: string): React.ReactNode {
+  if (AGENT_ICONS[agentName]) return AGENT_ICONS[agentName]
+  // "_debate" サフィックスを除去して再試行
+  const withoutDebate = agentName.replace(/_debate$/, "")
+  if (AGENT_ICONS[withoutDebate]) return AGENT_ICONS[withoutDebate]
+  // 言語サフィックス（_en, _es, _de 等）を除去して再試行
+  const baseName = withoutDebate.replace(/_[a-z]{2}$/, "")
+  return AGENT_ICONS[baseName] || null
 }
 
 const STATUS_CONFIG = {
@@ -76,7 +96,7 @@ export function PipelineTimeline({ logs, className }: PipelineTimelineProps) {
                 {/* Content */}
                 <div className="flex-1 pt-1">
                   <div className="flex items-center gap-2 mb-1">
-                    {AGENT_ICONS[log.agent_name]}
+                    {getAgentIcon(log.agent_name)}
                     <h4 className="font-mono text-sm uppercase tracking-wider text-parchment">
                       {label}
                     </h4>

--- a/web-admin/src/hooks/use-pipeline-run.ts
+++ b/web-admin/src/hooks/use-pipeline-run.ts
@@ -1,0 +1,62 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { doc, onSnapshot, Timestamp } from "firebase/firestore"
+import { getFirestoreDb } from "@ghost/shared/src/lib/firebase/config"
+import { COLLECTIONS } from "@ghost/shared/src/lib/firebase/config"
+import type { PipelineRun } from "@ghost/shared/src/types/mystery"
+
+/**
+ * Firestore Timestamp を Date に変換するヘルパー
+ */
+function toDate(val: unknown): Date {
+  if (val instanceof Timestamp) return val.toDate()
+  if (val instanceof Date) return val
+  if (typeof val === "string") return new Date(val)
+  return new Date()
+}
+
+/**
+ * 単一パイプライン実行を onSnapshot でリアルタイム監視するフック
+ * 完了/エラー後も最終状態を保持し、dismiss まで表示する。
+ */
+export function usePipelineRun(runId: string | null) {
+  const [run, setRun] = useState<PipelineRun | null>(null)
+
+  useEffect(() => {
+    if (!runId) {
+      setRun(null)
+      return
+    }
+
+    const db = getFirestoreDb()
+    const docRef = doc(db, COLLECTIONS.PIPELINE_RUNS, runId)
+
+    const unsubscribe = onSnapshot(docRef, (snapshot) => {
+      if (!snapshot.exists()) {
+        setRun(null)
+        return
+      }
+      const data = snapshot.data()
+      setRun({
+        id: snapshot.id,
+        type: (data.type as PipelineRun["type"]) || "blog",
+        status: (data.status as PipelineRun["status"]) || "running",
+        query: (data.query as string) || null,
+        mystery_id: (data.mystery_id as string) || null,
+        current_agent: (data.current_agent as string) || null,
+        pipeline_log: Array.isArray(data.pipeline_log) ? data.pipeline_log : [],
+        started_at: toDate(data.started_at),
+        updated_at: toDate(data.updated_at),
+        completed_at: data.completed_at ? toDate(data.completed_at) : null,
+        error_message: (data.error_message as string) || null,
+      })
+    }, (error) => {
+      console.error("[usePipelineRun] onSnapshot error:", error)
+    })
+
+    return () => unsubscribe()
+  }, [runId])
+
+  return run
+}

--- a/web-admin/src/hooks/use-pipeline-runs.ts
+++ b/web-admin/src/hooks/use-pipeline-runs.ts
@@ -1,0 +1,82 @@
+"use client"
+
+import { useEffect, useState, useCallback } from "react"
+import {
+  collection,
+  query,
+  where,
+  orderBy,
+  onSnapshot,
+  Timestamp,
+} from "firebase/firestore"
+import { getFirestoreDb } from "@ghost/shared/src/lib/firebase/config"
+import { COLLECTIONS } from "@ghost/shared/src/lib/firebase/config"
+import type { PipelineRun } from "@ghost/shared/src/types/mystery"
+
+/**
+ * Firestore Timestamp を Date に変換するヘルパー
+ */
+function toDate(val: unknown): Date {
+  if (val instanceof Timestamp) return val.toDate()
+  if (val instanceof Date) return val
+  if (typeof val === "string") return new Date(val)
+  return new Date()
+}
+
+/**
+ * Firestore ドキュメントを PipelineRun に変換する
+ */
+function docToPipelineRun(id: string, data: Record<string, unknown>): PipelineRun {
+  return {
+    id,
+    type: (data.type as PipelineRun["type"]) || "blog",
+    status: (data.status as PipelineRun["status"]) || "running",
+    query: (data.query as string) || null,
+    mystery_id: (data.mystery_id as string) || null,
+    current_agent: (data.current_agent as string) || null,
+    pipeline_log: Array.isArray(data.pipeline_log) ? data.pipeline_log : [],
+    started_at: toDate(data.started_at),
+    updated_at: toDate(data.updated_at),
+    completed_at: data.completed_at ? toDate(data.completed_at) : null,
+    error_message: (data.error_message as string) || null,
+  }
+}
+
+/**
+ * 全 running パイプラインをリアルタイム監視するフック
+ * status=="running" のドキュメントを onSnapshot で購読する。
+ * 完了すると Firestore クエリ結果から消えるため、dismiss ロジックを内蔵。
+ */
+export function usePipelineRuns() {
+  const [runs, setRuns] = useState<PipelineRun[]>([])
+  const [dismissedIds, setDismissedIds] = useState<Set<string>>(new Set())
+
+  useEffect(() => {
+    const db = getFirestoreDb()
+    const q = query(
+      collection(db, COLLECTIONS.PIPELINE_RUNS),
+      where("status", "==", "running"),
+      orderBy("started_at", "desc"),
+    )
+
+    const unsubscribe = onSnapshot(q, (snapshot) => {
+      const pipelineRuns: PipelineRun[] = []
+      snapshot.forEach((doc) => {
+        pipelineRuns.push(docToPipelineRun(doc.id, doc.data()))
+      })
+      setRuns(pipelineRuns)
+    }, (error) => {
+      console.error("[usePipelineRuns] onSnapshot error:", error)
+    })
+
+    return () => unsubscribe()
+  }, [])
+
+  const dismiss = useCallback((runId: string) => {
+    setDismissedIds((prev) => new Set(prev).add(runId))
+  }, [])
+
+  const visibleRuns = runs.filter((r) => !dismissedIds.has(r.id))
+
+  return { runs: visibleRuns, dismiss }
+}


### PR DESCRIPTION
## Summary

- 管理画面でパイプライン実行中の進捗をリアルタイム表示する機能を追加
- Python バックエンドが `pipeline_runs` コレクションに書き込む進捗データを Firestore `onSnapshot` で購読
- 既存の TODO コメント（技術的負債）を解消

## 変更内容

### 型定義・設定（`packages/shared/`）
- `PipelineRun` 型、`PipelineRunStatus`、`PipelineRunType` を追加
- `COLLECTIONS` に `PIPELINE_RUNS` を追加
- `AGENT_NAME_LABELS` を全エージェント（多言語 librarian/scholar/debate, armchair_polymath, translator）に拡充

### カスタムフック（`web-admin/src/hooks/`）
- `usePipelineRuns()`: `status=="running"` の全パイプラインを onSnapshot で監視
- `usePipelineRun(runId)`: 特定ドキュメントを監視（完了/エラー後も最終状態を保持）

### コンポーネント
- `ActivePipelinePanel`: ステータスに応じた表示（スピナー/完了/エラー）、経過時間、現在のエージェント名、PipelineSummary/Timeline の展開/折りたたみ
- `PipelineTimeline`: `theme_analyzer`/`armchair_polymath`/`translator` のアイコン追加 + `getAgentIcon()` ヘルパーで `librarian_en` → `librarian` 等のベース名解決

### ダッシュボード統合（`page.tsx`）
- `handleStartPipeline`/`handlePodcast` で API レスポンスの `run_id` をキャプチャ
- `usePipelineRuns()` + `usePipelineRun(currentRunId)` をマージして表示
- パイプライン完了時に記事一覧を自動更新（`fetchMysteries()`）
- TODO コメント（L126-128）を削除

## 注意事項

- **Firestore 複合インデックス**: `pipeline_runs` で `status` + `started_at` の複合インデックスが必要（初回アクセス時にコンソールにエラーリンクが表示される）
- **Python 側の変更はゼロ**: バックエンドは完全に実装済み

## Test plan

- [ ] Firebase Emulator で `pipeline_runs` ドキュメントを手動追加し、パネルが表示されることを確認
- [ ] `current_agent` フィールド更新時にエージェント名ラベルが即座に反映されることを確認
- [ ] `pipeline_log` への `AgentLogEntry` 追加でタイムラインが更新されることを確認
- [ ] `status` を `"completed"` に変更 → 完了表示 + dismiss ボタンが出ることを確認
- [ ] `status` を `"error"` に変更 → エラーメッセージが表示されることを確認
- [ ] 実パイプライン実行（`python -m mystery_agents "test"`）でリアルタイム更新を確認
- [ ] TypeScript 型チェック: `tsc --noEmit` パス済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)