### PR TITLE
chore: firebase-debug.log を Claude Code の ask ルールに追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,7 +19,8 @@
       "Read(logs/**)",
       "Read(.adk/**)",
       "Read(uv.lock)",
-      "Read(package-lock.json)"
+      "Read(package-lock.json)",
+      "Read(firebase-debug.log)"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- `firebase-debug.log` を `.claude/settings.json` の `permissions.ask` に追加
- デバッグ時に参照する可能性があるため `deny` ではなく `ask`（確認付き読み取り）に設定

## 背景
`.claudeignore` の導入を検討したが、Claude Code では公式未サポート（2026年2月時点）のため、引き続き `permissions.deny` / `permissions.ask` で管理する方針を維持。

🤖 Generated with [Claude Code](https://claude.com/claude-code)