### PR TITLE
refactor: API エンドポイントをリソース指向命名にリネーム

### DIFF
--- a/web-admin/src/app/(main)/page.tsx
+++ b/web-admin/src/app/(main)/page.tsx
@@ -120,7 +120,7 @@ export default function AdminPage() {
   // リビルド失敗は approve/archive の成否に影響しない（fire-and-forget）
   const triggerRebuild = async () => {
     try {
-      await fetch("/api/rebuild-public", { method: "POST" })
+      await fetch("/api/deployments/rebuild", { method: "POST" })
     } catch (error) {
       console.error("Failed to trigger rebuild:", error)
     }
@@ -155,7 +155,7 @@ export default function AdminPage() {
   const handlePodcast = async (id: string) => {
     try {
       await requestPodcast(id)
-      const res = await fetch("/api/podcast", {
+      const res = await fetch("/api/podcasts/generate", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ mysteryId: id }),
@@ -179,7 +179,7 @@ export default function AdminPage() {
     if (!themeInput.trim()) return
     setPipelineLoading(true)
     try {
-      const res = await fetch("/api/pipeline", {
+      const res = await fetch("/api/mysteries/investigate", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ query: themeInput.trim() }),
@@ -206,7 +206,7 @@ export default function AdminPage() {
     setSuggestLoading(true)
     setSuggestions([])
     try {
-      const res = await fetch("/api/suggest-theme", { method: "POST" })
+      const res = await fetch("/api/themes/suggest", { method: "POST" })
       if (!res.ok) throw new Error("API request failed")
       const data = await res.json()
       setSuggestions(Array.isArray(data.suggestions) ? data.suggestions : [])

--- a/web-admin/src/app/api/deployments/rebuild/route.ts
+++ b/web-admin/src/app/api/deployments/rebuild/route.ts
@@ -1,5 +1,5 @@
 /**
- * POST /api/rebuild-public
+ * POST /api/deployments/rebuild
  *
  * approve/archive 後に web-public の SSG リビルドを発火する。
  * - 本番: google-auth-library で access token を取得し、Cloud Build triggers.run を呼び出す

--- a/web-admin/src/app/api/mysteries/investigate/route.ts
+++ b/web-admin/src/app/api/mysteries/investigate/route.ts
@@ -1,7 +1,7 @@
 /**
- * POST /api/podcast
+ * POST /api/mysteries/investigate
  *
- * Triggers podcast generation pipeline via HTTP POST to Pipeline Cloud Run Service.
+ * Triggers blog creation pipeline via HTTP POST to Pipeline Cloud Run Service.
  * - Production: IAM-authenticated HTTP call to Cloud Run Service
  * - Local: Direct HTTP call to localhost (docker compose)
  */
@@ -28,24 +28,24 @@ async function getAuthHeaders(): Promise<Record<string, string>> {
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const { mysteryId } = body;
+    const { query } = body;
 
-    if (!mysteryId || typeof mysteryId !== "string") {
+    if (!query || typeof query !== "string") {
       return NextResponse.json(
-        { error: "mysteryId is required" },
+        { error: "query is required" },
         { status: 400 }
       );
     }
 
     const authHeaders = await getAuthHeaders();
 
-    const response = await fetch(`${pipelineServiceUrl}/podcast`, {
+    const response = await fetch(`${pipelineServiceUrl}/investigate`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         ...authHeaders,
       },
-      body: JSON.stringify({ mystery_id: mysteryId }),
+      body: JSON.stringify({ query }),
       signal: AbortSignal.timeout(30000),
     });
 
@@ -53,7 +53,7 @@ export async function POST(request: NextRequest) {
       const errorBody = await response.text();
       console.error(`Pipeline service error (${response.status}):`, errorBody);
       return NextResponse.json(
-        { error: "Failed to start podcast pipeline" },
+        { error: "Failed to start blog pipeline" },
         { status: 500 }
       );
     }
@@ -61,14 +61,14 @@ export async function POST(request: NextRequest) {
     const data = await response.json();
     return NextResponse.json({
       status: "accepted",
-      mysteryId,
-      message: "Podcast pipeline started",
+      query,
+      message: "Blog pipeline started",
       run_id: data.run_id,
     });
   } catch (error) {
-    console.error("Failed to start podcast pipeline:", error);
+    console.error("Failed to start blog pipeline:", error);
     return NextResponse.json(
-      { error: "Failed to start podcast pipeline" },
+      { error: "Failed to start blog pipeline" },
       { status: 500 }
     );
   }

--- a/web-admin/src/app/api/mysteries/translate/route.ts
+++ b/web-admin/src/app/api/mysteries/translate/route.ts
@@ -1,9 +1,11 @@
 /**
- * POST /api/pipeline
+ * POST /api/mysteries/translate
  *
- * Triggers blog creation pipeline via HTTP POST to Pipeline Cloud Run Service.
+ * Triggers translation pipeline via HTTP POST to Pipeline Cloud Run Service.
  * - Production: IAM-authenticated HTTP call to Cloud Run Service
  * - Local: Direct HTTP call to localhost (docker compose)
+ *
+ * Status should already be set to "translating" by approveMystery().
  */
 
 import { NextRequest, NextResponse } from "next/server";
@@ -28,24 +30,24 @@ async function getAuthHeaders(): Promise<Record<string, string>> {
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const { query } = body;
+    const { mysteryId } = body;
 
-    if (!query || typeof query !== "string") {
+    if (!mysteryId || typeof mysteryId !== "string") {
       return NextResponse.json(
-        { error: "query is required" },
+        { error: "mysteryId is required" },
         { status: 400 }
       );
     }
 
     const authHeaders = await getAuthHeaders();
 
-    const response = await fetch(`${pipelineServiceUrl}/investigate`, {
+    const response = await fetch(`${pipelineServiceUrl}/translate`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         ...authHeaders,
       },
-      body: JSON.stringify({ query }),
+      body: JSON.stringify({ mystery_id: mysteryId }),
       signal: AbortSignal.timeout(30000),
     });
 
@@ -53,7 +55,7 @@ export async function POST(request: NextRequest) {
       const errorBody = await response.text();
       console.error(`Pipeline service error (${response.status}):`, errorBody);
       return NextResponse.json(
-        { error: "Failed to start blog pipeline" },
+        { error: "Failed to start translation" },
         { status: 500 }
       );
     }
@@ -61,14 +63,14 @@ export async function POST(request: NextRequest) {
     const data = await response.json();
     return NextResponse.json({
       status: "accepted",
-      query,
-      message: "Blog pipeline started",
+      mysteryId,
+      message: "Translation started",
       run_id: data.run_id,
     });
   } catch (error) {
-    console.error("Failed to start blog pipeline:", error);
+    console.error("Failed to run translation:", error);
     return NextResponse.json(
-      { error: "Failed to start blog pipeline" },
+      { error: "Failed to run translation" },
       { status: 500 }
     );
   }

--- a/web-admin/src/app/api/podcasts/generate/route.ts
+++ b/web-admin/src/app/api/podcasts/generate/route.ts
@@ -1,11 +1,9 @@
 /**
- * POST /api/translate
+ * POST /api/podcasts/generate
  *
- * Triggers translation pipeline via HTTP POST to Pipeline Cloud Run Service.
+ * Triggers podcast generation pipeline via HTTP POST to Pipeline Cloud Run Service.
  * - Production: IAM-authenticated HTTP call to Cloud Run Service
  * - Local: Direct HTTP call to localhost (docker compose)
- *
- * Status should already be set to "translating" by approveMystery().
  */
 
 import { NextRequest, NextResponse } from "next/server";
@@ -41,7 +39,7 @@ export async function POST(request: NextRequest) {
 
     const authHeaders = await getAuthHeaders();
 
-    const response = await fetch(`${pipelineServiceUrl}/translate`, {
+    const response = await fetch(`${pipelineServiceUrl}/podcast`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -55,7 +53,7 @@ export async function POST(request: NextRequest) {
       const errorBody = await response.text();
       console.error(`Pipeline service error (${response.status}):`, errorBody);
       return NextResponse.json(
-        { error: "Failed to start translation" },
+        { error: "Failed to start podcast pipeline" },
         { status: 500 }
       );
     }
@@ -64,13 +62,13 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({
       status: "accepted",
       mysteryId,
-      message: "Translation started",
+      message: "Podcast pipeline started",
       run_id: data.run_id,
     });
   } catch (error) {
-    console.error("Failed to run translation:", error);
+    console.error("Failed to start podcast pipeline:", error);
     return NextResponse.json(
-      { error: "Failed to run translation" },
+      { error: "Failed to start podcast pipeline" },
       { status: 500 }
     );
   }

--- a/web-admin/src/app/api/themes/suggest/route.ts
+++ b/web-admin/src/app/api/themes/suggest/route.ts
@@ -1,5 +1,5 @@
 /**
- * POST /api/suggest-theme
+ * POST /api/themes/suggest
  *
  * Calls the Curator Cloud Run Service to generate theme suggestions.
  * - Production: IAM-authenticated HTTP call to Cloud Run Service


### PR DESCRIPTION
## Summary

- Next.js ログで `POST /api/pipeline 200` と出ても何のパイプラインか不明瞭だった問題を解決
- Google AIP のリソース指向設計に倣い、`/api/{resource}/{action}` 形式に統一
- 対応表:
  - `/api/pipeline` → `/api/mysteries/investigate`
  - `/api/suggest-theme` → `/api/themes/suggest`
  - `/api/podcast` → `/api/podcasts/generate`
  - `/api/translate` → `/api/mysteries/translate`
  - `/api/rebuild-public` → `/api/deployments/rebuild`

## Test plan

- [x] `npm run build`（web-admin）でビルド成功を確認
- [ ] 開発環境でテーマ提案・パイプライン起動・ポッドキャスト生成の各ボタンが動作すること（手動確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)