### PR TITLE
feat: 外部 API リトライ戦略を shared/http_retry.py に追加

### DIFF
--- a/mystery_agents/tools/chronicling_america.py
+++ b/mystery_agents/tools/chronicling_america.py
@@ -9,6 +9,8 @@ from typing import Any, Dict, List, Optional
 
 import requests
 
+from shared.http_retry import create_retry_session
+
 from ..schemas.document import ArchiveDocument, SourceLanguage, SourceType
 from .search_utils import build_search_query
 
@@ -31,6 +33,7 @@ BASE_URL = "https://www.loc.gov/search/"
 # Rate limiting: minimum delay between requests (seconds)
 MIN_REQUEST_DELAY = 3.0  # Conservative to respect rate limits
 _last_request_time = 0.0
+_session = create_retry_session()
 
 
 def _rate_limit() -> None:
@@ -111,7 +114,7 @@ def search_chronicling_america(
     _rate_limit()
 
     try:
-        response = requests.get(
+        response = _session.get(
             BASE_URL,
             params=params,
             timeout=30,

--- a/mystery_agents/tools/ddb.py
+++ b/mystery_agents/tools/ddb.py
@@ -11,10 +11,13 @@ from typing import Any, Dict, List, Optional
 
 import requests
 
+from shared.http_retry import create_retry_session
+
 from ..schemas.document import ArchiveDocument, SourceLanguage, SourceType
 from .search_utils import build_search_query
 
 BASE_URL = "https://api.deutsche-digitale-bibliothek.de/search"
+_session = create_retry_session()
 ITEM_URL = "https://www.deutsche-digitale-bibliothek.de/item"
 MIN_REQUEST_DELAY = 1.0
 _last_request_time = 0.0
@@ -73,7 +76,7 @@ def search_ddb(
     _rate_limit()
 
     try:
-        response = requests.get(
+        response = _session.get(
             BASE_URL,
             params=params,
             headers=headers,

--- a/mystery_agents/tools/dpla.py
+++ b/mystery_agents/tools/dpla.py
@@ -11,10 +11,13 @@ from typing import Any, Dict, List, Optional
 
 import requests
 
+from shared.http_retry import create_retry_session
+
 from ..schemas.document import ArchiveDocument, SourceLanguage, SourceType
 from .search_utils import build_search_query
 
 BASE_URL = "https://api.dp.la/v2/items"
+_session = create_retry_session()
 MIN_REQUEST_DELAY = 1.0
 _last_request_time = 0.0
 
@@ -84,7 +87,7 @@ def search_dpla(
     _rate_limit()
 
     try:
-        response = requests.get(
+        response = _session.get(
             BASE_URL,
             params=params,
             timeout=30,

--- a/mystery_agents/tools/internet_archive.py
+++ b/mystery_agents/tools/internet_archive.py
@@ -10,10 +10,13 @@ from typing import Any, Dict, List, Optional
 
 import requests
 
+from shared.http_retry import create_retry_session
+
 from ..schemas.document import ArchiveDocument, SourceLanguage, SourceType
 from .search_utils import build_search_query
 
 BASE_URL = "https://archive.org/advancedsearch.php"
+_session = create_retry_session()
 MIN_REQUEST_DELAY = 2.0
 _last_request_time = 0.0
 
@@ -83,7 +86,7 @@ def search_internet_archive(
     _rate_limit()
 
     try:
-        response = requests.get(
+        response = _session.get(
             BASE_URL,
             params=params,
             timeout=30,

--- a/mystery_agents/tools/link_validator.py
+++ b/mystery_agents/tools/link_validator.py
@@ -12,6 +12,8 @@ from urllib.parse import urlparse
 
 import requests
 
+from shared.http_retry import create_retry_session
+
 from ..schemas.document import ArchiveDocument, SourceType
 
 logger = logging.getLogger(__name__)
@@ -21,6 +23,9 @@ _DEAD_LINK_STATUSES = {404, 410}
 
 # SourceType ごとの期待ドメインリスト
 # 空リスト = ドメイン検証スキップ（DPLA のようにパートナー機関ドメインが多様なケース）
+# リンク検証は URL 数が多いためリトライ回数を抑制
+_session = create_retry_session(retries=2)
+
 EXPECTED_DOMAINS: dict[SourceType, list[str]] = {
     SourceType.NEWSPAPER: ["loc.gov"],
     SourceType.LOC_DIGITAL: ["loc.gov"],
@@ -92,11 +97,11 @@ def verify_link(
     """
     start = time.monotonic()
     try:
-        resp = requests.head(url, timeout=timeout, allow_redirects=True)
+        resp = _session.head(url, timeout=timeout, allow_redirects=True)
 
         # HEAD 非対応の場合は GET にフォールバック
         if resp.status_code == 405:
-            resp = requests.get(url, timeout=timeout, stream=True)
+            resp = _session.get(url, timeout=timeout, stream=True)
             resp.close()
 
         elapsed_ms = int((time.monotonic() - start) * 1000)

--- a/mystery_agents/tools/loc_digital.py
+++ b/mystery_agents/tools/loc_digital.py
@@ -10,10 +10,13 @@ from typing import Any, Dict, List, Optional
 
 import requests
 
+from shared.http_retry import create_retry_session
+
 from ..schemas.document import ArchiveDocument, SourceLanguage, SourceType
 from .search_utils import build_search_query
 
 BASE_URL = "https://www.loc.gov/search/"
+_session = create_retry_session()
 MIN_REQUEST_DELAY = 3.0
 _last_request_time = 0.0
 
@@ -63,7 +66,7 @@ def search_loc_digital(
     _rate_limit()
 
     try:
-        response = requests.get(
+        response = _session.get(
             BASE_URL,
             params=params,
             timeout=30,

--- a/mystery_agents/tools/nypl_digital.py
+++ b/mystery_agents/tools/nypl_digital.py
@@ -11,10 +11,13 @@ from typing import Any, Dict, List, Optional
 
 import requests
 
+from shared.http_retry import create_retry_session
+
 from ..schemas.document import ArchiveDocument, SourceLanguage, SourceType
 from .search_utils import build_search_query
 
 BASE_URL = "https://api.repo.nypl.org/api/v2/items/search"
+_session = create_retry_session()
 MIN_REQUEST_DELAY = 1.0
 _last_request_time = 0.0
 
@@ -68,7 +71,7 @@ def search_nypl(
     _rate_limit()
 
     try:
-        response = requests.get(
+        response = _session.get(
             BASE_URL,
             params=params,
             timeout=30,

--- a/shared/http_retry.py
+++ b/shared/http_retry.py
@@ -1,0 +1,47 @@
+"""リトライ付き requests.Session ファクトリ。
+
+外部アーカイブ API（LOC, DPLA, Internet Archive 等）への HTTP リクエストに
+指数バックオフ付きリトライを適用する。新規依存なし（urllib3 は requests に同梱）。
+
+既存の _rate_limit() とは補完関係:
+- _rate_limit(): リクエスト間の最小間隔を保証（サーバー負荷軽減）
+- create_retry_session(): 一時的なエラー（429, 5xx）に対する自動リトライ
+"""
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+
+def create_retry_session(
+    retries: int = 3,
+    backoff_factor: float = 1.0,
+    status_forcelist: tuple[int, ...] = (429, 500, 502, 503, 504),
+) -> requests.Session:
+    """指数バックオフ付きリトライ Session を生成する。
+
+    リトライ間隔: backoff_factor * (2 ** (retry_count - 1))
+    例: backoff_factor=1.0 → 1s, 2s, 4s
+
+    Args:
+        retries: 最大リトライ回数（デフォルト 3）
+        backoff_factor: バックオフ係数（デフォルト 1.0）
+        status_forcelist: リトライ対象の HTTP ステータスコード
+
+    Returns:
+        リトライ設定済みの requests.Session
+    """
+    retry = Retry(
+        total=retries,
+        backoff_factor=backoff_factor,
+        status_forcelist=status_forcelist,
+        allowed_methods=["GET", "HEAD"],
+        raise_on_status=False,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+
+    session = requests.Session()
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+
+    return session

--- a/tests/unit/test_http_retry.py
+++ b/tests/unit/test_http_retry.py
@@ -1,0 +1,152 @@
+"""Tests for shared/http_retry.py のリトライ動作検証。"""
+
+import responses
+
+from shared.http_retry import create_retry_session
+
+
+class TestCreateRetrySession:
+    """create_retry_session のテスト。"""
+
+    def test_returns_session_with_adapters(self):
+        """HTTPS/HTTP アダプタがマウントされている。"""
+        session = create_retry_session()
+        assert "https://" in session.adapters
+        assert "http://" in session.adapters
+
+    def test_custom_retries(self):
+        """retries パラメータが適用される。"""
+        session = create_retry_session(retries=5)
+        adapter = session.get_adapter("https://example.com")
+        assert adapter.max_retries.total == 5
+
+    def test_custom_backoff_factor(self):
+        """backoff_factor パラメータが適用される。"""
+        session = create_retry_session(backoff_factor=2.0)
+        adapter = session.get_adapter("https://example.com")
+        assert adapter.max_retries.backoff_factor == 2.0
+
+    def test_custom_status_forcelist(self):
+        """status_forcelist パラメータが適用される。"""
+        session = create_retry_session(status_forcelist=(503,))
+        adapter = session.get_adapter("https://example.com")
+        assert 503 in adapter.max_retries.status_forcelist
+
+    def test_default_status_forcelist(self):
+        """デフォルトの status_forcelist に 429 と 5xx が含まれる。"""
+        session = create_retry_session()
+        adapter = session.get_adapter("https://example.com")
+        forcelist = adapter.max_retries.status_forcelist
+        assert 429 in forcelist
+        assert 500 in forcelist
+        assert 502 in forcelist
+        assert 503 in forcelist
+        assert 504 in forcelist
+
+
+class TestRetryBehavior:
+    """responses ライブラリでリトライ動作をシミュレート。"""
+
+    @responses.activate
+    def test_success_on_first_try(self):
+        """初回成功時はリトライなしで結果を返す。"""
+        responses.add(
+            responses.GET,
+            "https://api.example.com/search",
+            json={"results": []},
+            status=200,
+        )
+        session = create_retry_session()
+        resp = session.get("https://api.example.com/search", timeout=5)
+
+        assert resp.status_code == 200
+        assert len(responses.calls) == 1
+
+    @responses.activate
+    def test_retry_on_server_error(self):
+        """500 エラー後にリトライして成功する。"""
+        responses.add(
+            responses.GET,
+            "https://api.example.com/search",
+            status=500,
+        )
+        responses.add(
+            responses.GET,
+            "https://api.example.com/search",
+            json={"results": []},
+            status=200,
+        )
+        session = create_retry_session(retries=3, backoff_factor=0)
+        resp = session.get("https://api.example.com/search", timeout=5)
+
+        assert resp.status_code == 200
+        assert len(responses.calls) == 2
+
+    @responses.activate
+    def test_retry_on_429(self):
+        """429 Too Many Requests でリトライする。"""
+        responses.add(
+            responses.GET,
+            "https://api.example.com/search",
+            status=429,
+        )
+        responses.add(
+            responses.GET,
+            "https://api.example.com/search",
+            json={"results": []},
+            status=200,
+        )
+        session = create_retry_session(retries=3, backoff_factor=0)
+        resp = session.get("https://api.example.com/search", timeout=5)
+
+        assert resp.status_code == 200
+        assert len(responses.calls) == 2
+
+    @responses.activate
+    def test_no_retry_on_404(self):
+        """404 はリトライ対象外。"""
+        responses.add(
+            responses.GET,
+            "https://api.example.com/search",
+            status=404,
+        )
+        session = create_retry_session(retries=3, backoff_factor=0)
+        resp = session.get("https://api.example.com/search", timeout=5)
+
+        assert resp.status_code == 404
+        assert len(responses.calls) == 1
+
+    @responses.activate
+    def test_exhausted_retries_returns_last_response(self):
+        """リトライ上限到達時は最後のレスポンスを返す（raise_on_status=False）。"""
+        for _ in range(4):
+            responses.add(
+                responses.GET,
+                "https://api.example.com/search",
+                status=503,
+            )
+        session = create_retry_session(retries=3, backoff_factor=0)
+        resp = session.get("https://api.example.com/search", timeout=5)
+
+        assert resp.status_code == 503
+        # 初回 + 3回リトライ = 4回
+        assert len(responses.calls) == 4
+
+    @responses.activate
+    def test_head_request_also_retries(self):
+        """HEAD リクエストもリトライ対象。"""
+        responses.add(
+            responses.HEAD,
+            "https://example.com/doc",
+            status=502,
+        )
+        responses.add(
+            responses.HEAD,
+            "https://example.com/doc",
+            status=200,
+        )
+        session = create_retry_session(retries=3, backoff_factor=0)
+        resp = session.head("https://example.com/doc", timeout=5)
+
+        assert resp.status_code == 200
+        assert len(responses.calls) == 2


### PR DESCRIPTION
## 概要

- `shared/http_retry.py` にリトライ付き `requests.Session` ファクトリを新設
- `urllib3.util.retry.Retry` + `requests.adapters.HTTPAdapter` を使用（新規依存なし）
- 全7つのアーカイブ API ツールで共有セッションを使用するよう変更

## 変更内容

- `shared/http_retry.py`: `create_retry_session()` ファクトリ（指数バックオフ、429/5xx リトライ）
- 7ファイルで `requests.get/head()` → `_session.get/head()` に置換:
  - `chronicling_america.py`, `ddb.py`, `dpla.py`, `internet_archive.py`
  - `loc_digital.py`, `nypl_digital.py`, `link_validator.py`（retries=2）
- `tests/unit/test_http_retry.py`: リトライ動作検証テスト（11件）

## 設計判断

- 既存の `_rate_limit()` はそのまま維持（レート制限とリトライは補完関係）
- `link_validator.py` は URL 数が多いため `retries=2` に抑制
- `raise_on_status=False`: 既存コードが `response.raise_for_status()` で処理済みのため

## テスト計画

- [x] `test_http_retry.py` 全11件パス
- [x] 既存テスト全件パス（463件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>