### PR TITLE
fix: 記事詳細ページのタイトル重複 + 画像非表示を修正

### DIFF
--- a/mystery_agents/tools/publisher_tools.py
+++ b/mystery_agents/tools/publisher_tools.py
@@ -168,11 +168,15 @@ def _upload_images_internal(mystery_id: str, image_paths: list[str]) -> dict:
             continue
 
         # Build public URL (use STORAGE_EMULATOR_PUBLIC_HOST for browser-accessible URL)
+        # 本番: Firebase Storage REST API 形式（セキュリティルール allow read: if true が適用される）
         storage_public_host = os.environ.get("STORAGE_EMULATOR_PUBLIC_HOST", "") or os.environ.get("STORAGE_EMULATOR_HOST", "")
         if storage_public_host:
             public_url = f"{storage_public_host}/v0/b/{bucket.name}/o/{blob_name.replace('/', '%2F')}?alt=media"
         else:
-            public_url = f"https://storage.googleapis.com/{bucket.name}/{blob_name}"
+            public_url = (
+                f"https://firebasestorage.googleapis.com/v0/b/{bucket.name}"
+                f"/o/{blob_name.replace('/', '%2F')}?alt=media"
+            )
 
         lbl = variant_suffix.lstrip("_") if variant_suffix else "original"
         if lbl == "original":
@@ -348,6 +352,16 @@ def publish_mystery(
             except Exception as e:
                 logger.error("Image upload failed, continuing without images: %s", e)
 
+        # 画像処理結果の診断ログ
+        if "images" in data:
+            logger.info("Images prepared: hero=%s, variants=%s",
+                        data["images"].get("hero", "MISSING"),
+                        list(data["images"].get("variants", {}).keys()))
+        else:
+            logger.warning("No images attached. image_metadata=%s, visual_assets_json=%s",
+                           type(image_source).__name__ if image_source else "None",
+                           "provided" if visual_assets_json and visual_assets_json.strip() else "empty")
+
         now = datetime.now(timezone.utc)
 
         # Set timestamps and status
@@ -458,11 +472,15 @@ def upload_images(mystery_id: str, image_paths: str) -> str:
 
             # エミュレータではmake_public()が使えないため、URLを直接構築
             # STORAGE_EMULATOR_PUBLIC_HOST: ブラウザからアクセス可能なURL用ホスト
+            # 本番: Firebase Storage REST API 形式（セキュリティルール allow read: if true が適用される）
             storage_public_host = os.environ.get("STORAGE_EMULATOR_PUBLIC_HOST", "") or os.environ.get("STORAGE_EMULATOR_HOST", "")
             if storage_public_host:
                 public_url = f"{storage_public_host}/v0/b/{bucket.name}/o/{blob_name.replace('/', '%2F')}?alt=media"
             else:
-                public_url = f"https://storage.googleapis.com/{bucket.name}/{blob_name}"
+                public_url = (
+                    f"https://firebasestorage.googleapis.com/v0/b/{bucket.name}"
+                    f"/o/{blob_name.replace('/', '%2F')}?alt=media"
+                )
 
             uploaded.append({
                 "path": local_path,

--- a/packages/shared/src/lib/utils.ts
+++ b/packages/shared/src/lib/utils.ts
@@ -4,3 +4,12 @@ import { twMerge } from 'tailwind-merge'
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * マークダウン先頭の H1 見出し（# Title）を除去する。
+ * CaseFileHeader の <h1> と narrative_content の H1 が重複するのを防ぐ。
+ * H2 以下（## Subtitle 等）は除去しない。
+ */
+export function stripLeadingH1(markdown: string): string {
+  return markdown.replace(/^\s*#\s+[^\n]*\n*/, "")
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -203,7 +203,7 @@ def mock_storage_bucket():
     mock_bucket.blob.return_value = mock_blob
     mock_blob.upload_from_filename.return_value = None
     mock_blob.make_public.return_value = None
-    mock_blob.public_url = "https://storage.googleapis.com/test-bucket/image.png"
+    mock_blob.public_url = "https://firebasestorage.googleapis.com/v0/b/test-bucket/o/image.png?alt=media"
 
     return mock_bucket
 

--- a/web-admin/src/app/(main)/preview/[id]/preview-content.tsx
+++ b/web-admin/src/app/(main)/preview/[id]/preview-content.tsx
@@ -20,6 +20,7 @@ import {
 } from "lucide-react"
 import Markdown from "react-markdown"
 import remarkGfm from "remark-gfm"
+import { stripLeadingH1 } from "@ghost/shared/src/lib/utils"
 
 /**
  * Date は Server→Client シリアライズで string になるため、
@@ -162,7 +163,7 @@ export function PreviewContent({ mystery }: PreviewContentProps) {
               {narrativeContent ? (
                 <section className="prose prose-lg prose-invert max-w-none prose-headings:font-serif prose-headings:text-parchment prose-headings:mt-12 prose-headings:mb-4 prose-p:text-foreground/90 prose-p:leading-loose prose-p:mb-6 prose-a:text-gold prose-blockquote:border-gold/30 prose-blockquote:bg-card prose-blockquote:px-6 prose-blockquote:py-4 prose-blockquote:rounded-sm prose-blockquote:text-foreground/70 prose-blockquote:italic prose-blockquote:font-serif prose-strong:text-parchment prose-hr:border-border">
                   <Markdown remarkPlugins={[remarkGfm]}>
-                    {narrativeContent.replace(/\*\*(.+?)\*\*/g, ' **$1** ')}
+                    {stripLeadingH1(narrativeContent).replace(/\*\*(.+?)\*\*/g, ' **$1** ')}
                   </Markdown>
                 </section>
               ) : (

--- a/web-public/src/components/mystery/narrative-section.tsx
+++ b/web-public/src/components/mystery/narrative-section.tsx
@@ -1,5 +1,6 @@
 import Markdown from "react-markdown"
 import remarkGfm from "remark-gfm"
+import { stripLeadingH1 } from "@ghost/shared/src/lib/utils"
 
 interface NarrativeSectionProps {
   narrativeContent?: string
@@ -11,7 +12,7 @@ export function NarrativeSection({ narrativeContent, summary }: NarrativeSection
     return (
       <section className="prose prose-lg prose-invert max-w-none prose-headings:font-serif prose-headings:text-parchment prose-headings:mt-12 prose-headings:mb-4 prose-p:text-foreground/90 prose-p:leading-loose prose-p:mb-6 prose-a:text-gold prose-blockquote:border-gold/30 prose-blockquote:bg-card prose-blockquote:px-6 prose-blockquote:py-4 prose-blockquote:rounded-sm prose-blockquote:text-foreground/70 prose-blockquote:italic prose-blockquote:font-serif prose-strong:text-parchment prose-hr:border-border">
         <Markdown remarkPlugins={[remarkGfm]}>
-          {narrativeContent.replace(/\*\*(.+?)\*\*/g, ' **$1** ')}
+          {stripLeadingH1(narrativeContent).replace(/\*\*(.+?)\*\*/g, ' **$1** ')}
         </Markdown>
       </section>
     )


### PR DESCRIPTION
## Summary
- **タイトル重複の解消**: `stripLeadingH1()` を `@ghost/shared` に追加し、`narrative_content` 先頭の `# Title` を除去。CaseFileHeader の `<h1>` との重複を解消（web-public / web-admin 両方に適用）
- **画像非表示の修正**: Publisher の画像 URL を `storage.googleapis.com` → `firebasestorage.googleapis.com` 形式に変更。Firebase Security Rules（`allow read: if true`）が適用される形式にすることで 403 エラーを解消
- **診断ログ追加**: `publish_mystery()` 内に画像処理結果の診断ログを追加（デバッグ支援）

## 修正対象ファイル
| ファイル | 変更内容 |
|---------|---------|
| `packages/shared/src/lib/utils.ts` | `stripLeadingH1()` 追加 |
| `web-public/src/components/mystery/narrative-section.tsx` | `stripLeadingH1()` 適用 |
| `web-admin/src/app/(main)/preview/[id]/preview-content.tsx` | `stripLeadingH1()` 適用 |
| `mystery_agents/tools/publisher_tools.py` | URL形式変更（2箇所） + 診断ログ追加 |
| `tests/conftest.py` | mock URL を新形式に更新 |

## 注意事項
- この修正は **今後の新規記事** に適用される
- 既存記事の `images.hero` URL（`storage.googleapis.com` 形式）は手動更新または再パブリッシュが必要

## Test plan
- [x] `pytest tests/unit/ -v` — 全 370 件パス
- [ ] ローカル dev サーバーで記事詳細を確認 → タイトルが1回のみ表示
- [ ] 管理画面プレビューで画像表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)