### PR TITLE
fix: 討論モード Scholar の「(no text output)」問題を修正

### DIFF
--- a/mystery_agents/agents/language_scholars.py
+++ b/mystery_agents/agents/language_scholars.py
@@ -125,8 +125,12 @@ Structure your analysis as a focused report:
 # 3. 他言語の分析と自分の分析の共通点・相違点を明確にする
 # 4. 統合分析に向けた提案を行う
 #
+# ## 出力要件
+# - 討論内容を明確で構造化されたテキストレスポンスとして提示すること
+# - テキスト出力がこの討論の主たる記録であり、パイプライン実行ログに表示される
+# - append_to_whiteboard ツールも使用して、他の Scholar が参照できるよう共有ホワイトボードに記録すること
+#
 # ## 重要
-# - 必ず append_to_whiteboard ツールを呼んで討論内容をホワイトボードに記録すること
 # - 討論結果は英語で出力すること
 # - 建設的な批判を心がけること
 # - 新たな証拠やソースがあれば引用すること
@@ -180,11 +184,13 @@ their points rather than repeating what has been said.
 - Propose which narrative best explains the cross-language evidence
 - Recommend areas where further investigation is needed
 
-## MANDATORY: Record Your Contribution
-After formulating your debate response, you MUST call `append_to_whiteboard` with:
-- speaker: "{language_name}"
-- round_number: the current round (check the whiteboard to determine which round this is)
-- contribution: your full debate response
+## Output Requirements
+
+Present your debate contribution as a clear, structured text response.
+Your text output is the primary record of this debate and appears in the pipeline execution logs.
+
+Also use the `append_to_whiteboard` tool to record your contribution to the shared whiteboard
+so other Scholars can reference it in subsequent rounds.
 
 ## Important
 - Output in **English**


### PR DESCRIPTION
## Summary

- 討論モード Scholar の instruction で、テキスト出力を「主」、`append_to_whiteboard` ツール呼び出しを「副」に重心を逆転
- `## MANDATORY: Record Your Contribution` → `## Output Requirements` に変更し、パラメータ詳細指示（speaker, round_number, contribution）を削除
- ADK の設計原則に準拠（ツールの使い方はスキーマから推論、instruction では「いつ・なぜ」のガイダンスのみ）

## Background

討論モード Scholar が `append_to_whiteboard` ツールのみを呼び出し、テキスト出力を省略するケースがあった。
現行 instruction が `MANDATORY` / `MUST` でツール呼び出しを強調していたため、LLM がツール呼び出しで仕事を完了したと判断し、テキスト出力を省略していた。

## Test plan

- [x] `pytest tests/unit/ -v -k scholar` — 22件全パス
- [ ] パイプライン実行時に討論モード Scholar のログにテキスト出力が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)