### PR TITLE
fix: Curator CLI のセッション状態に failed_themes と category_distribution を追加

### DIFF
--- a/curator_agents/cli.py
+++ b/curator_agents/cli.py
@@ -24,24 +24,27 @@ from google.adk.sessions import InMemorySessionService
 from google.genai import types
 
 from .agents.curator import curator_agent
-from shared.firestore import get_firestore_client
-
-
-def get_existing_titles() -> list[str]:
-    """Fetch titles of all existing mysteries from Firestore."""
-    try:
-        db = get_firestore_client()
-        docs = db.collection("mysteries").select(["title"]).stream(timeout=10)
-        return [doc.to_dict().get("title", "") for doc in docs if doc.to_dict().get("title")]
-    except Exception as e:
-        print(f"Warning: Could not fetch existing titles: {e}", file=sys.stderr)
-        return []
+from .queries import get_existing_titles, get_category_distribution, format_category_distribution
+from shared.pipeline_failure import get_recent_failures
 
 
 async def suggest_themes() -> None:
     """Run the Curator agent and output JSON to stdout."""
     existing_titles = get_existing_titles()
     titles_text = "\n".join(f"- {t}" for t in existing_titles) if existing_titles else "(なし - まだ調査済みのテーマはありません)"
+
+    # 最近失敗したテーマを取得し、Curator に渡す
+    recent_failures = get_recent_failures(limit=20)
+    failed_themes = list({f["theme"] for f in recent_failures if f.get("theme")})
+    failed_themes_text = (
+        "\n".join(f"- {t}" for t in failed_themes)
+        if failed_themes
+        else "(None)"
+    )
+
+    # カテゴリ分布を取得してプロンプト用テキストに変換
+    distribution = get_category_distribution()
+    category_distribution_text = format_category_distribution(distribution)
 
     session_service = InMemorySessionService()
     runner = Runner(
@@ -57,7 +60,11 @@ async def suggest_themes() -> None:
         app_name="ghost_in_the_archive_curator",
         user_id=user_id,
         session_id=session_id,
-        state={"existing_titles": titles_text},
+        state={
+            "existing_titles": titles_text,
+            "failed_themes": failed_themes_text,
+            "category_distribution": category_distribution_text,
+        },
     )
 
     result_text = ""

--- a/curator_agents/queries.py
+++ b/curator_agents/queries.py
@@ -1,0 +1,84 @@
+"""Curator ドメインクエリ — Firestore からテーマ提案に必要な情報を取得する。
+
+CLI (`cli.py`) と本番サービス (`services/curator.py`) の両方から使用される。
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+from shared.firestore import get_firestore_client
+
+# 8分類コードの定義（mystery_id プレフィックス）
+ALL_CATEGORIES = ["HIS", "FLK", "ANT", "OCC", "URB", "CRM", "REL", "LOC"]
+
+
+def get_existing_titles() -> list[str]:
+    """Fetch titles of all existing mysteries from Firestore."""
+    try:
+        db = get_firestore_client()
+        docs = db.collection("mysteries").select(["title"]).stream(timeout=10)
+        return [
+            title
+            for doc in docs
+            if (title := doc.to_dict().get("title"))
+        ]
+    except Exception as e:
+        print(f"Warning: Could not fetch existing titles: {e}")
+        return []
+
+
+def get_category_distribution() -> dict[str, int]:
+    """Firestore の mystery_id フィールドからカテゴリ分布を集計する。
+
+    mystery_id は {CLS}-{ST}-{AREA}-{TS} 形式で、先頭3文字が分類コード。
+    """
+    try:
+        db = get_firestore_client()
+        docs = db.collection("mysteries").select(["mystery_id"]).stream(timeout=10)
+        prefixes = []
+        for doc in docs:
+            mystery_id = doc.to_dict().get("mystery_id", "")
+            if mystery_id and len(mystery_id) >= 3:
+                prefix = mystery_id[:3].upper()
+                if prefix in ALL_CATEGORIES:
+                    prefixes.append(prefix)
+        return dict(Counter(prefixes))
+    except Exception as e:
+        print(f"Warning: Could not fetch category distribution: {e}")
+        return {}
+
+
+def format_category_distribution(distribution: dict[str, int]) -> str:
+    """カテゴリ分布をプロンプト用テキストに変換する。
+
+    空の場合はコールドスタート向けメッセージを返す。
+    データありの場合は各カテゴリの件数と過小表現カテゴリを表示。
+    """
+    if not distribution:
+        return (
+            "No existing articles yet. This is a fresh start — "
+            "use all 8 categories broadly. Aim for maximum diversity across "
+            "HIS, FLK, ANT, OCC, URB, CRM, REL, and LOC."
+        )
+
+    total = sum(distribution.values())
+    lines = []
+    for cat in ALL_CATEGORIES:
+        count = distribution.get(cat, 0)
+        lines.append(f"  {cat}: {count} article(s)")
+
+    # 過小表現カテゴリ（0件 or 平均以下）の特定
+    avg = total / len(ALL_CATEGORIES)
+    underrepresented = [
+        cat for cat in ALL_CATEGORIES
+        if distribution.get(cat, 0) < avg
+    ]
+
+    if underrepresented:
+        lines.append(
+            f"\nUnderrepresented categories (prioritize these): "
+            f"{', '.join(underrepresented)}"
+        )
+
+    return "\n".join(lines)

--- a/services/curator.py
+++ b/services/curator.py
@@ -11,7 +11,6 @@ Endpoints:
 
 import json
 import os
-from collections import Counter
 
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
@@ -22,85 +21,15 @@ from google.adk.sessions import InMemorySessionService
 from google.genai import types
 
 from curator_agents.agents.curator import curator_agent
+from curator_agents.queries import (
+    get_existing_titles,
+    get_category_distribution,
+    format_category_distribution,
+)
 from translator_agents.agents.translator import translator_agent
-from shared.firestore import get_firestore_client
 from shared.pipeline_failure import get_recent_failures
 
 app = FastAPI()
-
-# 8分類コードの定義（mystery_id プレフィックス）
-ALL_CATEGORIES = ["HIS", "FLK", "ANT", "OCC", "URB", "CRM", "REL", "LOC"]
-
-
-def get_existing_titles() -> list[str]:
-    """Fetch titles of all existing mysteries from Firestore."""
-    try:
-        db = get_firestore_client()
-        docs = db.collection("mysteries").select(["title"]).stream(timeout=10)
-        return [
-            doc.to_dict().get("title", "")
-            for doc in docs
-            if doc.to_dict().get("title")
-        ]
-    except Exception as e:
-        print(f"Warning: Could not fetch existing titles: {e}")
-        return []
-
-
-def get_category_distribution() -> dict[str, int]:
-    """Firestore の mystery_id フィールドからカテゴリ分布を集計する。
-
-    mystery_id は {CLS}-{ST}-{AREA}-{TS} 形式で、先頭3文字が分類コード。
-    """
-    try:
-        db = get_firestore_client()
-        docs = db.collection("mysteries").select(["mystery_id"]).stream(timeout=10)
-        prefixes = []
-        for doc in docs:
-            mystery_id = doc.to_dict().get("mystery_id", "")
-            if mystery_id and len(mystery_id) >= 3:
-                prefix = mystery_id[:3].upper()
-                if prefix in ALL_CATEGORIES:
-                    prefixes.append(prefix)
-        return dict(Counter(prefixes))
-    except Exception as e:
-        print(f"Warning: Could not fetch category distribution: {e}")
-        return {}
-
-
-def format_category_distribution(distribution: dict[str, int]) -> str:
-    """カテゴリ分布をプロンプト用テキストに変換する。
-
-    空の場合はコールドスタート向けメッセージを返す。
-    データありの場合は各カテゴリの件数と過小表現カテゴリを表示。
-    """
-    if not distribution:
-        return (
-            "No existing articles yet. This is a fresh start — "
-            "use all 8 categories broadly. Aim for maximum diversity across "
-            "HIS, FLK, ANT, OCC, URB, CRM, REL, and LOC."
-        )
-
-    total = sum(distribution.values())
-    lines = []
-    for cat in ALL_CATEGORIES:
-        count = distribution.get(cat, 0)
-        lines.append(f"  {cat}: {count} article(s)")
-
-    # 過小表現カテゴリ（0件 or 平均以下）の特定
-    avg = total / len(ALL_CATEGORIES)
-    underrepresented = [
-        cat for cat in ALL_CATEGORIES
-        if distribution.get(cat, 0) < avg
-    ]
-
-    if underrepresented:
-        lines.append(
-            f"\nUnderrepresented categories (prioritize these): "
-            f"{', '.join(underrepresented)}"
-        )
-
-    return "\n".join(lines)
 
 
 async def run_curator() -> dict:

--- a/tests/unit/test_curator_server.py
+++ b/tests/unit/test_curator_server.py
@@ -138,18 +138,18 @@ class TestGetExistingTitles:
             mock_doc2,
         ]
 
-        with patch("services.curator.get_firestore_client", return_value=mock_db):
-            from services.curator import get_existing_titles
+        with patch("curator_agents.queries.get_firestore_client", return_value=mock_db):
+            from curator_agents.queries import get_existing_titles
 
             titles = get_existing_titles()
             assert titles == ["Mystery A", "Mystery B"]
 
     def test_returns_empty_list_on_error(self):
         with patch(
-            "services.curator.get_firestore_client",
+            "curator_agents.queries.get_firestore_client",
             side_effect=Exception("Connection failed"),
         ):
-            from services.curator import get_existing_titles
+            from curator_agents.queries import get_existing_titles
 
             titles = get_existing_titles()
             assert titles == []
@@ -166,8 +166,8 @@ class TestGetExistingTitles:
             mock_doc2,
         ]
 
-        with patch("services.curator.get_firestore_client", return_value=mock_db):
-            from services.curator import get_existing_titles
+        with patch("curator_agents.queries.get_firestore_client", return_value=mock_db):
+            from curator_agents.queries import get_existing_titles
 
             titles = get_existing_titles()
             assert titles == ["Mystery A"]
@@ -192,18 +192,18 @@ class TestGetCategoryDistribution:
         mock_db = MagicMock()
         mock_db.collection.return_value.select.return_value.stream.return_value = mock_docs
 
-        with patch("services.curator.get_firestore_client", return_value=mock_db):
-            from services.curator import get_category_distribution
+        with patch("curator_agents.queries.get_firestore_client", return_value=mock_db):
+            from curator_agents.queries import get_category_distribution
 
             dist = get_category_distribution()
             assert dist == {"HIS": 2, "OCC": 1, "FLK": 1}
 
     def test_returns_empty_dict_on_error(self):
         with patch(
-            "services.curator.get_firestore_client",
+            "curator_agents.queries.get_firestore_client",
             side_effect=Exception("Connection failed"),
         ):
-            from services.curator import get_category_distribution
+            from curator_agents.queries import get_category_distribution
 
             dist = get_category_distribution()
             assert dist == {}
@@ -230,8 +230,8 @@ class TestGetCategoryDistribution:
         mock_db = MagicMock()
         mock_db.collection.return_value.select.return_value.stream.return_value = mock_docs
 
-        with patch("services.curator.get_firestore_client", return_value=mock_db):
-            from services.curator import get_category_distribution
+        with patch("curator_agents.queries.get_firestore_client", return_value=mock_db):
+            from curator_agents.queries import get_category_distribution
 
             dist = get_category_distribution()
             assert dist == {"CRM": 1}
@@ -241,7 +241,7 @@ class TestFormatCategoryDistribution:
     """Tests for format_category_distribution helper."""
 
     def test_empty_distribution_returns_cold_start_message(self):
-        from services.curator import format_category_distribution
+        from curator_agents.queries import format_category_distribution
 
         result = format_category_distribution({})
         assert "fresh start" in result
@@ -249,7 +249,7 @@ class TestFormatCategoryDistribution:
         assert "LOC" in result
 
     def test_with_data_shows_all_categories(self):
-        from services.curator import format_category_distribution
+        from curator_agents.queries import format_category_distribution
 
         dist = {"HIS": 3, "OCC": 2, "FLK": 1}
         result = format_category_distribution(dist)
@@ -260,7 +260,7 @@ class TestFormatCategoryDistribution:
         assert "0 article(s)" in result
 
     def test_identifies_underrepresented_categories(self):
-        from services.curator import format_category_distribution
+        from curator_agents.queries import format_category_distribution
 
         # 平均 = 8/8 = 1.0 → 0件のカテゴリが underrepresented
         dist = {"HIS": 3, "OCC": 2, "FLK": 1, "ANT": 1, "URB": 1}
@@ -272,7 +272,7 @@ class TestFormatCategoryDistribution:
         assert "LOC" in result
 
     def test_uniform_distribution_no_underrepresented(self):
-        from services.curator import format_category_distribution
+        from curator_agents.queries import format_category_distribution
 
         # 全カテゴリ同数 → underrepresented なし
         dist = {cat: 2 for cat in ["HIS", "FLK", "ANT", "OCC", "URB", "CRM", "REL", "LOC"]}


### PR DESCRIPTION
## Summary

- Curator CLI (`python -m curator_agents`) がセッション状態に `{existing_titles}` しかセットしておらず、`{category_distribution}` と `{failed_themes}` がリテラル文字列のまま LLM に渡っていたバグを修正
- `curator_agents/queries.py` を新規作成し、`services/curator.py` と `curator_agents/cli.py` の重複ヘルパー関数を一元化（DRY）
- `get_existing_titles()` の `doc.to_dict()` 二重呼び出しを walrus operator で修正

## 変更ファイル

| ファイル | 操作 |
|---|---|
| `curator_agents/queries.py` | 新規作成（ドメインクエリ関数を集約） |
| `curator_agents/cli.py` | `failed_themes` + `category_distribution` をセッション状態に追加 |
| `services/curator.py` | 重複コード削除 → `queries.py` から import |
| `tests/unit/test_curator_server.py` | パッチ先を `curator_agents.queries.*` に更新 |

## Test plan

- [x] `pytest tests/unit/test_curator_server.py -v` — 16テスト全パス
- [x] import 検証 — `curator_agents.queries`, `services.curator`, `curator_agents.cli` の import 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)