### PR TITLE
fix: Storage emulator への画像アップロード失敗を修正

### DIFF
--- a/mystery_agents/tools/publisher_tools.py
+++ b/mystery_agents/tools/publisher_tools.py
@@ -171,7 +171,8 @@ def _upload_images_internal(mystery_id: str, image_paths: list[str]) -> dict:
         # 本番: Firebase Storage REST API 形式（セキュリティルール allow read: if true が適用される）
         storage_public_host = os.environ.get("STORAGE_EMULATOR_PUBLIC_HOST", "") or os.environ.get("STORAGE_EMULATOR_HOST", "")
         if storage_public_host:
-            public_url = f"{storage_public_host}/v0/b/{bucket.name}/o/{blob_name.replace('/', '%2F')}?alt=media"
+            host = storage_public_host if storage_public_host.startswith("http") else f"http://{storage_public_host}"
+            public_url = f"{host}/v0/b/{bucket.name}/o/{blob_name.replace('/', '%2F')}?alt=media"
         else:
             public_url = (
                 f"https://firebasestorage.googleapis.com/v0/b/{bucket.name}"
@@ -475,7 +476,8 @@ def upload_images(mystery_id: str, image_paths: str) -> str:
             # 本番: Firebase Storage REST API 形式（セキュリティルール allow read: if true が適用される）
             storage_public_host = os.environ.get("STORAGE_EMULATOR_PUBLIC_HOST", "") or os.environ.get("STORAGE_EMULATOR_HOST", "")
             if storage_public_host:
-                public_url = f"{storage_public_host}/v0/b/{bucket.name}/o/{blob_name.replace('/', '%2F')}?alt=media"
+                host = storage_public_host if storage_public_host.startswith("http") else f"http://{storage_public_host}"
+                public_url = f"{host}/v0/b/{bucket.name}/o/{blob_name.replace('/', '%2F')}?alt=media"
             else:
                 public_url = (
                     f"https://firebasestorage.googleapis.com/v0/b/{bucket.name}"

--- a/shared/firestore.py
+++ b/shared/firestore.py
@@ -12,11 +12,6 @@ from dotenv import load_dotenv
 # Load .env from project root
 load_dotenv(Path(__file__).parent.parent / ".env")
 
-# Storage emulator requires http:// prefix
-_storage_host = os.environ.get("STORAGE_EMULATOR_HOST", "")
-if _storage_host and not _storage_host.startswith("http"):
-    os.environ["STORAGE_EMULATOR_HOST"] = f"http://{_storage_host}"
-
 import firebase_admin
 from firebase_admin import firestore, storage
 
@@ -35,7 +30,29 @@ def get_firestore_client():
 
 
 def get_storage_bucket():
-    """Get a Cloud Storage bucket."""
-    if not firebase_admin._apps:
-        get_firestore_client()  # ensure initialized
-    return storage.bucket()
+    """Get a Cloud Storage bucket.
+
+    Emulator モードでは firebase_admin.storage を経由せず、
+    AnonymousCredentials で直接 google.cloud.storage.Client を生成する。
+    firebase_admin は ADC 認証情報を内部で使い回すため、
+    STORAGE_EMULATOR_HOST を設定しても emulator に接続できない問題を回避する。
+    """
+    storage_host = os.environ.get("STORAGE_EMULATOR_HOST", "")
+    if storage_host:
+        # Emulator モード: firebase_admin の認証を回避し anonymous credentials で接続
+        from google.auth.credentials import AnonymousCredentials
+        from google.cloud import storage as gcs_storage
+
+        api_endpoint = storage_host if storage_host.startswith("http") else f"http://{storage_host}"
+        project_id = os.environ.get("GOOGLE_CLOUD_PROJECT", "ghostinthearchive")
+        client = gcs_storage.Client(
+            project=project_id,
+            credentials=AnonymousCredentials(),
+            client_options={"api_endpoint": api_endpoint},
+        )
+        return client.bucket(f"{project_id}.appspot.com")
+    else:
+        # 本番モード: firebase_admin 経由
+        if not firebase_admin._apps:
+            get_firestore_client()
+        return storage.bucket()


### PR DESCRIPTION
## Summary

- Docker コンテナ内の Publisher が Cloud Storage emulator へのアップロードに全て失敗する問題を修正
- `firebase_admin.storage.bucket()` が ADC 認証情報を内部で使い回し、`STORAGE_EMULATOR_HOST` 環境変数による emulator モードが無視される根本原因に対処
- `get_storage_bucket()` を emulator 対応に改修し、`AnonymousCredentials` で直接接続するよう変更

## Changes

### `shared/firestore.py`
- `get_storage_bucket()`: `STORAGE_EMULATOR_HOST` 設定時は `firebase_admin.storage` を経由せず、`google.cloud.storage.Client` を `AnonymousCredentials` + emulator endpoint で直接生成
- モジュールレベルの `STORAGE_EMULATOR_HOST` 正規化ロジック（`http://` prefix 追加）を削除（各利用箇所で個別に処理）

### `mystery_agents/tools/publisher_tools.py`
- `_upload_images_internal()` と `upload_images()` の URL 構築ロジックで `http://` prefix を保証（2箇所）

## Test plan

- [x] `pytest tests/unit/ -v` — 378 tests passed
- [ ] Docker コンテナ再ビルド後、パイプライン実行で Storage emulator に画像がアップロードされることを確認
- [ ] Firestore ドキュメントの `images` フィールドに正しい emulator URL が設定されることを確認
- [ ] web-admin プレビューで画像が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)