### PR TITLE
fix: dev モード言語切り替えハング問題の修正 + preview コマンド追加

### DIFF
--- a/packages/shared/src/lib/firebase/config.ts
+++ b/packages/shared/src/lib/firebase/config.ts
@@ -17,34 +17,33 @@ const firebaseConfig = {
   appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
 };
 
-/** Firebaseアプリインスタンス（シングルトン） */
-let app: FirebaseApp;
-
-/** Firestoreインスタンス（シングルトン） */
-let db: Firestore;
-
-/** Storageインスタンス（シングルトン） */
-let storageInstance: FirebaseStorage;
-
-/** エミュレータ接続済みフラグ */
-let emulatorConnected = false;
-let storageEmulatorConnected = false;
+/**
+ * globalThis にインスタンスを保持することで、
+ * Next.js dev + Turbopack のモジュール再評価でもシングルトンを維持する
+ */
+const globalForFirebase = globalThis as unknown as {
+  _firebaseApp?: FirebaseApp;
+  _firestoreDb?: Firestore;
+  _firebaseStorage?: FirebaseStorage;
+  _firestoreEmulatorConnected?: boolean;
+  _storageEmulatorConnected?: boolean;
+};
 
 /**
  * Firebaseアプリを初期化して返す
  * 既に初期化済みの場合は既存のインスタンスを返す
  */
 export function getFirebaseApp(): FirebaseApp {
-  if (!app) {
+  if (!globalForFirebase._firebaseApp) {
     // 既存のアプリがあれば再利用、なければ新規作成
     const existingApps = getApps();
     if (existingApps.length > 0) {
-      app = existingApps[0];
+      globalForFirebase._firebaseApp = existingApps[0];
     } else {
-      app = initializeApp(firebaseConfig);
+      globalForFirebase._firebaseApp = initializeApp(firebaseConfig);
     }
   }
-  return app;
+  return globalForFirebase._firebaseApp;
 }
 
 /**
@@ -52,26 +51,26 @@ export function getFirebaseApp(): FirebaseApp {
  * 開発環境ではエミュレータに接続
  */
 export function getFirestoreDb(): Firestore {
-  if (!db) {
+  if (!globalForFirebase._firestoreDb) {
     const firebaseApp = getFirebaseApp();
-    db = getFirestore(firebaseApp);
+    globalForFirebase._firestoreDb = getFirestore(firebaseApp);
 
     // 開発環境でエミュレータを使用する場合（クライアント・サーバー両方）
     if (
       process.env.NEXT_PUBLIC_USE_FIREBASE_EMULATOR === "true" &&
-      !emulatorConnected
+      !globalForFirebase._firestoreEmulatorConnected
     ) {
       const host = process.env.NEXT_PUBLIC_FIREBASE_EMULATOR_HOST || "localhost";
       const port = parseInt(
         process.env.NEXT_PUBLIC_FIRESTORE_EMULATOR_PORT || "8080",
         10
       );
-      connectFirestoreEmulator(db, host, port);
-      emulatorConnected = true;
+      connectFirestoreEmulator(globalForFirebase._firestoreDb, host, port);
+      globalForFirebase._firestoreEmulatorConnected = true;
       console.log(`[Firebase] Firestore Emulator に接続: ${host}:${port}`);
     }
   }
-  return db;
+  return globalForFirebase._firestoreDb;
 }
 
 /**
@@ -79,25 +78,25 @@ export function getFirestoreDb(): Firestore {
  * 開発環境ではエミュレータに接続
  */
 export function getFirebaseStorage(): FirebaseStorage {
-  if (!storageInstance) {
+  if (!globalForFirebase._firebaseStorage) {
     const firebaseApp = getFirebaseApp();
-    storageInstance = getStorage(firebaseApp);
+    globalForFirebase._firebaseStorage = getStorage(firebaseApp);
 
     if (
       process.env.NEXT_PUBLIC_USE_FIREBASE_EMULATOR === "true" &&
-      !storageEmulatorConnected
+      !globalForFirebase._storageEmulatorConnected
     ) {
       const host = process.env.NEXT_PUBLIC_FIREBASE_EMULATOR_HOST || "localhost";
       const port = parseInt(
         process.env.NEXT_PUBLIC_STORAGE_EMULATOR_PORT || "9199",
         10
       );
-      connectStorageEmulator(storageInstance, host, port);
-      storageEmulatorConnected = true;
+      connectStorageEmulator(globalForFirebase._firebaseStorage, host, port);
+      globalForFirebase._storageEmulatorConnected = true;
       console.log(`[Firebase] Storage Emulator に接続: ${host}:${port}`);
     }
   }
-  return storageInstance;
+  return globalForFirebase._firebaseStorage;
 }
 
 /**

--- a/web-public/package.json
+++ b/web-public/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "npx serve out",
-    "preview": "next build && npx serve out",
+    "preview": "next build && npx serve out -l 3000",
     "lint": "eslint"
   },
   "dependencies": {

--- a/web-public/src/app/[lang]/loading.tsx
+++ b/web-public/src/app/[lang]/loading.tsx
@@ -1,0 +1,37 @@
+/**
+ * トップページのローディング UI
+ * 言語切り替え時のページ遷移中に表示される
+ */
+export default function HomeLoading() {
+  return (
+    <div className="min-h-screen flex flex-col film-grain">
+      {/* Header skeleton */}
+      <div className="h-16 border-b border-border/50" />
+
+      <main className="flex-1">
+        {/* Hero skeleton */}
+        <div className="py-16 md:py-24 text-center">
+          <div className="h-6 w-64 bg-muted/20 rounded-sm mx-auto mb-4 animate-pulse" />
+          <div className="h-12 w-96 bg-muted/20 rounded-sm mx-auto mb-6 animate-pulse" />
+          <div className="h-4 w-80 bg-muted/15 rounded-sm mx-auto animate-pulse" />
+        </div>
+
+        {/* Mystery cards skeleton */}
+        <section className="py-16 md:py-24">
+          <div className="container mx-auto px-4">
+            <div className="h-8 w-64 bg-muted/20 rounded-sm mb-12 animate-pulse" />
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+              {[...Array(6)].map((_, i) => (
+                <div key={i} className="border border-border rounded-sm p-6 space-y-4 animate-pulse">
+                  <div className="h-5 w-3/4 bg-muted/20 rounded-sm" />
+                  <div className="h-4 w-full bg-muted/15 rounded-sm" />
+                  <div className="h-4 w-2/3 bg-muted/15 rounded-sm" />
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+  )
+}

--- a/web-public/src/app/[lang]/mystery/[id]/loading.tsx
+++ b/web-public/src/app/[lang]/mystery/[id]/loading.tsx
@@ -1,0 +1,45 @@
+/**
+ * 記事詳細ページのローディング UI
+ * 言語切り替え時のページ遷移中に表示される
+ */
+export default function MysteryDetailLoading() {
+  return (
+    <div className="min-h-screen flex flex-col film-grain">
+      {/* Header skeleton */}
+      <div className="h-16 border-b border-border/50" />
+
+      <main className="flex-1 py-8 md:py-12">
+        <div className="container mx-auto px-4">
+          {/* Back link skeleton */}
+          <div className="h-5 w-40 bg-muted/20 rounded-sm mb-8 animate-pulse" />
+
+          {/* Case file header skeleton */}
+          <div className="mb-12">
+            <div className="flex items-center gap-3 mb-6">
+              <div className="h-8 w-48 bg-muted/20 rounded-sm animate-pulse" />
+            </div>
+            <div className="h-10 w-3/4 bg-muted/20 rounded-sm mb-4 animate-pulse" />
+            <div className="h-6 w-1/2 bg-muted/20 rounded-sm animate-pulse" />
+          </div>
+
+          {/* Hero image skeleton */}
+          <div className="mb-12 rounded-sm border border-border aspect-video bg-muted/10 animate-pulse" />
+
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 lg:gap-12">
+            {/* Main content skeleton */}
+            <div className="lg:col-span-2 space-y-6">
+              {[...Array(8)].map((_, i) => (
+                <div key={i} className="h-4 bg-muted/15 rounded-sm animate-pulse" style={{ width: `${85 + Math.random() * 15}%` }} />
+              ))}
+            </div>
+
+            {/* Sidebar skeleton */}
+            <div className="lg:col-span-1">
+              <div className="h-48 bg-muted/10 rounded-sm animate-pulse" />
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/web-public/src/components/language-switcher.tsx
+++ b/web-public/src/components/language-switcher.tsx
@@ -57,6 +57,7 @@ export function LanguageSwitcher({ currentLang }: LanguageSwitcherProps) {
             <Link
               key={lang}
               href={getPathForLang(lang)}
+              prefetch={false}
               onClick={() => handleSelect(lang)}
               className={`block px-4 py-2 text-sm no-underline transition-colors ${
                 lang === currentLang


### PR DESCRIPTION
## Summary
- `next dev` での言語切り替え時にハング（rendering 表示のまま停止）する問題を緩和
- `npm run preview` で SSG ビルド → 静的配信による多言語確認を可能に

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `packages/shared/src/lib/firebase/config.ts` | `globalThis` でシングルトン維持（Turbopack モジュール再評価対策） |
| `web-public/src/components/language-switcher.tsx` | `prefetch={false}` 追加（不要なプリフェッチ抑止） |
| `web-public/src/app/[lang]/loading.tsx` | トップページ用スケルトン UI 新規追加 |
| `web-public/src/app/[lang]/mystery/[id]/loading.tsx` | 記事詳細用スケルトン UI 新規追加 |
| `web-public/package.json` | `preview` スクリプトにポート 3000 指定追加 |

## 使い分け
- **`npm run dev`**: コード編集 + HMR（通常の開発）
- **`npm run preview`**: 多言語の表示確認（SSG ビルド → 静的配信、言語切り替え瞬時）

## Test plan
- [x] `pytest tests/unit/ -v` 全 370 テスト通過
- [ ] Firebase Emulator 起動中に `npm run preview` 実行 → ビルド成功
- [ ] `http://localhost:3000` にアクセス → 全7言語を連続切り替え → ハングなし
- [ ] `next dev` でも言語切り替え時にスケルトン UI が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)