### PR TITLE
fix: 管理画面の言語選択バグ修正 + グローバル言語設定

### DIFF
--- a/web-admin/src/app/(main)/layout.tsx
+++ b/web-admin/src/app/(main)/layout.tsx
@@ -1,4 +1,5 @@
 import { Header } from "@/components/header"
+import { LanguageProvider } from "@/contexts/language-context"
 
 export default function AdminLayout({
   children,
@@ -6,9 +7,11 @@ export default function AdminLayout({
   children: React.ReactNode
 }) {
   return (
-    <div className="min-h-screen flex flex-col">
-      <Header />
-      <main className="flex-1">{children}</main>
-    </div>
+    <LanguageProvider>
+      <div className="min-h-screen flex flex-col">
+        <Header />
+        <main className="flex-1">{children}</main>
+      </div>
+    </LanguageProvider>
   )
 }

--- a/web-admin/src/app/(main)/page.tsx
+++ b/web-admin/src/app/(main)/page.tsx
@@ -7,11 +7,14 @@ import { cn } from "@ghost/shared/src/lib/utils"
 import { Button } from "@ghost/shared/src/components/ui/button"
 import { getAllMysteries, approveMystery, archiveMystery, requestPodcast } from "@/lib/firestore/mysteries"
 import type { FirestoreMystery, MysteryStatus, PipelineRun } from "@ghost/shared/src/types/mystery"
+import { localizeMystery } from "@ghost/shared/src/lib/localize"
 import { PipelineSummary } from "@/components/pipeline-summary"
 import { PipelineTimeline } from "@/components/pipeline-timeline"
 import { ActivePipelinePanel } from "@/components/active-pipeline-panel"
 import { usePipelineRuns } from "@/hooks/use-pipeline-runs"
 import { usePipelineRun } from "@/hooks/use-pipeline-run"
+import { useLanguage } from "@/contexts/language-context"
+import type { PreviewLang } from "@/components/language-selector"
 import {
   Shield,
   FileText,
@@ -35,6 +38,7 @@ import {
 type FilterStatus = "all" | MysteryStatus | "translating"
 
 export default function AdminPage() {
+  const { lang } = useLanguage()
   const [filter, setFilter] = useState<FilterStatus>("all")
   const [mysteries, setMysteries] = useState<FirestoreMystery[]>([])
   const [loading, setLoading] = useState(true)
@@ -406,6 +410,7 @@ export default function AdminPage() {
               <AdminMysteryCard
                 key={mystery.mystery_id}
                 mystery={mystery}
+                lang={lang}
                 onApprove={() => handleApprove(mystery.mystery_id)}
                 onArchive={() => handleArchive(mystery.mystery_id)}
                 onPodcast={() => handlePodcast(mystery.mystery_id)}
@@ -420,18 +425,20 @@ export default function AdminPage() {
 
 interface AdminMysteryCardProps {
   mystery: FirestoreMystery
+  lang: PreviewLang
   onApprove: () => void
   onArchive: () => void
   onPodcast: () => void
 }
 
-function AdminMysteryCard({ mystery, onApprove, onArchive, onPodcast }: AdminMysteryCardProps) {
+function AdminMysteryCard({ mystery, lang, onApprove, onArchive, onPodcast }: AdminMysteryCardProps) {
   const [showPipeline, setShowPipeline] = useState(false)
   const isPending = mystery.status === "pending"
   const isTranslating = mystery.status === "translating"
   const location = mystery.historical_context?.geographic_scope?.[0] || ""
   const timePeriod = mystery.historical_context?.time_period || ""
   const hasPipelineLog = mystery.pipeline_log && mystery.pipeline_log.length > 0
+  const { title, summary } = localizeMystery(mystery, lang)
 
   return (
     <article className="aged-card letterpress-border rounded-sm p-5">
@@ -444,14 +451,14 @@ function AdminMysteryCard({ mystery, onApprove, onArchive, onPodcast }: AdminMys
         <StatusBadge status={mystery.status} />
       </div>
 
-      {/* Title (Japanese preferred for admin) */}
+      {/* タイトル（グローバル言語設定に連動） */}
       <h3 className="font-serif text-lg text-parchment mb-1 leading-tight">
-        {mystery.translations?.ja?.title || mystery.title_ja || mystery.title}
+        {title}
       </h3>
 
-      {/* Summary (Japanese preferred for admin) */}
+      {/* サマリー（グローバル言語設定に連動） */}
       <p className="text-sm text-foreground/80 leading-relaxed mb-4 line-clamp-2">
-        {mystery.translations?.ja?.summary || mystery.summary_ja || mystery.summary}
+        {summary}
       </p>
 
       {/* Metadata */}

--- a/web-admin/src/app/(main)/preview/[id]/preview-content.tsx
+++ b/web-admin/src/app/(main)/preview/[id]/preview-content.tsx
@@ -1,11 +1,12 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import Link from "next/link"
 import Image from "next/image"
 import { EvidenceBlock } from "@ghost/shared/src/components/evidence-block"
 import { localizeMystery, getTranslatedExcerpt } from "@ghost/shared/src/lib/localize"
 import { LanguageSelector, type PreviewLang } from "@/components/language-selector"
+import { useLanguage } from "@/contexts/language-context"
 import type { FirestoreMystery } from "@ghost/shared/src/types/mystery"
 import {
   ArrowLeft,
@@ -37,7 +38,13 @@ interface PreviewContentProps {
 }
 
 export function PreviewContent({ mystery }: PreviewContentProps) {
-  const [lang, setLang] = useState<PreviewLang>("en")
+  const { lang: globalLang } = useLanguage()
+  const [lang, setLang] = useState<PreviewLang>(globalLang)
+
+  // グローバル言語が初期化された場合に同期（SSR→クライアント遷移時）
+  useEffect(() => {
+    setLang(globalLang)
+  }, [globalLang])
 
   // translations map に存在する言語
   const availableLangs = Object.keys(mystery.translations ?? {})

--- a/web-admin/src/components/header-language-selector.tsx
+++ b/web-admin/src/components/header-language-selector.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import { Globe, Check } from "lucide-react"
+import { useState, useRef, useEffect } from "react"
+import { useLanguage } from "@/contexts/language-context"
+import { ALL_LANGS } from "@/components/language-selector"
+
+/**
+ * ヘッダー用グローバル言語セレクタ
+ * 翻訳可否ドットは表示しない（記事固有情報のためヘッダーでは不要）
+ */
+export function HeaderLanguageSelector() {
+  const { lang, setLang } = useLanguage()
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside)
+    return () => document.removeEventListener("mousedown", handleClickOutside)
+  }, [])
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        onClick={() => setOpen(!open)}
+        className="flex items-center gap-2 px-3 py-1.5 text-sm bg-card border border-border rounded-sm hover:border-gold/50 transition-colors"
+      >
+        <Globe className="w-4 h-4 text-gold" />
+        <span className="font-mono text-xs uppercase">{lang}</span>
+      </button>
+
+      {open && (
+        <div className="absolute right-0 mt-2 w-48 bg-card border border-border rounded-sm shadow-lg z-50">
+          {ALL_LANGS.map(({ code, label }) => (
+            <button
+              key={code}
+              onMouseDown={(e) => {
+                e.preventDefault()
+                e.stopPropagation()
+                setLang(code)
+                setOpen(false)
+              }}
+              className={`w-full flex items-center gap-3 px-4 py-2 text-sm text-left transition-colors ${
+                code === lang
+                  ? "text-gold bg-gold/10"
+                  : "text-foreground hover:bg-card/80"
+              }`}
+            >
+              <span className="font-mono text-xs uppercase w-6">{code}</span>
+              <span className="flex-1">{label}</span>
+              {code === lang && <Check className="w-3 h-3 text-gold" />}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web-admin/src/components/header.tsx
+++ b/web-admin/src/components/header.tsx
@@ -2,12 +2,13 @@
 
 import Link from "next/link"
 import { Archive } from "lucide-react"
+import { HeaderLanguageSelector } from "@/components/header-language-selector"
 
 export function Header() {
   return (
     <header className="sticky top-0 z-50 border-b border-border/50 bg-background/80 backdrop-blur-sm">
       <div className="container mx-auto px-4">
-        <div className="flex items-center h-16">
+        <div className="flex items-center justify-between h-16">
           {/* Logo */}
           <Link href="/" className="flex items-center gap-3 group">
             <div className="relative">
@@ -18,6 +19,9 @@ export function Header() {
               Ghost in the Archive
             </span>
           </Link>
+
+          {/* グローバル言語セレクタ */}
+          <HeaderLanguageSelector />
         </div>
       </div>
     </header>

--- a/web-admin/src/components/language-selector.tsx
+++ b/web-admin/src/components/language-selector.tsx
@@ -7,7 +7,7 @@ import type { TranslationLang } from "@ghost/shared/src/types/mystery"
 /**
  * 利用可能な翻訳言語の定義
  */
-const ALL_LANGS = [
+export const ALL_LANGS = [
   { code: "en" as const, label: "English" },
   { code: "ja" as const, label: "日本語" },
   { code: "es" as const, label: "Español" },
@@ -70,7 +70,10 @@ export function LanguageSelector({
             return (
               <button
                 key={code}
-                onClick={() => {
+                onMouseDown={(e) => {
+                  // mousedown で即座に反映（document の mousedown ハンドラより先に発火）
+                  e.preventDefault()
+                  e.stopPropagation()
                   onLangChange(code)
                   setOpen(false)
                 }}

--- a/web-admin/src/contexts/language-context.tsx
+++ b/web-admin/src/contexts/language-context.tsx
@@ -1,0 +1,72 @@
+"use client"
+
+import { createContext, useContext, useState, useEffect, type ReactNode } from "react"
+import type { PreviewLang } from "@/components/language-selector"
+
+const STORAGE_KEY = "ghost-admin-lang"
+const SUPPORTED_LANGS: PreviewLang[] = ["en", "ja", "es", "de", "fr", "nl", "pt"]
+const DEFAULT_LANG: PreviewLang = "en"
+
+interface LanguageContextValue {
+  lang: PreviewLang
+  setLang: (lang: PreviewLang) => void
+}
+
+const LanguageContext = createContext<LanguageContextValue | null>(null)
+
+/**
+ * ブラウザ言語からサポート言語を検出する
+ * navigator.language の先頭2文字を抽出し、サポート言語に含まれるか判定
+ */
+function detectBrowserLang(): PreviewLang {
+  if (typeof navigator === "undefined") return DEFAULT_LANG
+  const browserLang = navigator.language.slice(0, 2).toLowerCase()
+  const matched = SUPPORTED_LANGS.find((l) => l === browserLang)
+  return matched ?? DEFAULT_LANG
+}
+
+/**
+ * グローバル言語設定 Provider
+ * - localStorage から復元、なければブラウザ言語を検出
+ * - 言語変更時に localStorage に永続化
+ */
+export function LanguageProvider({ children }: { children: ReactNode }) {
+  const [lang, setLangState] = useState<PreviewLang>(DEFAULT_LANG)
+  const [initialized, setInitialized] = useState(false)
+
+  // クライアントサイドで初期化（SSR 安全）
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored && SUPPORTED_LANGS.includes(stored as PreviewLang)) {
+      setLangState(stored as PreviewLang)
+    } else {
+      const detected = detectBrowserLang()
+      setLangState(detected)
+      localStorage.setItem(STORAGE_KEY, detected)
+    }
+    setInitialized(true)
+  }, [])
+
+  const setLang = (newLang: PreviewLang) => {
+    setLangState(newLang)
+    localStorage.setItem(STORAGE_KEY, newLang)
+  }
+
+  // 初期化前はデフォルト言語で表示（ちらつき防止のため children は常にレンダリング）
+  return (
+    <LanguageContext.Provider value={{ lang: initialized ? lang : DEFAULT_LANG, setLang }}>
+      {children}
+    </LanguageContext.Provider>
+  )
+}
+
+/**
+ * グローバル言語を取得・設定するフック
+ */
+export function useLanguage(): LanguageContextValue {
+  const context = useContext(LanguageContext)
+  if (!context) {
+    throw new Error("useLanguage must be used within a LanguageProvider")
+  }
+  return context
+}


### PR DESCRIPTION
## Summary

- 言語セレクタのドロップダウンで English 以外を選択してもボタン表示が EN のまま変わらないバグを修正
- ダッシュボードにグローバル言語セレクタを追加（ブラウザ言語検出 + localStorage 永続化）
- ハードコード日本語タイトル/サマリーを `localizeMystery()` による動的表示に置換

## 変更内容

| ファイル | 変更 |
|---------|------|
| `language-selector.tsx` | `onClick` → `onMouseDown` + `e.stopPropagation()` でバグ修正 |
| `contexts/language-context.tsx` | **新規** — `LanguageProvider` + `useLanguage()` フック |
| `header-language-selector.tsx` | **新規** — ヘッダー用グローバル言語セレクタ |
| `layout.tsx` | `<LanguageProvider>` でラップ |
| `header.tsx` | ヘッダー右側に `<HeaderLanguageSelector>` 追加 |
| `page.tsx` | カードのタイトル/サマリーを `localizeMystery(mystery, lang)` に変更 |
| `preview-content.tsx` | グローバル言語を初期値として使用 |

## 言語初期化ロジック

1. `localStorage` に `ghost-admin-lang` があればそれを使用
2. なければ `navigator.language` の先頭2文字を検出
3. サポート言語（en/ja/es/de/fr/nl/pt）に含まれればそれを使用
4. 含まれなければ `en` にフォールバック

## Test plan

- [ ] プレビューページで日本語を選択 → ボタンが JA に変わりコンテンツも日本語に切り替わること
- [ ] ヘッダーのセレクタで言語変更 → ダッシュボードカードのタイトル/サマリーが変わること
- [ ] ページリロード後も選択言語が維持されること（localStorage 永続化）
- [ ] プレビューページがグローバル言語で初期表示されること
- [ ] ブラウザ言語が `zh` など未サポートの場合に英語フォールバックすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)