### PR TITLE
feat: Curator テーマ多様性改善 — カテゴリバランス + 地理的分散

### DIFF
--- a/curator_agents/agents/curator.py
+++ b/curator_agents/agents/curator.py
@@ -6,6 +6,7 @@ overlap with existing mysteries.
 """
 
 from google.adk.agents import LlmAgent
+from google.genai import types
 
 from shared.model_config import create_pro_model
 
@@ -17,12 +18,45 @@ from shared.model_config import create_pro_model
 # 本プロジェクトは **歴史的事実（Fact）** と **民俗学的怪異・伝説（Folklore）** を融合させた
 # ナラティブを生成します。提案するテーマもこの Fact × Folklore のハイブリッドであるべきです。
 #
+# ## カテゴリバランス
+# 各テーマには以下の8分類コードのいずれかが対応します：
+# - HIS（歴史）: 歴史的記録の矛盾、消失した人物、文書の欠落
+# - FLK（民俗）: 地方伝承、祭り、口承伝統、民間信仰
+# - ANT（人類学）: 儀礼、社会構造、物質文化、異文化接触
+# - OCC（怪奇）: 説明不能な現象、超常的事象
+# - URB（都市伝説）: 近代の噂話、現代の怪談
+# - CRM（未解決事件）: 未解決犯罪、失踪事件、謎の死
+# - REL（信仰・禁忌）: 宗教的タブー、呪い、カルト
+# - LOC（地霊・場所）: 特定の場所に紐づく怪異、心霊スポット
+#
+# 現在のカテゴリ分布:
+# {category_distribution}
+#
+# 過小表現のカテゴリを優先してください。
+#
+# ## 地理的多様性
+# - **優先地域（東海岸）**: ボストン、ニューヨーク、フィラデルフィア、バルチモア、
+#   チャールストン、サバンナ、ニューオーリンズ
+# - **推奨地域（南部・中西部）**: リッチモンド、アトランタ、シカゴ、セントルイス、
+#   シンシナティ、デトロイト、ミルウォーキー
+# - **探索地域（西部・辺境）**: サンフランシスコ、デンバー、サンアントニオ、ポートランド
+# 全5件を東海岸だけに集中させない。少なくとも3つの異なる地域をカバーすること。
+#
 # ## テーマの条件
 # - 18世紀後半〜19世紀（1780-1899）の米国が主な対象
-# - 東海岸の港湾都市（ボストン、ニューヨーク、フィラデルフィア、バルチモア、ニューオーリンズ等）を優先
-# - デジタルアーカイブ（米国議会図書館、DPLA、NYPL、Internet Archive）で資料が見つかりそうなテーマ
+# - デジタルアーカイブ（米国議会図書館、DPLA、NYPL、Internet Archive）で
+#   資料が見つかりそうなテーマ
 # - 歴史的事実に基づく矛盾・謎と、民俗学的な伝説・怪異を組み合わせたもの
 # - 具体的な年代、地名、キーワードを含む調査クエリとして使えるもの
+#
+# ## 多様性要件
+# 5件のテーマ全体で以下を満たすこと：
+# - 少なくとも4つの異なるカテゴリ（HIS/FLK/ANT/OCC/URB/CRM/REL/LOC）を使用
+# - 少なくとも3つの異なる地域をカバー
+# - 少なくとも50年のスパンをカバー（例: 1790年代と1880年代の両方）
+# - 有名すぎるテーマ（Salem Witch Trials、Roanoke Colony、Bell Witch 等）は避け、
+#   あまり知られていないが十分な資料がある事例を探す
+# これらの要件は既存データの有無にかかわらず常に適用される。
 #
 # ## 既存のミステリー（重複回避）
 # 以下のテーマは既に調査済みです。これらと重複しないテーマを提案してください：
@@ -40,7 +74,8 @@ from shared.model_config import create_pro_model
 # [
 #   {
 #     "theme": "調査クエリとしてそのまま使える英語のテーマ文",
-#     "description": "このテーマが面白い理由の簡潔な英語説明（2-3文）"
+#     "description": "このテーマが面白い理由の簡潔な英語説明（2-3文）",
+#     "category": "分類コード（HIS/FLK/ANT/OCC/URB/CRM/REL/LOC）"
 #   }
 # ]
 # ```
@@ -56,12 +91,42 @@ Suggest 5 interesting research themes when the administrator is choosing the nex
 This project generates narratives that fuse **historical facts (Fact)** with **folkloric anomalies and legends (Folklore)**.
 The themes you suggest should also be Fact × Folklore hybrids.
 
+## Category Balance
+Each theme corresponds to one of the following 8 classification codes:
+- HIS (History): Historical record discrepancies, missing persons, document gaps
+- FLK (Folklore): Local traditions, festivals, oral traditions, folk beliefs
+- ANT (Anthropology): Rituals, social structures, material culture, cross-cultural contact
+- OCC (Occult): Unexplainable phenomena, supernatural events
+- URB (Urban Legend): Modern rumors, contemporary ghost stories
+- CRM (Crime): Unsolved crimes, disappearances, mysterious deaths
+- REL (Religion): Religious taboos, curses, cults
+- LOC (Locus): Place-bound anomalies, haunted locations
+
+Current category distribution:
+{category_distribution}
+
+Prioritize underrepresented categories.
+
+## Geographic Diversity
+- **Primary (East Coast)**: Boston, New York, Philadelphia, Baltimore, Charleston, Savannah, New Orleans
+- **Also consider (South & Midwest)**: Richmond, Atlanta, Chicago, St. Louis, Cincinnati, Detroit, Milwaukee
+- **Explore (West & Frontier)**: San Francisco, Denver, San Antonio, Portland
+Do NOT concentrate all 5 themes on the East Coast alone. Cover at least 3 distinct regions.
+
 ## Theme Requirements
-- Focus on the United States, late 18th to 19th century (1780–1899)
-- Prioritize East Coast port cities (Boston, New York, Philadelphia, Baltimore, New Orleans, etc.)
+- Focus on the United States, late 18th to 19th century (1780-1899)
 - Themes likely to yield results in digital archives (Library of Congress, DPLA, NYPL, Internet Archive)
 - Combine fact-based historical discrepancies/mysteries with folkloric legends/anomalies
 - Include specific dates, place names, and keywords usable as research queries
+
+## Diversity Requirements
+Across all 5 themes, ensure:
+- At least 4 distinct categories (from HIS/FLK/ANT/OCC/URB/CRM/REL/LOC)
+- At least 3 distinct geographic regions
+- At least a 50-year span covered (e.g., both 1790s and 1880s themes)
+- Avoid overly famous topics (Salem Witch Trials, Roanoke Colony, Bell Witch, etc.); \
+seek lesser-known but well-documented cases
+These requirements apply ALWAYS, regardless of whether existing data is available.
 
 ## Existing Mysteries (Avoid Duplicates)
 The following themes have already been investigated. Suggest themes that do not overlap with these:
@@ -79,7 +144,8 @@ Output the following JSON array. Do NOT output any text other than the JSON.
 [
   {
     "theme": "A theme statement in English, usable directly as a research query",
-    "description": "A concise explanation (2-3 sentences) of why this theme is interesting"
+    "description": "A concise explanation (2-3 sentences) of why this theme is interesting",
+    "category": "Classification code (HIS/FLK/ANT/OCC/URB/CRM/REL/LOC)"
   }
 ]
 ```
@@ -96,4 +162,5 @@ curator_agent = LlmAgent(
     ),
     instruction=CURATOR_INSTRUCTION,
     output_key="suggested_themes",
+    generate_content_config=types.GenerateContentConfig(temperature=1.2),
 )

--- a/services/curator.py
+++ b/services/curator.py
@@ -11,6 +11,7 @@ Endpoints:
 
 import json
 import os
+from collections import Counter
 
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
@@ -27,6 +28,9 @@ from shared.pipeline_failure import get_recent_failures
 
 app = FastAPI()
 
+# 8分類コードの定義（mystery_id プレフィックス）
+ALL_CATEGORIES = ["HIS", "FLK", "ANT", "OCC", "URB", "CRM", "REL", "LOC"]
+
 
 def get_existing_titles() -> list[str]:
     """Fetch titles of all existing mysteries from Firestore."""
@@ -41,6 +45,62 @@ def get_existing_titles() -> list[str]:
     except Exception as e:
         print(f"Warning: Could not fetch existing titles: {e}")
         return []
+
+
+def get_category_distribution() -> dict[str, int]:
+    """Firestore の mystery_id フィールドからカテゴリ分布を集計する。
+
+    mystery_id は {CLS}-{ST}-{AREA}-{TS} 形式で、先頭3文字が分類コード。
+    """
+    try:
+        db = get_firestore_client()
+        docs = db.collection("mysteries").select(["mystery_id"]).stream(timeout=10)
+        prefixes = []
+        for doc in docs:
+            mystery_id = doc.to_dict().get("mystery_id", "")
+            if mystery_id and len(mystery_id) >= 3:
+                prefix = mystery_id[:3].upper()
+                if prefix in ALL_CATEGORIES:
+                    prefixes.append(prefix)
+        return dict(Counter(prefixes))
+    except Exception as e:
+        print(f"Warning: Could not fetch category distribution: {e}")
+        return {}
+
+
+def format_category_distribution(distribution: dict[str, int]) -> str:
+    """カテゴリ分布をプロンプト用テキストに変換する。
+
+    空の場合はコールドスタート向けメッセージを返す。
+    データありの場合は各カテゴリの件数と過小表現カテゴリを表示。
+    """
+    if not distribution:
+        return (
+            "No existing articles yet. This is a fresh start — "
+            "use all 8 categories broadly. Aim for maximum diversity across "
+            "HIS, FLK, ANT, OCC, URB, CRM, REL, and LOC."
+        )
+
+    total = sum(distribution.values())
+    lines = []
+    for cat in ALL_CATEGORIES:
+        count = distribution.get(cat, 0)
+        lines.append(f"  {cat}: {count} article(s)")
+
+    # 過小表現カテゴリ（0件 or 平均以下）の特定
+    avg = total / len(ALL_CATEGORIES)
+    underrepresented = [
+        cat for cat in ALL_CATEGORIES
+        if distribution.get(cat, 0) < avg
+    ]
+
+    if underrepresented:
+        lines.append(
+            f"\nUnderrepresented categories (prioritize these): "
+            f"{', '.join(underrepresented)}"
+        )
+
+    return "\n".join(lines)
 
 
 async def run_curator() -> dict:
@@ -61,6 +121,10 @@ async def run_curator() -> dict:
         else "(None)"
     )
 
+    # カテゴリ分布を取得してプロンプト用テキストに変換
+    distribution = get_category_distribution()
+    category_distribution_text = format_category_distribution(distribution)
+
     session_service = InMemorySessionService()
     runner = Runner(
         agent=curator_agent,
@@ -78,6 +142,7 @@ async def run_curator() -> dict:
         state={
             "existing_titles": titles_text,
             "failed_themes": failed_themes_text,
+            "category_distribution": category_distribution_text,
         },
     )
 

--- a/tests/unit/test_curator_server.py
+++ b/tests/unit/test_curator_server.py
@@ -171,3 +171,110 @@ class TestGetExistingTitles:
 
             titles = get_existing_titles()
             assert titles == ["Mystery A"]
+
+
+class TestGetCategoryDistribution:
+    """Tests for get_category_distribution helper."""
+
+    def test_counts_categories_from_mystery_ids(self):
+        mock_docs = []
+        ids = [
+            "HIS-MA-617-20260101120000",
+            "HIS-NY-212-20260102120000",
+            "OCC-PA-215-20260103120000",
+            "FLK-LA-504-20260104120000",
+        ]
+        for mid in ids:
+            doc = MagicMock()
+            doc.to_dict.return_value = {"mystery_id": mid}
+            mock_docs.append(doc)
+
+        mock_db = MagicMock()
+        mock_db.collection.return_value.select.return_value.stream.return_value = mock_docs
+
+        with patch("services.curator.get_firestore_client", return_value=mock_db):
+            from services.curator import get_category_distribution
+
+            dist = get_category_distribution()
+            assert dist == {"HIS": 2, "OCC": 1, "FLK": 1}
+
+    def test_returns_empty_dict_on_error(self):
+        with patch(
+            "services.curator.get_firestore_client",
+            side_effect=Exception("Connection failed"),
+        ):
+            from services.curator import get_category_distribution
+
+            dist = get_category_distribution()
+            assert dist == {}
+
+    def test_skips_invalid_mystery_ids(self):
+        mock_docs = []
+        # 有効な ID
+        doc1 = MagicMock()
+        doc1.to_dict.return_value = {"mystery_id": "CRM-IL-312-20260101120000"}
+        mock_docs.append(doc1)
+        # 空の mystery_id
+        doc2 = MagicMock()
+        doc2.to_dict.return_value = {"mystery_id": ""}
+        mock_docs.append(doc2)
+        # mystery_id フィールドなし
+        doc3 = MagicMock()
+        doc3.to_dict.return_value = {}
+        mock_docs.append(doc3)
+        # 不正なプレフィックス
+        doc4 = MagicMock()
+        doc4.to_dict.return_value = {"mystery_id": "XXX-MA-617-20260101120000"}
+        mock_docs.append(doc4)
+
+        mock_db = MagicMock()
+        mock_db.collection.return_value.select.return_value.stream.return_value = mock_docs
+
+        with patch("services.curator.get_firestore_client", return_value=mock_db):
+            from services.curator import get_category_distribution
+
+            dist = get_category_distribution()
+            assert dist == {"CRM": 1}
+
+
+class TestFormatCategoryDistribution:
+    """Tests for format_category_distribution helper."""
+
+    def test_empty_distribution_returns_cold_start_message(self):
+        from services.curator import format_category_distribution
+
+        result = format_category_distribution({})
+        assert "fresh start" in result
+        assert "HIS" in result
+        assert "LOC" in result
+
+    def test_with_data_shows_all_categories(self):
+        from services.curator import format_category_distribution
+
+        dist = {"HIS": 3, "OCC": 2, "FLK": 1}
+        result = format_category_distribution(dist)
+        # 全8カテゴリが表示される
+        for cat in ["HIS", "FLK", "ANT", "OCC", "URB", "CRM", "REL", "LOC"]:
+            assert cat in result
+        assert "3 article(s)" in result
+        assert "0 article(s)" in result
+
+    def test_identifies_underrepresented_categories(self):
+        from services.curator import format_category_distribution
+
+        # 平均 = 8/8 = 1.0 → 0件のカテゴリが underrepresented
+        dist = {"HIS": 3, "OCC": 2, "FLK": 1, "ANT": 1, "URB": 1}
+        result = format_category_distribution(dist)
+        assert "Underrepresented" in result
+        # CRM, REL, LOC が0件なので underrepresented
+        assert "CRM" in result
+        assert "REL" in result
+        assert "LOC" in result
+
+    def test_uniform_distribution_no_underrepresented(self):
+        from services.curator import format_category_distribution
+
+        # 全カテゴリ同数 → underrepresented なし
+        dist = {cat: 2 for cat in ["HIS", "FLK", "ANT", "OCC", "URB", "CRM", "REL", "LOC"]}
+        result = format_category_distribution(dist)
+        assert "Underrepresented" not in result


### PR DESCRIPTION
## Summary

- Curator プロンプトに **Category Balance** / **Geographic Diversity** / **Diversity Requirements** の3セクションを追加し、コールドスタート時の有名テーマ偏重問題を解決
- `get_category_distribution()` / `format_category_distribution()` で Firestore の既存カテゴリ分布を動的に分析し、過小表現カテゴリの優先を指示
- `temperature=1.2` 設定でテーマ提案のランダム性を向上

## 変更内容

| ファイル | 変更 |
|---------|------|
| `curator_agents/agents/curator.py` | プロンプト3セクション追加 + `generate_content_config` で temperature=1.2 設定 |
| `services/curator.py` | `get_category_distribution()` + `format_category_distribution()` 追加、`run_curator()` に `category_distribution` session state 注入 |
| `tests/unit/test_curator_server.py` | 7件のユニットテスト追加（`TestGetCategoryDistribution` 3件 + `TestFormatCategoryDistribution` 4件） |

## 背景（問題点）

Firebase が空の状態で Curator を実行すると、同じ有名テーマ（Salem Witch Trials、New Orleans Voodoo 等）が繰り返し提案される。原因：
1. コールドスタート時に `{existing_titles}` = "(None)" で多様性ガードレールがゼロ
2. 地理的制約が東海岸港湾都市に限定
3. 8分類コードがプロンプトに渡されていない
4. 時代的分散の指示なし

## Test plan

- [x] `pytest tests/unit/test_curator_server.py -v` — 16 passed（既存9件 + 新規7件）
- [x] `pytest tests/unit/ -v` — 377 passed（全テスト通過）
- [ ] Firebase Emulator で空コレクション状態でCurator実行し、多様性を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)