### PR TITLE
refactor: テストスイート整理（ボイラープレート削除 + FakeInMemorySessionService導入）

### DIFF
--- a/.claude/skills/tdd/SKILL.md
+++ b/.claude/skills/tdd/SKILL.md
@@ -30,12 +30,38 @@ disable-model-invocation: false
 
 4. **最終確認**: `pytest tests/unit/ -v --tb=short`
 
+## 量より質 — テストで検証すべきもの / すべきでないもの
+
+### テストすべきもの（プロジェクト固有の価値）
+
+- カスタムバリデーション（`@field_validator`, `@model_validator`, `max_length` 等）
+- ビジネスロジック関数（フィルタリング、変換、パース）
+- 定数間の整合性（例: `TRANSLATION_LANGUAGES ⊂ ALLOWED_LANGUAGES`）
+- モジュール間の再エクスポート一致
+- エージェント間連携（output_key / プレースホルダーの静的検証）
+- 耐障害性（外部サービス障害がメインプロセスを停止させないこと）
+- 各スキーマの happy path（`test_valid_*`）— 契約ドキュメントとして 1 つ維持
+
+### テストすべきでないもの（フレームワーク / 標準ライブラリの再テスト）
+
+- Pydantic の標準動作: 必須フィールド検証、Enum 検証、Optional デフォルト、`default_factory`、`use_enum_values` config
+- Enum 値の羅列チェック（値が変われば happy path テストも壊れる）
+- ハードコード定数の値アサーション（設定値の変更 = テスト修正の二重管理）
+- Python 標準機能: `frozen=True` dataclass の不変性、`isinstance` 型チェック
+
+## モックよりフェイクを優先する
+
+- 同じモック設定が 3 箇所以上で重複する場合は、フェイクオブジェクト（`tests/fakes.py`）を作成する
+- フェイクは実際の API サーフェスのみ実装し、テストが何を検証しているか明確にする
+- `AsyncMock` のチェーン（`mock.attr.attr = AsyncMock(return_value=...)`）が 3 段以上になる場合はフェイクに置き換えを検討する
+
 ## テスト肥大化防止ルール
 
 - **1:1 マッピング**: 1つのソースモジュールにつきテストファイルは最大1つ。同一ソースモジュールに対する複数テストファイルが存在する場合は統合する
 - **追加前に重複チェック**: `pytest tests/ -v --collect-only -k "function_name"` で同じ振る舞いのテストが既にないか確認してから追加する
 - **インフラ制約で通らないテストは削除**: MagicMock 等の制約で意味のあるアサーションができないテストは保持しない（例: conftest が LlmAgent を MagicMock に置換する環境でのモデル名比較）
 - **カバレッジ重複は統合**: 同一の振る舞いを検証する複数テストは1つに統合する
+- **フレームワーク信頼の原則**: Pydantic / dataclass / Enum 等の標準動作はテスト不要。プロジェクト固有のカスタムバリデーションのみテストする
 
 ## テスト不要のケース
 
@@ -43,7 +69,7 @@ disable-model-invocation: false
 - コメントの追加・修正
 - 型ヒントの追加（ロジック変更なし）
 - 設定ファイルの軽微な調整
-- エージェントのモデル割当変更（`test_model_config.py` の定数テストでカバー済み）
+- エージェントのモデル割当変更（ファクトリ関数の呼び出しテストでカバー済み、モデル名文字列の定数テストは不要）
 
 ## テストファイル配置規則（1:1 マッピング）
 
@@ -68,9 +94,14 @@ disable-model-invocation: false
 | `shared/model_config.py` | `tests/unit/test_model_config.py` |
 | `shared/pipeline_failure.py` | `tests/unit/test_pipeline_failure.py` |
 | `shared/pipeline_run.py` | `tests/unit/test_pipeline_run.py` |
+| `shared/orchestrator.py` | `tests/unit/test_orchestrator.py` |
 | `services/mystery_pipeline.py` | `tests/unit/test_pipeline_server.py` |
 | `services/curator.py` | `tests/unit/test_curator_server.py` |
+| `podcast_agents/tools/script_tools.py`（save_podcast_script） | `tests/unit/test_script_tools.py` |
+| `podcast_agents/tools/script_tools.py`（多段階生成ツール） | `tests/unit/test_script_planner_tools.py` |
+| `podcast_agents/agents/script_planner.py` | `tests/unit/test_script_planner.py` |
 | Publisher 多言語統合 | `tests/unit/test_publisher_multilingual.py` |
+| テスト用フェイクオブジェクト | `tests/fakes.py` |
 | エージェント間連携（統合） | `tests/integration/test_agent_handover.py` |
 | Publisher ツール（統合） | `tests/integration/test_publisher_tools.py` |
 | エージェント品質（eval） | `tests/eval/eval_sets/*.json` |

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -1,0 +1,35 @@
+"""テスト用フェイクオブジェクト。
+
+同じモック設定が 3 箇所以上で重複する場合にフェイクを提供し、
+テストの可読性と保守性を向上させる。
+"""
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class FakeSession:
+    """ADK InMemorySessionService のセッションを模倣するフェイク。"""
+
+    state: dict = field(default_factory=dict)
+
+
+class FakeInMemorySessionService:
+    """ADK InMemorySessionService のフェイク実装。
+
+    create_session / get_session の最小限の API サーフェスのみ実装する。
+    post_run_state を指定すると、get_session 時にセッション状態を差し替えて
+    Runner 実行後の状態をシミュレートできる。
+    """
+
+    def __init__(self, post_run_state=None):
+        self._session = None
+        self._post_run_state = post_run_state
+
+    async def create_session(self, *, app_name, user_id, session_id, state):
+        self._session = FakeSession(state=dict(state))
+
+    async def get_session(self, *, app_name, user_id, session_id):
+        if self._post_run_state is not None:
+            self._session.state = self._post_run_state
+        return self._session

--- a/tests/unit/test_constants.py
+++ b/tests/unit/test_constants.py
@@ -4,27 +4,12 @@ from shared.constants import (
     ALLOWED_LANGUAGES,
     DEFAULT_SELECTED_LANGUAGES,
     MAX_LANGUAGES,
-    SCHEMA_VERSION,
-    STATUS_PENDING,
-    STATUS_PUBLISHED,
     TRANSLATION_LANGUAGES,
 )
 
 
 class TestLanguageConstants:
     """言語定数の整合性テスト。"""
-
-    def test_allowed_languages_set(self):
-        """許可言語セットが正しい。"""
-        assert ALLOWED_LANGUAGES == {"en", "de", "es", "fr", "nl", "pt"}
-
-    def test_max_languages_is_4(self):
-        """最大言語数が 4。"""
-        assert MAX_LANGUAGES == 4
-
-    def test_default_selected_languages_is_en(self):
-        """デフォルト選択言語が ["en"]。"""
-        assert DEFAULT_SELECTED_LANGUAGES == ["en"]
 
     def test_translation_languages_excludes_en(self):
         """翻訳対象言語に英語は含まれない（英語はソース言語）。"""
@@ -43,18 +28,6 @@ class TestLanguageConstants:
         """デフォルト言語は ALLOWED_LANGUAGES に含まれる。"""
         for lang in DEFAULT_SELECTED_LANGUAGES:
             assert lang in ALLOWED_LANGUAGES
-
-
-class TestStatusConstants:
-    """ステータス・スキーマ定数のテスト。"""
-
-    def test_status_values_are_strings(self):
-        assert isinstance(STATUS_PENDING, str)
-        assert isinstance(STATUS_PUBLISHED, str)
-
-    def test_schema_version_is_positive_int(self):
-        assert isinstance(SCHEMA_VERSION, int)
-        assert SCHEMA_VERSION > 0
 
 
 class TestReexportConsistency:

--- a/tests/unit/test_curator_schemas.py
+++ b/tests/unit/test_curator_schemas.py
@@ -22,11 +22,6 @@ class TestAllCategories:
         expected = [code.value for code in ClassificationCode]
         assert ALL_CATEGORIES == expected
 
-    def test_contains_all_8_codes(self):
-        assert len(ALL_CATEGORIES) == 8
-        for code in ["HIS", "FLK", "ANT", "OCC", "URB", "CRM", "REL", "LOC"]:
-            assert code in ALL_CATEGORIES
-
 
 class TestThemeSuggestion:
     """ThemeSuggestion Pydantic モデルの検証。"""
@@ -65,16 +60,6 @@ class TestThemeSuggestion:
         }
         with pytest.raises(Exception):
             ThemeSuggestion.model_validate(data)
-
-    def test_all_valid_categories_accepted(self):
-        for code in ALL_CATEGORIES:
-            data = {
-                "theme": "Test",
-                "description": "Test",
-                "category": code,
-            }
-            suggestion = ThemeSuggestion.model_validate(data)
-            assert suggestion.category == code
 
 
 class TestValidateSuggestions:

--- a/tests/unit/test_model_config.py
+++ b/tests/unit/test_model_config.py
@@ -1,25 +1,13 @@
 """shared/model_config のユニットテスト。
 
 Gemini モデルアダプタのリトライ設定ファクトリ関数が
-正常に呼び出せること、モデル名定数が正しいことを検証する。
+正常に呼び出せることを検証する。
 """
 
 from shared.model_config import (
-    MODEL_FLASH,
-    MODEL_PRO,
     create_flash_model,
     create_pro_model,
 )
-
-
-class TestModelConstants:
-    """モデル名定数のテスト。"""
-
-    def test_model_pro_name(self):
-        assert MODEL_PRO == "gemini-3-pro-preview"
-
-    def test_model_flash_name(self):
-        assert MODEL_FLASH == "gemini-2.5-flash"
 
 
 class TestCreateProModel:

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1,10 +1,11 @@
 """Unit tests for shared/orchestrator.py"""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from shared.orchestrator import PipelineResult, run_pipeline
+from tests.fakes import FakeInMemorySessionService
 
 
 def _make_event(author: str | None = None, text: str | None = None):
@@ -21,6 +22,23 @@ def _make_event(author: str | None = None, text: str | None = None):
         event.content = None
 
     return event
+
+
+def _make_runner(events=None):
+    """テスト用の Runner モックを生成する。
+
+    events が None の場合は空の AsyncGenerator を返す。
+    """
+    async def mock_run_async(**kwargs):
+        if events:
+            for e in events:
+                yield e
+        return
+        yield  # AsyncGenerator にするために必要
+
+    runner = MagicMock()
+    runner.run_async = mock_run_async
+    return runner
 
 
 class TestPipelineResult:
@@ -46,28 +64,12 @@ class TestRunPipeline:
         self, mock_create, mock_started, mock_completed, mock_complete
     ):
         """run_id 未指定時に pipeline_run を自動作成する。"""
-        agent = MagicMock()
+        fake_session = FakeInMemorySessionService()
 
-        # Runner.run_async を AsyncGenerator としてモック
-        async def mock_run_async(**kwargs):
-            return
-            yield  # AsyncGenerator にするために必要
-
-        mock_runner_instance = MagicMock()
-        mock_runner_instance.run_async = mock_run_async
-
-        # InMemorySessionService のモック
-        mock_session = MagicMock()
-        mock_session.state = {}
-
-        mock_session_service = AsyncMock()
-        mock_session_service.create_session = AsyncMock()
-        mock_session_service.get_session = AsyncMock(return_value=mock_session)
-
-        with patch("shared.orchestrator.Runner", return_value=mock_runner_instance), \
-             patch("shared.orchestrator.InMemorySessionService", return_value=mock_session_service):
+        with patch("shared.orchestrator.Runner", return_value=_make_runner()), \
+             patch("shared.orchestrator.InMemorySessionService", return_value=fake_session):
             result = await run_pipeline(
-                agent=agent,
+                agent=MagicMock(),
                 app_name="test_app",
                 user_message="test query",
                 initial_state={"key": "value"},
@@ -86,26 +88,12 @@ class TestRunPipeline:
         self, mock_create, mock_started, mock_completed, mock_complete
     ):
         """run_id 指定時は pipeline_run を新規作成しない。"""
-        agent = MagicMock()
+        fake_session = FakeInMemorySessionService()
 
-        async def mock_run_async(**kwargs):
-            return
-            yield
-
-        mock_runner_instance = MagicMock()
-        mock_runner_instance.run_async = mock_run_async
-
-        mock_session = MagicMock()
-        mock_session.state = {}
-
-        mock_session_service = AsyncMock()
-        mock_session_service.create_session = AsyncMock()
-        mock_session_service.get_session = AsyncMock(return_value=mock_session)
-
-        with patch("shared.orchestrator.Runner", return_value=mock_runner_instance), \
-             patch("shared.orchestrator.InMemorySessionService", return_value=mock_session_service):
+        with patch("shared.orchestrator.Runner", return_value=_make_runner()), \
+             patch("shared.orchestrator.InMemorySessionService", return_value=fake_session):
             result = await run_pipeline(
-                agent=agent,
+                agent=MagicMock(),
                 app_name="test_app",
                 user_message="test query",
                 initial_state={},
@@ -124,31 +112,16 @@ class TestRunPipeline:
         self, mock_create, mock_started, mock_completed, mock_complete
     ):
         """エージェント遷移が正しく追跡される。"""
-        agent = MagicMock()
-
         events = [
             _make_event(author="librarian", text="Found documents"),
             _make_event(author="scholar", text="Analysis complete"),
         ]
+        fake_session = FakeInMemorySessionService()
 
-        async def mock_run_async(**kwargs):
-            for e in events:
-                yield e
-
-        mock_runner_instance = MagicMock()
-        mock_runner_instance.run_async = mock_run_async
-
-        mock_session = MagicMock()
-        mock_session.state = {}
-
-        mock_session_service = AsyncMock()
-        mock_session_service.create_session = AsyncMock()
-        mock_session_service.get_session = AsyncMock(return_value=mock_session)
-
-        with patch("shared.orchestrator.Runner", return_value=mock_runner_instance), \
-             patch("shared.orchestrator.InMemorySessionService", return_value=mock_session_service):
+        with patch("shared.orchestrator.Runner", return_value=_make_runner(events)), \
+             patch("shared.orchestrator.InMemorySessionService", return_value=fake_session):
             result = await run_pipeline(
-                agent=agent,
+                agent=MagicMock(),
                 app_name="test_app",
                 user_message="test",
                 initial_state={},
@@ -170,31 +143,16 @@ class TestRunPipeline:
         self, mock_create, mock_started, mock_completed, mock_complete
     ):
         """skip_authors に含まれるエージェントはログ対象外。"""
-        agent = MagicMock()
-
         events = [
             _make_event(author="ghost_commander", text="Starting"),
             _make_event(author="librarian", text="Found documents"),
         ]
+        fake_session = FakeInMemorySessionService()
 
-        async def mock_run_async(**kwargs):
-            for e in events:
-                yield e
-
-        mock_runner_instance = MagicMock()
-        mock_runner_instance.run_async = mock_run_async
-
-        mock_session = MagicMock()
-        mock_session.state = {}
-
-        mock_session_service = AsyncMock()
-        mock_session_service.create_session = AsyncMock()
-        mock_session_service.get_session = AsyncMock(return_value=mock_session)
-
-        with patch("shared.orchestrator.Runner", return_value=mock_runner_instance), \
-             patch("shared.orchestrator.InMemorySessionService", return_value=mock_session_service):
+        with patch("shared.orchestrator.Runner", return_value=_make_runner(events)), \
+             patch("shared.orchestrator.InMemorySessionService", return_value=fake_session):
             result = await run_pipeline(
-                agent=agent,
+                agent=MagicMock(),
                 app_name="test_app",
                 user_message="test",
                 initial_state={},
@@ -215,31 +173,16 @@ class TestRunPipeline:
         self, mock_create, mock_started, mock_completed, mock_complete
     ):
         """テキスト出力時に on_text コールバックが呼ばれる。"""
-        agent = MagicMock()
         received_texts = []
-
         events = [
             _make_event(author="storyteller", text="Once upon a time"),
         ]
+        fake_session = FakeInMemorySessionService()
 
-        async def mock_run_async(**kwargs):
-            for e in events:
-                yield e
-
-        mock_runner_instance = MagicMock()
-        mock_runner_instance.run_async = mock_run_async
-
-        mock_session = MagicMock()
-        mock_session.state = {}
-
-        mock_session_service = AsyncMock()
-        mock_session_service.create_session = AsyncMock()
-        mock_session_service.get_session = AsyncMock(return_value=mock_session)
-
-        with patch("shared.orchestrator.Runner", return_value=mock_runner_instance), \
-             patch("shared.orchestrator.InMemorySessionService", return_value=mock_session_service):
+        with patch("shared.orchestrator.Runner", return_value=_make_runner(events)), \
+             patch("shared.orchestrator.InMemorySessionService", return_value=fake_session):
             await run_pipeline(
-                agent=agent,
+                agent=MagicMock(),
                 app_name="test_app",
                 user_message="test",
                 initial_state={},
@@ -253,23 +196,19 @@ class TestRunPipeline:
     @patch("shared.orchestrator.create_pipeline_run", return_value="run-005")
     async def test_error_marks_pipeline_run(self, mock_create, mock_error):
         """例外発生時に pipeline_run をエラーマークする。"""
-        agent = MagicMock()
-
-        async def mock_run_async(**kwargs):
+        async def error_run_async(**kwargs):
             raise RuntimeError("Something went wrong")
             yield
 
-        mock_runner_instance = MagicMock()
-        mock_runner_instance.run_async = mock_run_async
+        runner = MagicMock()
+        runner.run_async = error_run_async
+        fake_session = FakeInMemorySessionService()
 
-        mock_session_service = AsyncMock()
-        mock_session_service.create_session = AsyncMock()
-
-        with patch("shared.orchestrator.Runner", return_value=mock_runner_instance), \
-             patch("shared.orchestrator.InMemorySessionService", return_value=mock_session_service):
+        with patch("shared.orchestrator.Runner", return_value=runner), \
+             patch("shared.orchestrator.InMemorySessionService", return_value=fake_session):
             with pytest.raises(RuntimeError, match="Something went wrong"):
                 await run_pipeline(
-                    agent=agent,
+                    agent=MagicMock(),
                     app_name="test_app",
                     user_message="test",
                     initial_state={},
@@ -286,28 +225,17 @@ class TestRunPipeline:
         self, mock_create, mock_started, mock_completed, mock_complete
     ):
         """blog パイプラインでは session state から mystery_id を抽出する。"""
-        agent = MagicMock()
+        # Runner 実行後のセッション状態をシミュレート
+        fake_session = FakeInMemorySessionService(
+            post_run_state={
+                "published_episode": '{"mystery_id": "OCC-MA-617-20260208143025", "status": "success"}'
+            }
+        )
 
-        async def mock_run_async(**kwargs):
-            return
-            yield
-
-        mock_runner_instance = MagicMock()
-        mock_runner_instance.run_async = mock_run_async
-
-        mock_session = MagicMock()
-        mock_session.state = {
-            "published_episode": '{"mystery_id": "OCC-MA-617-20260208143025", "status": "success"}'
-        }
-
-        mock_session_service = AsyncMock()
-        mock_session_service.create_session = AsyncMock()
-        mock_session_service.get_session = AsyncMock(return_value=mock_session)
-
-        with patch("shared.orchestrator.Runner", return_value=mock_runner_instance), \
-             patch("shared.orchestrator.InMemorySessionService", return_value=mock_session_service):
+        with patch("shared.orchestrator.Runner", return_value=_make_runner()), \
+             patch("shared.orchestrator.InMemorySessionService", return_value=fake_session):
             result = await run_pipeline(
-                agent=agent,
+                agent=MagicMock(),
                 app_name="test_app",
                 user_message="test",
                 initial_state={},
@@ -324,26 +252,12 @@ class TestRunPipeline:
         self, mock_create, mock_complete
     ):
         """podcast パイプラインでは mystery_id 抽出をスキップする。"""
-        agent = MagicMock()
+        fake_session = FakeInMemorySessionService()
 
-        async def mock_run_async(**kwargs):
-            return
-            yield
-
-        mock_runner_instance = MagicMock()
-        mock_runner_instance.run_async = mock_run_async
-
-        mock_session = MagicMock()
-        mock_session.state = {}
-
-        mock_session_service = AsyncMock()
-        mock_session_service.create_session = AsyncMock()
-        mock_session_service.get_session = AsyncMock(return_value=mock_session)
-
-        with patch("shared.orchestrator.Runner", return_value=mock_runner_instance), \
-             patch("shared.orchestrator.InMemorySessionService", return_value=mock_session_service):
+        with patch("shared.orchestrator.Runner", return_value=_make_runner()), \
+             patch("shared.orchestrator.InMemorySessionService", return_value=fake_session):
             result = await run_pipeline(
-                agent=agent,
+                agent=MagicMock(),
                 app_name="test_app",
                 user_message="test",
                 initial_state={},

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -6,62 +6,13 @@ from pydantic import ValidationError
 from mystery_agents.schemas.document import (
     ArchiveDocument,
     SearchResults,
-    SourceLanguage,
-    SourceType,
 )
 from mystery_agents.schemas.mystery_report import (
     AnalysisResults,
-    ConfidenceLevel,
-    DiscrepancyType,
     Evidence,
     HistoricalContext,
     MysteryReport,
 )
-
-
-class TestSourceEnums:
-    """Tests for source-related enums."""
-
-    def test_source_language_values(self):
-        """SourceLanguage enum should have all supported language values."""
-        assert SourceLanguage.EN.value == "en"
-        assert SourceLanguage.ES.value == "es"
-        assert SourceLanguage.DE.value == "de"
-        assert SourceLanguage.FR.value == "fr"
-        assert SourceLanguage.NL.value == "nl"
-        assert SourceLanguage.PT.value == "pt"
-
-    def test_source_type_values(self):
-        """SourceType enum should have all archive source types."""
-        expected_types = [
-            "newspaper", "loc_digital", "dpla", "nypl", "pares",
-            "internet_archive", "ddb",
-        ]
-        actual_types = [st.value for st in SourceType]
-        assert set(expected_types) == set(actual_types)
-
-
-class TestDiscrepancyEnums:
-    """Tests for discrepancy-related enums."""
-
-    def test_discrepancy_type_values(self):
-        """DiscrepancyType enum should have all discrepancy categories."""
-        expected = [
-            "date_mismatch",
-            "person_missing",
-            "event_outcome",
-            "location_conflict",
-            "narrative_gap",
-            "name_variant",
-        ]
-        actual = [dt.value for dt in DiscrepancyType]
-        assert set(expected) == set(actual)
-
-    def test_confidence_level_values(self):
-        """ConfidenceLevel enum should have high, medium, low."""
-        assert ConfidenceLevel.HIGH.value == "high"
-        assert ConfidenceLevel.MEDIUM.value == "medium"
-        assert ConfidenceLevel.LOW.value == "low"
 
 
 class TestArchiveDocument:
@@ -74,50 +25,6 @@ class TestArchiveDocument:
         assert doc.language == "en"
         assert doc.source_type == "newspaper"
 
-    def test_missing_required_field(self, sample_archive_document_data):
-        """Missing required field should raise ValidationError."""
-        del sample_archive_document_data["title"]
-        with pytest.raises(ValidationError) as exc_info:
-            ArchiveDocument(**sample_archive_document_data)
-        assert "title" in str(exc_info.value)
-
-    def test_invalid_language_enum(self, sample_archive_document_data):
-        """Invalid language should raise ValidationError."""
-        sample_archive_document_data["language"] = "invalid"
-        with pytest.raises(ValidationError) as exc_info:
-            ArchiveDocument(**sample_archive_document_data)
-        assert "language" in str(exc_info.value)
-
-    def test_invalid_source_type_enum(self, sample_archive_document_data):
-        """Invalid source_type should raise ValidationError."""
-        sample_archive_document_data["source_type"] = "invalid_source"
-        with pytest.raises(ValidationError) as exc_info:
-            ArchiveDocument(**sample_archive_document_data)
-        assert "source_type" in str(exc_info.value)
-
-    def test_optional_fields_default_to_none(self):
-        """Optional fields should default to None or empty list."""
-        minimal_data = {
-            "title": "Test",
-            "source_url": "https://example.com",
-            "summary": "Test summary",
-            "language": "en",
-            "location": "Boston",
-            "source_type": "newspaper",
-        }
-        doc = ArchiveDocument(**minimal_data)
-        assert doc.date is None
-        assert doc.raw_text is None
-        assert doc.record_group is None
-        assert doc.keywords_matched == []
-
-    def test_use_enum_values_config(self, sample_archive_document_data):
-        """use_enum_values should serialize enums as strings."""
-        doc = ArchiveDocument(**sample_archive_document_data)
-        data = doc.model_dump()
-        assert data["language"] == "en"
-        assert data["source_type"] == "newspaper"
-
 
 class TestSearchResults:
     """Tests for SearchResults schema."""
@@ -129,21 +36,6 @@ class TestSearchResults:
         assert len(results.documents) == 1
         assert results.total_found == 1
 
-    def test_default_values(self):
-        """Default values should be applied correctly."""
-        results = SearchResults(theme="Test theme")
-        assert results.documents == []
-        assert results.total_found == 0
-        assert results.sources_searched == []
-        assert results.search_timestamp is not None
-
-    def test_search_timestamp_auto_generated(self):
-        """search_timestamp should be auto-generated if not provided."""
-        results = SearchResults(theme="Test")
-        assert len(results.search_timestamp) > 0
-        # Should be ISO format
-        assert "T" in results.search_timestamp
-
 
 class TestEvidence:
     """Tests for Evidence schema."""
@@ -154,18 +46,6 @@ class TestEvidence:
         assert evidence.source_type == "newspaper"
         assert evidence.source_language == "en"
 
-    def test_missing_required_field(self, sample_evidence_data):
-        """Missing required field should raise ValidationError."""
-        del sample_evidence_data["relevant_excerpt"]
-        with pytest.raises(ValidationError):
-            Evidence(**sample_evidence_data)
-
-    def test_optional_location_context(self, sample_evidence_data):
-        """location_context should be optional."""
-        del sample_evidence_data["location_context"]
-        evidence = Evidence(**sample_evidence_data)
-        assert evidence.location_context is None
-
 
 class TestHistoricalContext:
     """Tests for HistoricalContext schema."""
@@ -175,18 +55,6 @@ class TestHistoricalContext:
         context = HistoricalContext(**sample_historical_context_data)
         assert context.time_period == "Early 19th Century"
         assert "Boston" in context.geographic_scope
-
-    def test_default_empty_lists(self):
-        """List fields should default to empty lists."""
-        context = HistoricalContext(time_period="Test Period")
-        assert context.geographic_scope == []
-        assert context.relevant_events == []
-        assert context.key_figures == []
-
-    def test_optional_political_climate(self):
-        """political_climate should be optional."""
-        context = HistoricalContext(time_period="Test Period")
-        assert context.political_climate is None
 
 
 class TestMysteryReport:
@@ -204,29 +72,6 @@ class TestMysteryReport:
         sample_mystery_report_data["discrepancy_type"] = "date_mismatch"
         report = MysteryReport(**sample_mystery_report_data)
         assert report.discrepancy_type == "date_mismatch"
-
-    def test_invalid_discrepancy_type(self, sample_mystery_report_data):
-        """Invalid discrepancy_type should raise ValidationError."""
-        sample_mystery_report_data["discrepancy_type"] = "invalid_type"
-        with pytest.raises(ValidationError):
-            MysteryReport(**sample_mystery_report_data)
-
-    def test_invalid_confidence_level(self, sample_mystery_report_data):
-        """Invalid confidence_level should raise ValidationError."""
-        sample_mystery_report_data["confidence_level"] = "very_high"
-        with pytest.raises(ValidationError):
-            MysteryReport(**sample_mystery_report_data)
-
-    def test_analysis_timestamp_auto_generated(self, sample_mystery_report_data):
-        """analysis_timestamp should be auto-generated."""
-        report = MysteryReport(**sample_mystery_report_data)
-        assert report.analysis_timestamp is not None
-        assert "T" in report.analysis_timestamp
-
-    def test_narrative_content_optional(self, sample_mystery_report_data):
-        """narrative_content should be optional."""
-        report = MysteryReport(**sample_mystery_report_data)
-        assert report.narrative_content is None
 
     def test_additional_evidence_within_limit(self, sample_mystery_report_data, sample_evidence_data):
         """additional_evidence with 5 or fewer items should pass validation."""
@@ -260,11 +105,3 @@ class TestAnalysisResults:
         )
         assert results.theme == "Boston mysteries"
         assert len(results.mysteries_found) == 1
-
-    def test_default_values(self):
-        """Default values should be applied correctly."""
-        results = AnalysisResults(theme="Test", source_file="/test.json")
-        assert results.mysteries_found == []
-        assert results.total_documents_analyzed == 0
-        assert results.english_sources_count == 0
-        assert results.spanish_sources_count == 0

--- a/tests/unit/test_state_registry.py
+++ b/tests/unit/test_state_registry.py
@@ -28,15 +28,6 @@ class TestStateKeyDefinitions:
         for key in STATE_KEYS:
             assert key.description, f"{key.name} has empty description"
 
-    def test_state_key_is_frozen(self):
-        """StateKey は frozen dataclass で不変。"""
-        key = STATE_KEYS[0]
-        try:
-            key.name = "modified"
-            assert False, "Should be frozen"
-        except AttributeError:
-            pass
-
 
 class TestExpectedKeys:
     """CLAUDE.md に記載のキーが全て登録されているか。"""


### PR DESCRIPTION
## Summary

- テストレビュー報告書の指摘に基づき、保守コストが価値を上回るボイラープレートテスト **30件を削除**（527 → 497）
- オーケストレーターテストの AsyncMock 重複を **FakeInMemorySessionService** で解消（48行のボイラープレート → 各テスト1行）
- TDD スキル（`.claude/skills/tdd/SKILL.md`）に「量より質」方針とフェイク優先ルールを追加

## 削除テスト内訳

| ファイル | 削除数 | 残存数 | 削除理由 |
|---------|--------|--------|---------|
| `test_schemas.py` | 20 | 9 | Pydantic 標準動作（必須/Enum/Optional/default）の再テスト、Enum 値羅列 |
| `test_constants.py` | 5 | 5 | ハードコード定数の値アサーション、isinstance 型チェック |
| `test_curator_schemas.py` | 2 | 20 | 冗長な Enum 全数チェック |
| `test_model_config.py` | 2 | 2 | モデル名文字列のハードコード比較 |
| `test_state_registry.py` | 1 | 8 | frozen dataclass の不変性（Python 標準動作） |

## FakeInMemorySessionService

- `tests/fakes.py` 新規作成
- `FakeSession`（state dict を持つだけ）+ `FakeInMemorySessionService`（create/get_session の最小 API）
- `post_run_state` パラメータで Runner 実行後のセッション状態をシミュレート可能

## Test plan

- [x] 全ユニットテスト PASS（497 tests, 0 failures）
- [x] テスト数の差分が計画通り（527 - 30 = 497）
- [x] 残存テストのアサーション変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)