### PR TITLE
fix: パイプラインゲートの失敗マーカー誤判定を修正

### DIFF
--- a/mystery_agents/agents/pipeline_gate.py
+++ b/mystery_agents/agents/pipeline_gate.py
@@ -26,11 +26,16 @@ _FAILURE_MARKERS = frozenset({
 
 
 def _is_meaningful(value: str) -> bool:
-    """セッション状態の値が有意なデータを含むか判定する。"""
+    """セッション状態の値が有意なデータを含むか判定する。
+
+    テキストの先頭が失敗マーカーで始まる場合のみ「無意味」と判定する。
+    ドキュメント本文の途中や末尾に部分的な失敗マーカーが含まれていても、
+    先頭に有意なデータがあれば有意とみなす。
+    """
     if not value:
         return False
-    text = str(value)
-    return not any(marker in text for marker in _FAILURE_MARKERS)
+    text = str(value).strip()
+    return not any(text.startswith(marker) for marker in _FAILURE_MARKERS)
 
 
 def _log_and_record_failure(callback_context: CallbackContext, stage: str, message: str) -> None:

--- a/tests/unit/test_pipeline_gate.py
+++ b/tests/unit/test_pipeline_gate.py
@@ -44,6 +44,26 @@ class TestIsMeaningful:
     def test_real_content_is_meaningful(self):
         assert _is_meaningful("The Bell Witch haunting of Adams, Tennessee...") is True
 
+    def test_trailing_failure_marker_is_still_meaningful(self):
+        """ドキュメント本文の末尾に失敗マーカーがあっても有意と判定する。
+
+        Librarian が資料を見つけたが、特定のサブ検索で見つからなかった場合に
+        出力末尾に NO_DOCUMENTS_FOUND を付加するケースの再現。
+        """
+        text = (
+            "**Document 1**\n"
+            "- **Title**: A history of Block Island\n"
+            "- **Source URL**: https://www.loc.gov/item/rc01002999/\n"
+            "\n---\n\n"
+            "NO_DOCUMENTS_FOUND: No English-language documents found for "
+            '"Palatine Light" in newspapers.'
+        )
+        assert _is_meaningful(text) is True
+
+    def test_whitespace_before_failure_marker_is_not_meaningful(self):
+        """先頭に空白があっても失敗マーカーで始まれば無意味と判定する。"""
+        assert _is_meaningful("  NO_DOCUMENTS_FOUND: nothing.") is False
+
 
 class TestScholarGate:
     """make_scholar_gate のテスト。"""
@@ -66,6 +86,21 @@ class TestScholarGate:
         ctx = MockCallbackContext(state={
             "selected_languages": ["en", "de"],
             "collected_documents_en": "Found 5 documents about Bell Witch...",
+            "collected_documents_de": "NO_DOCUMENTS_FOUND: No German-language documents found.",
+        })
+        gate = make_scholar_gate()
+        result = gate(ctx)
+        assert result is None
+
+    def test_docs_with_trailing_marker_proceeds(self):
+        """Librarian がドキュメントを見つけたが末尾に NO_DOCUMENTS_FOUND がある場合。"""
+        docs_with_trailing_marker = (
+            "**Document 1**\n- **Title**: A history of Block Island\n\n---\n\n"
+            "NO_DOCUMENTS_FOUND: No documents found for specific sub-query."
+        )
+        ctx = MockCallbackContext(state={
+            "selected_languages": ["en", "de"],
+            "collected_documents_en": docs_with_trailing_marker,
             "collected_documents_de": "NO_DOCUMENTS_FOUND: No German-language documents found.",
         })
         gate = make_scholar_gate()


### PR DESCRIPTION
## Summary

- Librarian がドキュメントを収集した後、末尾のサブ検索結果として `NO_DOCUMENTS_FOUND` を付加した場合にパイプライン全体が早期中断するバグを修正
- `_is_meaningful()` の判定ロジックを部分一致（`in`）から先頭一致（`startswith`）に変更

## 再現ケース

英語 Librarian が Block Island について 19 件のドキュメントを収集したが、新聞検索の結果として出力末尾に `NO_DOCUMENTS_FOUND` を追記。ScholarGate が `"NO_DOCUMENTS_FOUND" in text` で誤判定し、全ゲートがカスケード中断。

## Changes

### `mystery_agents/agents/pipeline_gate.py`
- `_is_meaningful()`: `any(marker in text ...)` → `any(text.startswith(marker) ...)` に変更
- `strip()` で先頭空白を除去してからチェック

### `tests/unit/test_pipeline_gate.py`
- 末尾に失敗マーカーがある場合に有意と判定するテスト追加
- 先頭空白 + 失敗マーカーのテスト追加
- ScholarGate で末尾マーカー付きドキュメントが通過するテスト追加

## Test plan

- [x] `pytest tests/unit/test_pipeline_gate.py -v` — 21 tests passed
- [x] `pytest tests/unit/ -v` — 381 tests passed
- [ ] Docker 再ビルド後にパイプライン再実行で ScholarGate を通過することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)