### PR TITLE
fix: 証拠抜粋テキスト（relevant_excerpt）空表示問題の修正

### DIFF
--- a/mystery_agents/agents/armchair_polymath.py
+++ b/mystery_agents/agents/armchair_polymath.py
@@ -44,6 +44,11 @@ from ..tools.scholar_tools import save_structured_report
 # 5. 統合 Mystery Report を英語で作成
 # 6. save_structured_report を必ず呼び出す
 #
+# ## 重要: evidence の relevant_excerpt は必須
+# すべての evidence オブジェクト（evidence_a, evidence_b, additional_evidence 各項目）には
+# 空でない relevant_excerpt を必ず含めること。具体的な抜粋が見つからない場合は、
+# 元資料の内容を簡潔に言い換えること。空の excerpt は絶対に不可。
+#
 # ## ガード
 # - 全言語の分析が空 → INSUFFICIENT_DATA を出力
 # - 1言語のみ → その結果のみで Master Report 作成
@@ -182,8 +187,26 @@ After completing your analysis, you MUST call `save_structured_report` with a JS
     "relevant_excerpt": "Excerpt",
     "location_context": "Location"
   }},
-  "evidence_b": {{ "..." }},
-  "additional_evidence": [ {{ "..." }} ],
+  "evidence_b": {{
+    "source_type": "newspaper/archive/book",
+    "source_language": "en/de/es/fr/nl/pt",
+    "source_title": "Contrasting source name",
+    "source_date": "YYYY-MM-DD",
+    "source_url": "URL",
+    "relevant_excerpt": "A direct quote or close paraphrase from this source",
+    "location_context": "Location"
+  }},
+  "additional_evidence": [
+    {{
+      "source_type": "newspaper/archive/book",
+      "source_language": "en/de/es/fr/nl/pt",
+      "source_title": "Additional source name",
+      "source_date": "YYYY-MM-DD",
+      "source_url": "URL",
+      "relevant_excerpt": "A direct quote or close paraphrase — NEVER leave empty",
+      "location_context": "Location"
+    }}
+  ],
   "hypothesis": "Primary hypothesis in English",
   "alternative_hypotheses": ["Alt 1", "Alt 2"],
   "confidence_level": "high|medium|low",
@@ -201,6 +224,10 @@ After completing your analysis, you MUST call `save_structured_report` with a JS
 ```
 
 This call is mandatory — do NOT skip it.
+
+**CRITICAL: Every evidence object MUST include a non-empty `relevant_excerpt`.**
+If you cannot find a specific verbatim quote, write a brief paraphrase of the source material.
+NEVER leave `relevant_excerpt` as an empty string — items with empty excerpts will be automatically removed.
 """
 
 armchair_polymath_agent = LlmAgent(

--- a/mystery_agents/tools/publisher_tools.py
+++ b/mystery_agents/tools/publisher_tools.py
@@ -316,10 +316,23 @@ def publish_mystery(
         data.setdefault("additional_evidence", [])
         data["additional_evidence"] = data["additional_evidence"][:5]
 
-        # additional_evidence の source_url 欠落チェック
+        # evidence_a / evidence_b の空 excerpt 警告（除外はしない）
+        for key in ("evidence_a", "evidence_b"):
+            ev = data.get(key)
+            if ev and isinstance(ev, dict):
+                if not ev.get("relevant_excerpt", "").strip():
+                    logger.warning("%s has empty relevant_excerpt, title=%s", key, ev.get("source_title", "unknown"))
+
+        # additional_evidence の source_url 欠落チェック + 空 excerpt フィルタリング
+        filtered_additional = []
         for i, ev in enumerate(data.get("additional_evidence", [])):
             if not ev.get("source_url"):
                 logger.warning("additional_evidence[%d] missing source_url, title=%s", i, ev.get("source_title", "unknown"))
+            if not ev.get("relevant_excerpt", "").strip():
+                logger.warning("additional_evidence[%d] removed (empty relevant_excerpt), title=%s", i, ev.get("source_title", "unknown"))
+                continue
+            filtered_additional.append(ev)
+        data["additional_evidence"] = filtered_additional
         data.setdefault("alternative_hypotheses", [])
         data.setdefault("research_questions", [])
         data.setdefault("story_hooks", [])

--- a/mystery_agents/tools/scholar_tools.py
+++ b/mystery_agents/tools/scholar_tools.py
@@ -463,6 +463,24 @@ def build_analysis_context(filepaths: list[str] | None = None) -> str:
     return json.dumps(analysis_context, ensure_ascii=False, indent=2)
 
 
+def _validate_evidence(evidence: dict, label: str) -> list[str]:
+    """evidence オブジェクトの必須フィールドを検証する。
+
+    Args:
+        evidence: evidence オブジェクト（source_url, relevant_excerpt 等）
+        label: ログ用ラベル（例: "evidence_a", "additional_evidence[0]"）
+
+    Returns:
+        警告メッセージのリスト（問題がなければ空リスト）
+    """
+    warnings: list[str] = []
+    if not evidence.get("relevant_excerpt", "").strip():
+        warnings.append(f"{label}: relevant_excerpt is empty or missing")
+    if not evidence.get("source_url", "").strip():
+        warnings.append(f"{label}: source_url is empty or missing")
+    return warnings
+
+
 def save_structured_report(
     report_json: str,
     tool_context: ToolContext,
@@ -472,6 +490,10 @@ def save_structured_report(
     Called by the Scholar Agent after completing analysis to store
     structured data (evidence, hypothesis, etc.) directly in session
     state, bypassing LLM text interpretation for downstream agents.
+
+    evidence バリデーション:
+    - evidence_a / evidence_b: 空 excerpt は警告のみ（構造上必須のため除外しない）
+    - additional_evidence: 空 excerpt の項目はフィルタリング（除外）
 
     Args:
         report_json: JSON string containing the structured report with fields:
@@ -494,7 +516,7 @@ def save_structured_report(
         tool_context: ADK tool context for session state access.
 
     Returns:
-        JSON string with save status.
+        JSON string with save status and warnings.
     """
     try:
         report_data = json.loads(report_json)
@@ -504,6 +526,31 @@ def save_structured_report(
             ensure_ascii=False,
         )
 
+    # evidence バリデーション
+    warnings: list[str] = []
+
+    # evidence_a / evidence_b: 警告のみ（構造上必須のため除外しない）
+    for key in ("evidence_a", "evidence_b"):
+        ev = report_data.get(key)
+        if ev and isinstance(ev, dict):
+            warnings.extend(_validate_evidence(ev, key))
+
+    # additional_evidence: 空 excerpt の項目をフィルタリング
+    additional = report_data.get("additional_evidence")
+    if additional and isinstance(additional, list):
+        filtered = []
+        for i, ev in enumerate(additional):
+            if not isinstance(ev, dict):
+                continue
+            excerpt = ev.get("relevant_excerpt", "").strip()
+            if excerpt:
+                filtered.append(ev)
+            else:
+                warnings.append(
+                    f"additional_evidence[{i}]: removed (empty relevant_excerpt)"
+                )
+        report_data["additional_evidence"] = filtered
+
     # Store structured report in session state
     tool_context.state["structured_report"] = report_data
 
@@ -512,6 +559,7 @@ def save_structured_report(
             "status": "success",
             "message": "Structured report saved to session state",
             "fields_saved": list(report_data.keys()),
+            "warnings": warnings,
         },
         ensure_ascii=False,
     )

--- a/packages/shared/src/components/evidence-block.tsx
+++ b/packages/shared/src/components/evidence-block.tsx
@@ -23,6 +23,10 @@ export function EvidenceBlock({ evidence, label, translatedExcerpt, labels, clas
   const viewLabel = labels?.view ?? "View"
   const originalTextLabel = labels?.originalText ?? "Original text"
 
+  // 空 excerpt のフォールバック: テキスト部分を非表示にする（既存 Firestore データ対応）
+  const hasExcerpt = !!evidence.relevant_excerpt?.trim()
+  const hasTranslatedExcerpt = !!translatedExcerpt?.trim()
+
   return (
     <figure className={cn("relative group", className)}>
       {label && (
@@ -42,36 +46,43 @@ export function EvidenceBlock({ evidence, label, translatedExcerpt, labels, clas
 
         {/* Date badge + Quote marks row */}
         <div className="flex items-start justify-between mb-1">
-          <div className="text-4xl text-parchment/20 font-serif leading-none" aria-hidden="true">
-            &ldquo;
-          </div>
+          {(hasExcerpt || hasTranslatedExcerpt) && (
+            <div className="text-4xl text-parchment/20 font-serif leading-none" aria-hidden="true">
+              &ldquo;
+            </div>
+          )}
           {evidence.source_date && (
-            <div className="px-2 py-0.5 bg-blood-red/20 border border-blood-red/30 rounded-sm shrink-0">
+            <div className={cn(
+              "px-2 py-0.5 bg-blood-red/20 border border-blood-red/30 rounded-sm shrink-0",
+              !(hasExcerpt || hasTranslatedExcerpt) && "ml-auto"
+            )}>
               <span className="text-xs font-mono text-[#ff6b6b]">{evidence.source_date}</span>
             </div>
           )}
         </div>
 
-        {/* Evidence text: 翻訳があればメインに、原文はサブに */}
-        {translatedExcerpt ? (
+        {/* Evidence text: 翻訳があればメインに、原文はサブに。空 excerpt は非表示。 */}
+        {hasTranslatedExcerpt ? (
           <div className="relative pl-6">
             <p className="text-sm text-foreground/90 leading-relaxed font-mono whitespace-pre-wrap">
               {translatedExcerpt}
             </p>
-            <div className="mt-3 pt-3 border-t border-border/30">
-              <p className="text-xs text-muted-foreground/60 mb-1 font-mono uppercase tracking-wider">
-                {originalTextLabel}
-              </p>
-              <p className="text-xs text-foreground/50 leading-relaxed font-mono whitespace-pre-wrap">
-                {evidence.relevant_excerpt}
-              </p>
-            </div>
+            {hasExcerpt && (
+              <div className="mt-3 pt-3 border-t border-border/30">
+                <p className="text-xs text-muted-foreground/60 mb-1 font-mono uppercase tracking-wider">
+                  {originalTextLabel}
+                </p>
+                <p className="text-xs text-foreground/50 leading-relaxed font-mono whitespace-pre-wrap">
+                  {evidence.relevant_excerpt}
+                </p>
+              </div>
+            )}
           </div>
-        ) : (
+        ) : hasExcerpt ? (
           <p className="relative text-sm text-foreground/90 leading-relaxed pl-6 font-mono whitespace-pre-wrap">
             {evidence.relevant_excerpt}
           </p>
-        )}
+        ) : null}
       </blockquote>
 
       {/* Source citation */}

--- a/tests/unit/test_publisher_tools.py
+++ b/tests/unit/test_publisher_tools.py
@@ -635,3 +635,94 @@ class TestCleanupTempImages:
 
         assert "Failed to delete temp image" in caplog.text
 
+
+class TestPublishMysteryEvidenceFiltering:
+    """Tests for evidence excerpt validation in publish_mystery()."""
+
+    @patch("mystery_agents.tools.publisher_tools.get_storage_bucket")
+    @patch("mystery_agents.tools.publisher_tools.get_firestore_client")
+    def test_empty_excerpt_additional_evidence_filtered(
+        self, mock_get_db, mock_get_bucket
+    ):
+        """additional_evidence の空 excerpt は除外される。"""
+        mock_db = MagicMock()
+        mock_get_db.return_value = mock_db
+        mock_bucket = MagicMock()
+        mock_get_bucket.return_value = mock_bucket
+
+        mystery_json = _make_mystery_json(
+            additional_evidence=[
+                {"source_url": "https://a.com", "relevant_excerpt": "Good"},
+                {"source_url": "https://b.com", "relevant_excerpt": ""},
+                {"source_url": "https://c.com", "relevant_excerpt": "Also good"},
+            ]
+        )
+
+        result = publish_mystery(mystery_json, "")
+        result_data = json.loads(result)
+        assert result_data["status"] == "success"
+
+        saved = mock_db.collection.return_value.document.return_value.set.call_args[0][0]
+        assert len(saved["additional_evidence"]) == 2
+        assert all(ev["relevant_excerpt"] for ev in saved["additional_evidence"])
+
+    @patch("mystery_agents.tools.publisher_tools.get_storage_bucket")
+    @patch("mystery_agents.tools.publisher_tools.get_firestore_client")
+    def test_valid_additional_evidence_preserved(
+        self, mock_get_db, mock_get_bucket
+    ):
+        """正常な additional_evidence はそのまま保持される。"""
+        mock_db = MagicMock()
+        mock_get_db.return_value = mock_db
+        mock_bucket = MagicMock()
+        mock_get_bucket.return_value = mock_bucket
+
+        mystery_json = _make_mystery_json(
+            additional_evidence=[
+                {"source_url": "https://a.com", "relevant_excerpt": "Excerpt 1"},
+                {"source_url": "https://b.com", "relevant_excerpt": "Excerpt 2"},
+            ]
+        )
+
+        result = publish_mystery(mystery_json, "")
+        result_data = json.loads(result)
+        assert result_data["status"] == "success"
+
+        saved = mock_db.collection.return_value.document.return_value.set.call_args[0][0]
+        assert len(saved["additional_evidence"]) == 2
+
+    @patch("mystery_agents.tools.publisher_tools.get_storage_bucket")
+    @patch("mystery_agents.tools.publisher_tools.get_firestore_client")
+    def test_empty_excerpt_evidence_a_warns_but_saves(
+        self, mock_get_db, mock_get_bucket, caplog
+    ):
+        """evidence_a の excerpt が空でも警告のみで保存される。"""
+        mock_db = MagicMock()
+        mock_get_db.return_value = mock_db
+        mock_bucket = MagicMock()
+        mock_get_bucket.return_value = mock_bucket
+
+        mystery_json = _make_mystery_json(
+            evidence_a={
+                "source_type": "newspaper",
+                "source_language": "en",
+                "source_title": "Test",
+                "source_date": "1842-01-01",
+                "source_url": "https://example.com",
+                "relevant_excerpt": "",
+                "location_context": "Boston",
+            }
+        )
+
+        with caplog.at_level(logging.WARNING, logger="mystery_agents.tools.publisher_tools"):
+            result = publish_mystery(mystery_json, "")
+
+        result_data = json.loads(result)
+        assert result_data["status"] == "success"
+
+        saved = mock_db.collection.return_value.document.return_value.set.call_args[0][0]
+        # evidence_a は除外されない
+        assert "evidence_a" in saved
+        # 警告ログが出力されている
+        assert any("evidence_a" in r.message and "relevant_excerpt" in r.message for r in caplog.records)
+

--- a/tests/unit/test_scholar_tools.py
+++ b/tests/unit/test_scholar_tools.py
@@ -6,7 +6,10 @@ Tests for saving structured analysis reports to session state via tool_context.
 import json
 from unittest.mock import MagicMock
 
-from mystery_agents.tools.scholar_tools import save_structured_report
+from mystery_agents.tools.scholar_tools import (
+    _validate_evidence,
+    save_structured_report,
+)
 
 
 class TestSaveStructuredReport:
@@ -135,3 +138,184 @@ class TestSaveStructuredReport:
         assert saved["evidence_b"]["source_language"] == "es"
         assert saved["historical_context"]["geographic_scope"] == ["Boston", "Havana"]
         assert saved["classification"] == "OCC"
+
+
+class TestValidateEvidence:
+    """Tests for _validate_evidence() helper."""
+
+    def test_valid_evidence_returns_no_warnings(self):
+        """正常な evidence は警告なし。"""
+        evidence = {
+            "source_url": "https://example.com",
+            "relevant_excerpt": "The vessel departed Boston Harbor...",
+        }
+        warnings = _validate_evidence(evidence, "evidence_a")
+        assert warnings == []
+
+    def test_empty_excerpt_returns_warning(self):
+        """relevant_excerpt が空文字 → 警告。"""
+        evidence = {
+            "source_url": "https://example.com",
+            "relevant_excerpt": "",
+        }
+        warnings = _validate_evidence(evidence, "evidence_a")
+        assert len(warnings) == 1
+        assert "relevant_excerpt" in warnings[0]
+
+    def test_missing_excerpt_returns_warning(self):
+        """relevant_excerpt キーがない → 警告。"""
+        evidence = {
+            "source_url": "https://example.com",
+        }
+        warnings = _validate_evidence(evidence, "evidence_b")
+        assert len(warnings) == 1
+        assert "relevant_excerpt" in warnings[0]
+
+    def test_empty_source_url_returns_warning(self):
+        """source_url が空文字 → 警告。"""
+        evidence = {
+            "source_url": "",
+            "relevant_excerpt": "Some text",
+        }
+        warnings = _validate_evidence(evidence, "evidence_a")
+        assert len(warnings) == 1
+        assert "source_url" in warnings[0]
+
+    def test_missing_source_url_returns_warning(self):
+        """source_url キーがない → 警告。"""
+        evidence = {
+            "relevant_excerpt": "Some text",
+        }
+        warnings = _validate_evidence(evidence, "evidence_a")
+        assert len(warnings) == 1
+        assert "source_url" in warnings[0]
+
+    def test_both_empty_returns_two_warnings(self):
+        """両方空 → 警告2件。"""
+        evidence = {
+            "source_url": "",
+            "relevant_excerpt": "",
+        }
+        warnings = _validate_evidence(evidence, "evidence_a")
+        assert len(warnings) == 2
+
+    def test_whitespace_only_excerpt_returns_warning(self):
+        """空白のみの excerpt → 警告。"""
+        evidence = {
+            "source_url": "https://example.com",
+            "relevant_excerpt": "   ",
+        }
+        warnings = _validate_evidence(evidence, "evidence_a")
+        assert len(warnings) == 1
+        assert "relevant_excerpt" in warnings[0]
+
+
+class TestSaveStructuredReportEvidenceValidation:
+    """Tests for evidence validation in save_structured_report()."""
+
+    def test_empty_excerpt_in_evidence_a_warns_but_saves(self):
+        """evidence_a の excerpt が空 → 警告付きで保存される。"""
+        report_data = {
+            "title": "Test",
+            "evidence_a": {
+                "source_url": "https://example.com",
+                "relevant_excerpt": "",
+            },
+            "evidence_b": {
+                "source_url": "https://example.com/b",
+                "relevant_excerpt": "Valid excerpt",
+            },
+        }
+        mock_ctx = MagicMock()
+        mock_ctx.state = {}
+
+        result = save_structured_report(json.dumps(report_data), mock_ctx)
+        result_data = json.loads(result)
+
+        assert result_data["status"] == "success"
+        assert len(result_data["warnings"]) > 0
+        # evidence_a は除外されない（構造上必須）
+        assert "evidence_a" in mock_ctx.state["structured_report"]
+
+    def test_empty_excerpt_in_additional_evidence_filtered_out(self):
+        """additional_evidence の excerpt が空 → フィルタリングされる。"""
+        report_data = {
+            "title": "Test",
+            "evidence_a": {
+                "source_url": "https://example.com",
+                "relevant_excerpt": "Valid",
+            },
+            "additional_evidence": [
+                {
+                    "source_url": "https://example.com/1",
+                    "relevant_excerpt": "Good excerpt",
+                },
+                {
+                    "source_url": "https://example.com/2",
+                    "relevant_excerpt": "",
+                },
+                {
+                    "source_url": "https://example.com/3",
+                    "relevant_excerpt": "Another good one",
+                },
+            ],
+        }
+        mock_ctx = MagicMock()
+        mock_ctx.state = {}
+
+        result = save_structured_report(json.dumps(report_data), mock_ctx)
+        result_data = json.loads(result)
+
+        assert result_data["status"] == "success"
+        saved = mock_ctx.state["structured_report"]
+        # 空 excerpt の項目がフィルタリングされて2件のみ
+        assert len(saved["additional_evidence"]) == 2
+        assert all(
+            ev["relevant_excerpt"] for ev in saved["additional_evidence"]
+        )
+
+    def test_all_additional_evidence_empty_results_in_empty_list(self):
+        """全 additional_evidence が空 excerpt → 空リスト。"""
+        report_data = {
+            "title": "Test",
+            "additional_evidence": [
+                {"source_url": "https://a.com", "relevant_excerpt": ""},
+                {"source_url": "https://b.com", "relevant_excerpt": "  "},
+            ],
+        }
+        mock_ctx = MagicMock()
+        mock_ctx.state = {}
+
+        result = save_structured_report(json.dumps(report_data), mock_ctx)
+        result_data = json.loads(result)
+
+        assert result_data["status"] == "success"
+        assert mock_ctx.state["structured_report"]["additional_evidence"] == []
+
+    def test_valid_report_has_no_warnings(self):
+        """全 evidence が正常 → warnings 空リスト。"""
+        report_data = {
+            "title": "Test",
+            "evidence_a": {
+                "source_url": "https://example.com",
+                "relevant_excerpt": "Excerpt A",
+            },
+            "evidence_b": {
+                "source_url": "https://example.com/b",
+                "relevant_excerpt": "Excerpt B",
+            },
+            "additional_evidence": [
+                {
+                    "source_url": "https://example.com/c",
+                    "relevant_excerpt": "Excerpt C",
+                },
+            ],
+        }
+        mock_ctx = MagicMock()
+        mock_ctx.state = {}
+
+        result = save_structured_report(json.dumps(report_data), mock_ctx)
+        result_data = json.loads(result)
+
+        assert result_data["status"] == "success"
+        assert result_data["warnings"] == []


### PR DESCRIPTION
## Summary

- `save_structured_report` に `_validate_evidence` ヘルパーを追加し、`additional_evidence` の空 `relevant_excerpt` をフィルタリング（evidence_a/b は警告のみ）
- Armchair Polymath プロンプトの JSON 例で `evidence_b` と `additional_evidence` を省略表記から完全な例に展開し、`relevant_excerpt` 必須ルールを明示
- Publisher にも防御的バリデーション追加（空 excerpt の `additional_evidence` 除外 + evidence_a/b 警告ログ）
- EvidenceBlock コンポーネントで空 excerpt 時にテキスト部分を非表示にするフォールバック（既存 Firestore データ対応）

## 原因

`save_structured_report` にバリデーションがなく、LLM 出力をそのまま session state → Firestore に保存していた。さらに Armchair Polymath プロンプトの JSON 例で `evidence_b` と `additional_evidence` が省略表記（`{ "..." }`）のため、LLM が `relevant_excerpt` を省略しがちだった。

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `mystery_agents/tools/scholar_tools.py` | `_validate_evidence` + フィルタリング |
| `mystery_agents/agents/armchair_polymath.py` | プロンプト JSON 例展開 + 必須ルール追加 |
| `mystery_agents/tools/publisher_tools.py` | 防御的フィルタリング |
| `packages/shared/src/components/evidence-block.tsx` | 空 excerpt フォールバック |
| `tests/unit/test_scholar_tools.py` | バリデーションテスト追加（+11テスト） |
| `tests/unit/test_publisher_tools.py` | フィルタリングテスト追加（+3テスト） |

## Test plan

- [x] `pytest tests/unit/test_scholar_tools.py -v` — 16 passed
- [x] `pytest tests/unit/test_publisher_tools.py -v` — 27 passed
- [x] `pytest tests/unit/ -v` — 357 passed（全テスト回帰なし）
- [ ] パイプライン実行で Firestore データの `relevant_excerpt` が空でないことを確認
- [ ] web-public で既存記事の evidence ブロックに空テキストがないことを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)