### PR TITLE
fix: パイプライン進捗表示の並列対応 + スキップエージェント除去

### DIFF
--- a/mystery_agents/agent.py
+++ b/mystery_agents/agent.py
@@ -139,4 +139,21 @@ ghost_commander = SequentialAgent(
     ],
 )
 
+# オーケストレーター/パラレルエージェントはログ対象外
+# 実際にテキストを生成するリーフエージェントのみ進捗表示する
+SKIP_AUTHORS = {
+    "ghost_commander",
+    "parallel_librarians",
+    "parallel_scholars",
+    "parallel_debate_scholars",
+    "debate_loop",
+    "debate_round",
+    "parallel_translators",
+    "scholar_block",
+    "polymath_block",
+    "storyteller_block",
+    "post_story_block",
+    "post_story_parallel",
+}
+
 root_agent = ghost_commander

--- a/mystery_agents/cli.py
+++ b/mystery_agents/cli.py
@@ -14,7 +14,7 @@ from dotenv import load_dotenv
 # .env はプロジェクトルートに配置
 load_dotenv(Path(__file__).parent.parent / ".env")
 
-from .agent import ghost_commander
+from .agent import ghost_commander, SKIP_AUTHORS
 from shared.orchestrator import run_pipeline
 
 # プロジェクト全体のログを有効化（Publisher, Illustrator 等の既存ログが出力される）
@@ -24,19 +24,6 @@ logging.basicConfig(
 )
 
 PIPELINE_TIMEOUT_SECONDS = 1800  # 30 minutes
-
-# オーケストレーター/パラレルエージェントはログ対象外
-_SKIP_AUTHORS = {
-    "ghost_commander",
-    "parallel_librarians",
-    "parallel_scholars",
-    "debate_loop",           # LoopAgent の実際の名前
-    "parallel_translators",  # 翻訳 ParallelAgent
-    "scholar_block",
-    "polymath_block",
-    "storyteller_block",
-    "post_story_block",
-}
 
 
 async def investigate(query: str, *, run_id: str | None = None) -> str | None:
@@ -68,7 +55,7 @@ async def investigate(query: str, *, run_id: str | None = None) -> str | None:
         run_type="blog",
         timeout_seconds=PIPELINE_TIMEOUT_SECONDS,
         max_llm_calls=120,
-        skip_authors=_SKIP_AUTHORS,
+        skip_authors=SKIP_AUTHORS,
         on_text=lambda text: print(text),
     )
 

--- a/mystery_agents/utils/pipeline_logger.py
+++ b/mystery_agents/utils/pipeline_logger.py
@@ -2,6 +2,7 @@
 
 各エージェントの実行状況（開始・完了・エラー・所要時間・出力サマリー）を
 記録し、Firestore 保存用のデータを生成する。
+並列実行エージェントの追跡に対応し、複数エージェントの同時実行を管理する。
 """
 
 from datetime import datetime, timezone
@@ -12,55 +13,65 @@ AgentStatus = Literal["running", "completed", "error"]
 
 
 class PipelineLogger:
-    """パイプライン実行中の各エージェントの状態を追跡する。"""
+    """パイプライン実行中の各エージェントの状態を追跡する。
+
+    並列実行に対応するため、エージェントごとの開始時刻を dict で管理する。
+    """
 
     def __init__(self) -> None:
         self.logs: list[dict] = []
-        self._current_agent: str | None = None
-        self._start_time: datetime | None = None
+        # エージェント名 → 開始時刻（並列対応）
+        self._start_times: dict[str, datetime] = {}
 
     def start_agent(self, agent_name: str) -> None:
         """エージェントの実行開始を記録する。"""
-        self._current_agent = agent_name
-        self._start_time = datetime.now(timezone.utc)
+        self._start_times[agent_name] = datetime.now(timezone.utc)
         self.logs.append({
             "agent_name": agent_name,
             "status": "running",
-            "start_time": self._start_time.isoformat(),
+            "start_time": self._start_times[agent_name].isoformat(),
             "end_time": None,
             "duration_seconds": None,
             "output_summary": None,
         })
 
-    def complete_agent(self, output_summary: str) -> None:
-        """現在のエージェントを完了としてマークする。"""
-        self._finish_current("completed", output_summary)
+    def complete_agent(self, agent_name: str, output_summary: str) -> None:
+        """指定したエージェントを完了としてマークする。"""
+        self._finish_agent(agent_name, "completed", output_summary)
 
-    def error_agent(self, error_message: str) -> None:
-        """現在のエージェントをエラーとしてマークする。"""
-        self._finish_current("error", f"ERROR: {error_message}")
+    def error_agent(self, agent_name: str, error_message: str) -> None:
+        """指定したエージェントをエラーとしてマークする。"""
+        self._finish_agent(agent_name, "error", f"ERROR: {error_message}")
 
     def get_logs(self) -> list[dict]:
         """全ログエントリを返す。"""
         return self.logs
 
-    def _finish_current(self, status: AgentStatus, summary: str) -> None:
-        if not self._current_agent or not self._start_time:
+    def remove_last_log(self, agent_name: str) -> None:
+        """指定したエージェントの最後のログエントリを削除する。
+
+        スキップされたエージェント（空テキスト + 短時間）のログを除去する際に使用。
+        """
+        for i in range(len(self.logs) - 1, -1, -1):
+            if self.logs[i]["agent_name"] == agent_name:
+                self.logs.pop(i)
+                break
+
+    def _finish_agent(self, agent_name: str, status: AgentStatus, summary: str) -> None:
+        start_time = self._start_times.pop(agent_name, None)
+        if start_time is None:
             return
 
         end_time = datetime.now(timezone.utc)
-        duration = (end_time - self._start_time).total_seconds()
+        duration = (end_time - start_time).total_seconds()
 
         for log in reversed(self.logs):
-            if log["agent_name"] == self._current_agent and log["status"] == "running":
+            if log["agent_name"] == agent_name and log["status"] == "running":
                 log["status"] = status
                 log["end_time"] = end_time.isoformat()
                 log["duration_seconds"] = round(duration, 2)
                 log["output_summary"] = self._truncate(summary)
                 break
-
-        self._current_agent = None
-        self._start_time = None
 
     @staticmethod
     def _truncate(text: str, max_length: int = 200) -> str:

--- a/services/mystery_pipeline.py
+++ b/services/mystery_pipeline.py
@@ -64,7 +64,7 @@ async def _run_investigate(query: str, run_id: str) -> None:
     """
     try:
         from shared.orchestrator import run_pipeline
-        from mystery_agents.agent import ghost_commander
+        from mystery_agents.agent import ghost_commander, SKIP_AUTHORS
 
         await run_pipeline(
             agent=ghost_commander,
@@ -73,6 +73,7 @@ async def _run_investigate(query: str, run_id: str) -> None:
             initial_state={"investigation_query": query},
             run_id=run_id,
             run_type="blog",
+            skip_authors=SKIP_AUTHORS,
         )
     except Exception as e:
         logger.exception("Blog pipeline failed: %s", e)

--- a/shared/orchestrator.py
+++ b/shared/orchestrator.py
@@ -2,6 +2,11 @@
 
 Runner セットアップ、イベントループ処理、進捗追跡、セッション管理を一元化する。
 CLI と Cloud Run Service の両方から呼ばれるビジネスロジック層。
+
+並列実行エージェント（ParallelAgent）のインターリーブイベントに対応:
+- エージェントごとに独立したテキスト蓄積とログインデックスを管理
+- 同一エージェントの複数イベントを1エントリに集約（2重エントリ防止）
+- スキップされたエージェント（空テキスト + 短時間）のログを除去
 """
 
 import asyncio
@@ -26,6 +31,9 @@ from shared.pipeline_run import (
 
 logger = logging.getLogger(__name__)
 
+# スキップされたエージェント判定の閾値（秒）
+_SKIP_DURATION_THRESHOLD = 0.5
+
 # イベントコールバック型
 OnText = Callable[[str], None]
 
@@ -38,6 +46,43 @@ class PipelineResult:
     mystery_id: str | None = None  # blog パイプラインのみ
     logs: list[dict] = field(default_factory=list)
     session_state: dict = field(default_factory=dict)
+
+
+def _complete_agent(
+    pipeline_logger: PipelineLogger,
+    run_id: str | None,
+    agent_name: str,
+    texts: list[str],
+    log_index: int | None,
+) -> None:
+    """エージェントを完了マークし、スキップ判定を行う。
+
+    空テキスト + 短時間（< 0.5s）のエージェントはスキップとみなし、ログから除去する。
+    """
+    summary = " ".join(texts)[:200] or "(no text output)"
+    pipeline_logger.complete_agent(agent_name, summary)
+
+    # スキップ判定: 空テキスト + 短時間ならログから除去
+    completed_log = None
+    for log in reversed(pipeline_logger.get_logs()):
+        if log["agent_name"] == agent_name and log["status"] == "completed":
+            completed_log = log
+            break
+
+    if completed_log:
+        duration = completed_log.get("duration_seconds") or 0
+        is_skipped = (
+            not texts
+            and duration < _SKIP_DURATION_THRESHOLD
+        )
+        if is_skipped:
+            pipeline_logger.remove_last_log(agent_name)
+            return
+
+    # Firestore に完了を通知
+    completed_logs = pipeline_logger.get_logs()
+    if completed_logs:
+        update_agent_completed(run_id, log_index, completed_log)
 
 
 async def run_pipeline(
@@ -61,6 +106,11 @@ async def run_pipeline(
     3. イベントループ処理（エージェント遷移検出、進捗追跡、Firestore 同期）
     4. セッション状態からの結果抽出
     5. pipeline_run 完了/エラーマーク
+
+    並列実行対応:
+    - agent_texts: エージェントごとのテキスト蓄積
+    - agent_log_indices: エージェントごとの Firestore ログインデックス
+    - 新規 author 検出時にエントリ作成、既存 author は蓄積のみ
 
     Args:
         agent: ADK Agent（ghost_commander / podcast_commander）
@@ -109,11 +159,10 @@ async def run_pipeline(
         state=state,
     )
 
-    # 進捗追跡
+    # 進捗追跡（並列対応: エージェントごとの dict で管理）
     pipeline_logger = PipelineLogger()
-    current_agent_name: str | None = None
-    accumulated_text: list[str] = []
-    current_log_index: int | None = None
+    agent_texts: dict[str, list[str]] = {}  # {agent_name: [text_chunks]}
+    agent_log_indices: dict[str, int | None] = {}  # {agent_name: firestore_index}
 
     run_config = RunConfig(max_llm_calls=max_llm_calls)
 
@@ -130,22 +179,26 @@ async def run_pipeline(
             ):
                 # エージェント遷移検出
                 author = getattr(event, "author", None)
-                if author and author not in skip_authors and author != current_agent_name:
-                    # 前のエージェントを完了マーク
-                    if current_agent_name:
-                        summary = " ".join(accumulated_text)[:200]
-                        pipeline_logger.complete_agent(summary or "(no text output)")
-                        completed_logs = pipeline_logger.get_logs()
-                        if completed_logs:
-                            update_agent_completed(
-                                run_id, current_log_index, completed_logs[-1]
+                if not author or author in skip_authors:
+                    # skip_authors のイベントはステージ境界として検出
+                    # 前ステージの全 active エージェントを一括完了
+                    if author and author in skip_authors and agent_texts:
+                        for name in list(agent_texts.keys()):
+                            _complete_agent(
+                                pipeline_logger,
+                                run_id,
+                                name,
+                                agent_texts.pop(name),
+                                agent_log_indices.pop(name, None),
                             )
-                        accumulated_text = []
-                    # 新しいエージェントを開始
-                    current_agent_name = author
-                    pipeline_logger.start_agent(current_agent_name)
-                    current_log_index = update_agent_started(
-                        run_id, current_agent_name, pipeline_logger.get_logs()[-1]
+                    continue
+
+                # 新規エージェントの場合のみエントリ作成
+                if author not in agent_texts:
+                    agent_texts[author] = []
+                    pipeline_logger.start_agent(author)
+                    agent_log_indices[author] = update_agent_started(
+                        run_id, author, pipeline_logger.get_logs()[-1]
                     )
 
                 # テキスト出力処理
@@ -154,17 +207,17 @@ async def run_pipeline(
                         if hasattr(part, "text") and part.text:
                             if on_text:
                                 on_text(part.text)
-                            accumulated_text.append(part.text[:100])
+                            agent_texts[author].append(part.text[:100])
 
-        # 最後のエージェントを完了マーク
-        if current_agent_name:
-            summary = " ".join(accumulated_text)[:200]
-            pipeline_logger.complete_agent(summary or "(no text output)")
-            completed_logs = pipeline_logger.get_logs()
-            if completed_logs:
-                update_agent_completed(
-                    run_id, current_log_index, completed_logs[-1]
-                )
+        # 残存エージェントを完了マーク
+        for name in list(agent_texts.keys()):
+            _complete_agent(
+                pipeline_logger,
+                run_id,
+                name,
+                agent_texts.pop(name),
+                agent_log_indices.pop(name, None),
+            )
 
         # セッション状態を取得
         session = await session_service.get_session(

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -265,3 +265,111 @@ class TestRunPipeline:
             )
 
         assert result.mystery_id is None
+
+
+class TestParallelAgentTracking:
+    """並列エージェントのインターリーブイベント追跡テスト"""
+
+    @pytest.mark.asyncio
+    @patch("shared.orchestrator.complete_pipeline_run")
+    @patch("shared.orchestrator.update_agent_completed")
+    @patch("shared.orchestrator.update_agent_started", return_value=0)
+    @patch("shared.orchestrator.create_pipeline_run", return_value="run-100")
+    async def test_interleaved_parallel_events_single_entry(
+        self, mock_create, mock_started, mock_completed, mock_complete
+    ):
+        """並列エージェントの交互イベントが1エントリずつに集約される。"""
+        events = [
+            # ParallelAgent 内でインターリーブ
+            _make_event(author="librarian_en", text="Searching LOC..."),
+            _make_event(author="librarian_es", text="Buscando en DPLA..."),
+            _make_event(author="librarian_en", text="Found 5 documents"),
+            _make_event(author="librarian_es", text="Encontré 3 documentos"),
+        ]
+        fake_session = FakeInMemorySessionService()
+
+        with patch("shared.orchestrator.Runner", return_value=_make_runner(events)), \
+             patch("shared.orchestrator.InMemorySessionService", return_value=fake_session):
+            result = await run_pipeline(
+                agent=MagicMock(),
+                app_name="test_app",
+                user_message="test",
+                initial_state={},
+            )
+
+        # 各エージェントが1エントリのみ（2重エントリなし）
+        assert mock_started.call_count == 2
+        assert len(result.logs) == 2
+        assert result.logs[0]["agent_name"] == "librarian_en"
+        assert result.logs[1]["agent_name"] == "librarian_es"
+
+        # テキストが蓄積されている
+        assert "Searching LOC..." in result.logs[0]["output_summary"]
+        assert "Buscando en DPLA..." in result.logs[1]["output_summary"]
+
+    @pytest.mark.asyncio
+    @patch("shared.orchestrator.complete_pipeline_run")
+    @patch("shared.orchestrator.update_agent_completed")
+    @patch("shared.orchestrator.update_agent_started", return_value=0)
+    @patch("shared.orchestrator.create_pipeline_run", return_value="run-101")
+    async def test_skip_author_triggers_stage_boundary(
+        self, mock_create, mock_started, mock_completed, mock_complete
+    ):
+        """skip_authors イベントがステージ境界として機能し、前ステージを一括完了する。"""
+        events = [
+            _make_event(author="librarian_en", text="Found docs"),
+            _make_event(author="librarian_es", text="Encontré docs"),
+            # ステージ境界: scholar_block（skip_authors）
+            _make_event(author="scholar_block"),
+            _make_event(author="scholar_en", text="Analysis done"),
+        ]
+        fake_session = FakeInMemorySessionService()
+
+        with patch("shared.orchestrator.Runner", return_value=_make_runner(events)), \
+             patch("shared.orchestrator.InMemorySessionService", return_value=fake_session):
+            result = await run_pipeline(
+                agent=MagicMock(),
+                app_name="test_app",
+                user_message="test",
+                initial_state={},
+                skip_authors={"scholar_block"},
+            )
+
+        # librarian_en, librarian_es, scholar_en の3エントリ
+        assert len(result.logs) == 3
+        # scholar_block のイベントで librarian 2つが完了済み
+        assert result.logs[0]["status"] == "completed"
+        assert result.logs[1]["status"] == "completed"
+        assert result.logs[2]["status"] == "completed"
+
+    @pytest.mark.asyncio
+    @patch("shared.orchestrator.complete_pipeline_run")
+    @patch("shared.orchestrator.update_agent_completed")
+    @patch("shared.orchestrator.update_agent_started", return_value=0)
+    @patch("shared.orchestrator.create_pipeline_run", return_value="run-102")
+    async def test_skipped_agent_empty_text_short_duration_removed(
+        self, mock_create, mock_started, mock_completed, mock_complete
+    ):
+        """空テキスト + 短時間のスキップエージェントがログから除去される。"""
+        # language_gate でスキップされたエージェント: テキストなし
+        events = [
+            _make_event(author="librarian_en", text="Found documents"),
+            _make_event(author="librarian_de"),  # テキストなし = スキップ
+        ]
+        fake_session = FakeInMemorySessionService()
+
+        with patch("shared.orchestrator.Runner", return_value=_make_runner(events)), \
+             patch("shared.orchestrator.InMemorySessionService", return_value=fake_session):
+            result = await run_pipeline(
+                agent=MagicMock(),
+                app_name="test_app",
+                user_message="test",
+                initial_state={},
+            )
+
+        # librarian_de はスキップ判定（テストでは duration ≈ 0 なので除去される）
+        # librarian_en のみ残る
+        agent_names = [log["agent_name"] for log in result.logs]
+        assert "librarian_en" in agent_names
+        # librarian_de は空テキスト + 短時間で除去される
+        assert "librarian_de" not in agent_names

--- a/tests/unit/test_pipeline_logger.py
+++ b/tests/unit/test_pipeline_logger.py
@@ -14,11 +14,10 @@ class TestPipelineLoggerInit:
         logger = PipelineLogger()
         assert logger.logs == []
 
-    def test_init_no_current_agent(self):
-        """New PipelineLogger should have no current agent."""
+    def test_init_no_active_agents(self):
+        """New PipelineLogger should have no active agents."""
         logger = PipelineLogger()
-        assert logger._current_agent is None
-        assert logger._start_time is None
+        assert logger._start_times == {}
 
 
 class TestStartAgent:
@@ -39,13 +38,12 @@ class TestStartAgent:
         assert log["duration_seconds"] is None
         assert log["output_summary"] is None
 
-    def test_start_agent_sets_current(self):
-        """start_agent should set current agent tracking."""
+    def test_start_agent_tracks_start_time(self):
+        """start_agent should track start time in _start_times dict."""
         logger = PipelineLogger()
         logger.start_agent("scholar")
 
-        assert logger._current_agent == "scholar"
-        assert logger._start_time is not None
+        assert "scholar" in logger._start_times
 
     def test_multiple_start_agents(self):
         """Starting multiple agents should create multiple entries."""
@@ -56,6 +54,16 @@ class TestStartAgent:
         assert len(logger.logs) == 2
         assert logger.logs[0]["agent_name"] == "librarian"
         assert logger.logs[1]["agent_name"] == "scholar"
+
+    def test_parallel_agents_tracked_simultaneously(self):
+        """複数エージェントの同時追跡が可能であること。"""
+        logger = PipelineLogger()
+        logger.start_agent("librarian_en")
+        logger.start_agent("librarian_es")
+
+        assert "librarian_en" in logger._start_times
+        assert "librarian_es" in logger._start_times
+        assert len(logger.logs) == 2
 
 
 class TestCompleteAgent:
@@ -68,7 +76,7 @@ class TestCompleteAgent:
         logger.start_agent("librarian")
 
         with freeze_time("2024-01-15 12:01:30", tz_offset=0):
-            logger.complete_agent("Found 15 documents")
+            logger.complete_agent("librarian", "Found 15 documents")
 
         log = logger.logs[0]
         assert log["status"] == "completed"
@@ -76,21 +84,34 @@ class TestCompleteAgent:
         assert log["duration_seconds"] == 90.0
         assert log["output_summary"] == "Found 15 documents"
 
-    def test_complete_agent_clears_current(self):
-        """complete_agent should clear current agent tracking."""
+    def test_complete_agent_removes_from_tracking(self):
+        """complete_agent should remove agent from _start_times."""
         logger = PipelineLogger()
         logger.start_agent("librarian")
-        logger.complete_agent("Done")
+        logger.complete_agent("librarian", "Done")
 
-        assert logger._current_agent is None
-        assert logger._start_time is None
+        assert "librarian" not in logger._start_times
 
     def test_complete_without_start_does_nothing(self):
         """complete_agent without start should not create entry."""
         logger = PipelineLogger()
-        logger.complete_agent("Done")
+        logger.complete_agent("unknown", "Done")
 
         assert len(logger.logs) == 0
+
+    def test_complete_specific_parallel_agent(self):
+        """並列エージェントの個別完了が正しく動作すること。"""
+        logger = PipelineLogger()
+        logger.start_agent("librarian_en")
+        logger.start_agent("librarian_es")
+
+        logger.complete_agent("librarian_es", "Found Spanish documents")
+
+        # librarian_es が完了、librarian_en はまだ running
+        assert logger.logs[0]["status"] == "running"
+        assert logger.logs[1]["status"] == "completed"
+        assert "librarian_en" in logger._start_times
+        assert "librarian_es" not in logger._start_times
 
 
 class TestErrorAgent:
@@ -103,7 +124,7 @@ class TestErrorAgent:
         logger.start_agent("illustrator")
 
         with freeze_time("2024-01-15 12:00:30", tz_offset=0):
-            logger.error_agent("Image generation failed")
+            logger.error_agent("illustrator", "Image generation failed")
 
         log = logger.logs[0]
         assert log["status"] == "error"
@@ -114,9 +135,33 @@ class TestErrorAgent:
     def test_error_without_start_does_nothing(self):
         """error_agent without start should not create entry."""
         logger = PipelineLogger()
-        logger.error_agent("Failed")
+        logger.error_agent("unknown", "Failed")
 
         assert len(logger.logs) == 0
+
+
+class TestRemoveLastLog:
+    """Tests for remove_last_log method."""
+
+    def test_remove_last_log_removes_entry(self):
+        """指定エージェントの最後のログエントリを削除すること。"""
+        logger = PipelineLogger()
+        logger.start_agent("librarian_de")
+        logger.start_agent("librarian_en")
+
+        logger.remove_last_log("librarian_de")
+
+        assert len(logger.logs) == 1
+        assert logger.logs[0]["agent_name"] == "librarian_en"
+
+    def test_remove_last_log_no_match(self):
+        """マッチしない場合は何も変更しないこと。"""
+        logger = PipelineLogger()
+        logger.start_agent("librarian_en")
+
+        logger.remove_last_log("nonexistent")
+
+        assert len(logger.logs) == 1
 
 
 class TestGetLogs:
@@ -126,9 +171,9 @@ class TestGetLogs:
         """get_logs should return all log entries."""
         logger = PipelineLogger()
         logger.start_agent("librarian")
-        logger.complete_agent("Done 1")
+        logger.complete_agent("librarian", "Done 1")
         logger.start_agent("scholar")
-        logger.complete_agent("Done 2")
+        logger.complete_agent("scholar", "Done 2")
 
         logs = logger.get_logs()
         assert len(logs) == 2
@@ -181,19 +226,19 @@ class TestAgentTransitions:
         # Agent 1: Librarian
         logger.start_agent("librarian")
         with freeze_time("2024-01-15 12:01:00", tz_offset=0):
-            logger.complete_agent("Found 10 documents")
+            logger.complete_agent("librarian", "Found 10 documents")
 
         # Agent 2: Scholar
         with freeze_time("2024-01-15 12:01:00", tz_offset=0):
             logger.start_agent("scholar")
         with freeze_time("2024-01-15 12:03:00", tz_offset=0):
-            logger.complete_agent("Generated 2 mystery reports")
+            logger.complete_agent("scholar", "Generated 2 mystery reports")
 
         # Agent 3: Storyteller (with error)
         with freeze_time("2024-01-15 12:03:00", tz_offset=0):
             logger.start_agent("storyteller")
         with freeze_time("2024-01-15 12:03:30", tz_offset=0):
-            logger.error_agent("Content generation timeout")
+            logger.error_agent("storyteller", "Content generation timeout")
 
         logs = logger.get_logs()
         assert len(logs) == 3
@@ -211,20 +256,21 @@ class TestAgentTransitions:
         assert logs[2]["duration_seconds"] == 30.0
         assert "ERROR:" in logs[2]["output_summary"]
 
-    def test_overlapping_agent_handling(self):
-        """Starting new agent before completing previous should work."""
+    def test_parallel_agents_complete_independently(self):
+        """並列エージェントが独立して完了すること。"""
         logger = PipelineLogger()
 
-        logger.start_agent("librarian")
-        # Start new agent without completing previous
-        logger.start_agent("scholar")
+        logger.start_agent("librarian_en")
+        logger.start_agent("librarian_es")
 
-        # Complete scholar
-        logger.complete_agent("Done")
+        # es が先に完了
+        logger.complete_agent("librarian_es", "Found Spanish docs")
+        # en が後から完了
+        logger.complete_agent("librarian_en", "Found English docs")
 
         logs = logger.get_logs()
         assert len(logs) == 2
-        # Librarian should still be running (not updated)
-        assert logs[0]["status"] == "running"
-        # Scholar should be completed
+        assert logs[0]["agent_name"] == "librarian_en"
+        assert logs[0]["status"] == "completed"
+        assert logs[1]["agent_name"] == "librarian_es"
         assert logs[1]["status"] == "completed"

--- a/web-admin/src/lib/pipeline-phases.ts
+++ b/web-admin/src/lib/pipeline-phases.ts
@@ -38,12 +38,28 @@ export interface PhaseGroup {
 }
 
 /**
+ * スキップされたエージェントのログエントリか判定する。
+ * Orchestrator 側で除外するのが本筋だが、修正前の既存ログデータへの防御として
+ * ダッシュボード側でもフィルタする。
+ */
+function isSkippedEntry(log: AgentLogEntry): boolean {
+  return (
+    log.duration_seconds !== null &&
+    log.duration_seconds < 1.0 &&
+    (!log.output_summary || log.output_summary === "(no text output)")
+  )
+}
+
+/**
  * ログ配列をフェーズごとにグループ化する
  */
 export function groupLogsByPhase(logs: AgentLogEntry[]): PhaseGroup[] {
   const groups: PhaseGroup[] = []
 
   for (const log of logs) {
+    // スキップされたエントリを除外（language_gate による空応答等）
+    if (isSkippedEntry(log)) continue
+
     const phase = PIPELINE_PHASES.find((p) => p.match(log.agent_name))
     if (!phase) continue
 


### PR DESCRIPTION
## Summary

- **Orchestrator 並列対応**: `ParallelAgent` のインターリーブイベントで同一エージェントが2重エントリになる問題を修正。エージェントごとの dict 追跡に切り替え
- **スキップエージェント除去**: `language_gate` でスキップされた言語のエージェント（空テキスト + 短時間）をログから自動除去
- **SKIP_AUTHORS 集約**: `agent.py` に定数を定義し、CLI / Cloud Run Service から参照。`debate_round` 等の漏れを追加
- **ダッシュボード防御フィルタ**: 既存ログデータに対して `duration < 1s + 空テキスト` のエントリを除外

## 修正した問題

1. ThemeAnalyzer が選択しなかった言語の Librarian/Scholar が進捗に表示される
2. ParallelAgent のイベントインターリーブで同一エージェントが2重エントリになる
3. Cloud Run Service で `skip_authors` が未指定のため全ラッパーエージェントがログに記録される

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `shared/orchestrator.py` | イベントループを並列対応に書き換え |
| `mystery_agents/utils/pipeline_logger.py` | `complete_agent(name, summary)` API + `remove_last_log()` |
| `mystery_agents/agent.py` | `SKIP_AUTHORS` 定数追加 |
| `mystery_agents/cli.py` | `SKIP_AUTHORS` import に変更 |
| `services/mystery_pipeline.py` | `skip_authors` パラメータ追加 |
| `web-admin/src/lib/pipeline-phases.ts` | `isSkippedEntry()` フィルタ追加 |
| `tests/unit/test_orchestrator.py` | 並列イベントテスト3件追加 |
| `tests/unit/test_pipeline_logger.py` | 新 API 対応 + 並列テスト追加 |

## Test plan

- [x] `pytest tests/unit/ -v` — 全 504 テスト通過
- [ ] ローカルで `python -m mystery_agents` を実行し、進捗表示を確認
- [ ] 管理画面で進捗表示が以下を満たすことを確認:
  - ThemeAnalyzer が選択した言語のみ表示
  - 各エージェントが1エントリのみ
  - 正しい実行時間と出力サマリー

🤖 Generated with [Claude Code](https://claude.com/claude-code)