### PR TITLE
fix: 管理画面 API エラーハンドリング改善（詳細転送 + toast 色分け）

### DIFF
--- a/web-admin/src/app/(main)/page.tsx
+++ b/web-admin/src/app/(main)/page.tsx
@@ -41,6 +41,7 @@ export default function AdminPage() {
   const [mysteries, setMysteries] = useState<FirestoreMystery[]>([])
   const [loading, setLoading] = useState(true)
   const [actionFeedback, setActionFeedback] = useState<string | null>(null)
+  const [actionFeedbackIsError, setActionFeedbackIsError] = useState(false)
   const [themeInput, setThemeInput] = useState("")
   const [suggestions, setSuggestions] = useState<{ theme: string; description: string; theme_ja?: string; description_ja?: string }[]>([])
   const [suggestLoading, setSuggestLoading] = useState(false)
@@ -128,13 +129,16 @@ export default function AdminPage() {
     try {
       await approveMystery(id)
       setActionFeedback(`Case ${id} approved and published`)
+      setActionFeedbackIsError(false)
       fetchMysteries()
       triggerRebuild()
       setTimeout(() => setActionFeedback(null), 3000)
     } catch (error) {
       console.error("Failed to approve:", error)
-      setActionFeedback(`Failed to approve case`)
-      setTimeout(() => setActionFeedback(null), 3000)
+      const message = error instanceof Error ? error.message : "不明なエラー"
+      setActionFeedback(`承認に失敗しました: ${message}`)
+      setActionFeedbackIsError(true)
+      setTimeout(() => setActionFeedback(null), 5000)
     }
   }
 
@@ -142,11 +146,16 @@ export default function AdminPage() {
     try {
       await archiveMystery(id)
       setActionFeedback(`Case ${id} archived`)
+      setActionFeedbackIsError(false)
       fetchMysteries()
       triggerRebuild()
       setTimeout(() => setActionFeedback(null), 3000)
     } catch (error) {
       console.error("Failed to archive:", error)
+      const message = error instanceof Error ? error.message : "不明なエラー"
+      setActionFeedback(`アーカイブに失敗しました: ${message}`)
+      setActionFeedbackIsError(true)
+      setTimeout(() => setActionFeedback(null), 5000)
     }
   }
 
@@ -159,19 +168,25 @@ export default function AdminPage() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ query: themeInput.trim() }),
       })
-      if (!res.ok) throw new Error("API request failed")
+      if (!res.ok) {
+        const errorData = await res.json().catch(() => ({}))
+        throw new Error(errorData.detail || errorData.error || `API error (${res.status})`)
+      }
       const data = await res.json()
       if (data.run_id) {
         setCurrentRunId(data.run_id)
       }
       setActionFeedback("調査パイプラインを開始しました")
+      setActionFeedbackIsError(false)
       setThemeInput("")
       setSuggestions([])
       setTimeout(() => setActionFeedback(null), 3000)
     } catch (error) {
       console.error("Failed to start pipeline:", error)
-      setActionFeedback("パイプラインの開始に失敗しました")
-      setTimeout(() => setActionFeedback(null), 3000)
+      const message = error instanceof Error ? error.message : "不明なエラー"
+      setActionFeedback(`パイプラインの開始に失敗しました: ${message}`)
+      setActionFeedbackIsError(true)
+      setTimeout(() => setActionFeedback(null), 5000)
     } finally {
       setPipelineLoading(false)
     }
@@ -182,13 +197,18 @@ export default function AdminPage() {
     setSuggestions([])
     try {
       const res = await fetch("/api/themes/suggest", { method: "POST" })
-      if (!res.ok) throw new Error("API request failed")
+      if (!res.ok) {
+        const errorData = await res.json().catch(() => ({}))
+        throw new Error(errorData.detail || errorData.error || `API error (${res.status})`)
+      }
       const data = await res.json()
       setSuggestions(Array.isArray(data.suggestions) ? data.suggestions : [])
     } catch (error) {
       console.error("Failed to get suggestions:", error)
-      setActionFeedback("テーマ提案の取得に失敗しました")
-      setTimeout(() => setActionFeedback(null), 3000)
+      const message = error instanceof Error ? error.message : "不明なエラー"
+      setActionFeedback(`テーマ提案の取得に失敗しました: ${message}`)
+      setActionFeedbackIsError(true)
+      setTimeout(() => setActionFeedback(null), 5000)
     } finally {
       setSuggestLoading(false)
     }
@@ -280,8 +300,16 @@ export default function AdminPage() {
 
         {/* Action feedback toast */}
         {actionFeedback && (
-          <div className="fixed top-20 right-4 z-50 px-4 py-3 bg-teal/20 border border-teal/30 rounded-sm animate-in fade-in slide-in-from-right-5">
-            <p className="text-sm text-[#5fb3a1] font-mono">
+          <div className={cn(
+            "fixed top-20 right-4 z-50 px-4 py-3 rounded-sm animate-in fade-in slide-in-from-right-5",
+            actionFeedbackIsError
+              ? "bg-blood-red/10 border border-blood-red/30"
+              : "bg-teal/20 border border-teal/30"
+          )}>
+            <p className={cn(
+              "text-sm font-mono",
+              actionFeedbackIsError ? "text-[#ff6b6b]" : "text-[#5fb3a1]"
+            )}>
               {actionFeedback}
             </p>
           </div>

--- a/web-admin/src/app/(main)/podcasts/[id]/podcast-detail.tsx
+++ b/web-admin/src/app/(main)/podcasts/[id]/podcast-detail.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useRef, useEffect } from "react"
 import Link from "next/link"
+import { cn } from "@ghost/shared/src/lib/utils"
 import { Button } from "@ghost/shared/src/components/ui/button"
 import { usePodcast } from "@/hooks/use-podcast"
 import { usePipelineRun } from "@/hooks/use-pipeline-run"
@@ -32,6 +33,7 @@ export function PodcastDetail({ podcastId }: PodcastDetailProps) {
   const [saving, setSaving] = useState(false)
   const [audioGenerating, setAudioGenerating] = useState(false)
   const [feedback, setFeedback] = useState<string | null>(null)
+  const [feedbackIsError, setFeedbackIsError] = useState(false)
   const hasUnsavedChanges = useRef(false)
 
   // podcast のステータスが audio_generating に変わったらローカルの generating フラグもリセット
@@ -53,11 +55,14 @@ export function PodcastDetail({ podcastId }: PodcastDetailProps) {
       await updatePodcastScript(podcastId, editedScript)
       hasUnsavedChanges.current = false
       setFeedback("脚本を保存しました")
+      setFeedbackIsError(false)
       setTimeout(() => setFeedback(null), 3000)
     } catch (error) {
       console.error("Failed to save script:", error)
-      setFeedback("脚本の保存に失敗しました")
-      setTimeout(() => setFeedback(null), 3000)
+      const message = error instanceof Error ? error.message : "不明なエラー"
+      setFeedback(`脚本の保存に失敗しました: ${message}`)
+      setFeedbackIsError(true)
+      setTimeout(() => setFeedback(null), 5000)
     } finally {
       setSaving(false)
     }
@@ -78,14 +83,20 @@ export function PodcastDetail({ podcastId }: PodcastDetailProps) {
           script: scriptToSend,
         }),
       })
-      if (!res.ok) throw new Error("API request failed")
+      if (!res.ok) {
+        const errorData = await res.json().catch(() => ({}))
+        throw new Error(errorData.detail || errorData.error || `API error (${res.status})`)
+      }
       setFeedback("音声生成を開始しました")
+      setFeedbackIsError(false)
       setTimeout(() => setFeedback(null), 3000)
     } catch (error) {
       console.error("Failed to generate audio:", error)
       setAudioGenerating(false)
-      setFeedback("音声生成の開始に失敗しました")
-      setTimeout(() => setFeedback(null), 3000)
+      const message = error instanceof Error ? error.message : "不明なエラー"
+      setFeedback(`音声生成の開始に失敗しました: ${message}`)
+      setFeedbackIsError(true)
+      setTimeout(() => setFeedback(null), 5000)
     }
   }, [podcast, podcastId, editedScript])
 
@@ -98,15 +109,20 @@ export function PodcastDetail({ podcastId }: PodcastDetailProps) {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ mystery_id: podcast.mystery_id }),
       })
-      if (!res.ok) throw new Error("API request failed")
+      if (!res.ok) {
+        const errorData = await res.json().catch(() => ({}))
+        throw new Error(errorData.detail || errorData.error || `API error (${res.status})`)
+      }
       const data = await res.json()
       if (data.podcast_id) {
         window.location.href = `/podcasts/${data.podcast_id}`
       }
     } catch (error) {
       console.error("Failed to retry:", error)
-      setFeedback("再試行に失敗しました")
-      setTimeout(() => setFeedback(null), 3000)
+      const message = error instanceof Error ? error.message : "不明なエラー"
+      setFeedback(`再試行に失敗しました: ${message}`)
+      setFeedbackIsError(true)
+      setTimeout(() => setFeedback(null), 5000)
     }
   }, [podcast])
 
@@ -142,8 +158,16 @@ export function PodcastDetail({ podcastId }: PodcastDetailProps) {
       <div className="container mx-auto px-4">
         {/* フィードバック */}
         {feedback && (
-          <div className="fixed top-20 right-4 z-50 px-4 py-3 bg-teal/20 border border-teal/30 rounded-sm animate-in fade-in slide-in-from-right-5">
-            <p className="text-sm text-[#5fb3a1] font-mono">{feedback}</p>
+          <div className={cn(
+            "fixed top-20 right-4 z-50 px-4 py-3 rounded-sm animate-in fade-in slide-in-from-right-5",
+            feedbackIsError
+              ? "bg-blood-red/10 border border-blood-red/30"
+              : "bg-teal/20 border border-teal/30"
+          )}>
+            <p className={cn(
+              "text-sm font-mono",
+              feedbackIsError ? "text-[#ff6b6b]" : "text-[#5fb3a1]"
+            )}>{feedback}</p>
           </div>
         )}
 

--- a/web-admin/src/app/(main)/podcasts/page.tsx
+++ b/web-admin/src/app/(main)/podcasts/page.tsx
@@ -30,6 +30,7 @@ export default function PodcastsPage() {
   const [customInstructions, setCustomInstructions] = useState("")
   const [generating, setGenerating] = useState(false)
   const [feedback, setFeedback] = useState<string | null>(null)
+  const [feedbackIsError, setFeedbackIsError] = useState(false)
 
   // Podcast タイプのパイプラインのみ表示
   const { runs: runningPipelines, dismiss: dismissRunning } = usePipelineRuns()
@@ -88,20 +89,26 @@ export default function PodcastsPage() {
           custom_instructions: customInstructions.trim(),
         }),
       })
-      if (!res.ok) throw new Error("API request failed")
+      if (!res.ok) {
+        const errorData = await res.json().catch(() => ({}))
+        throw new Error(errorData.detail || errorData.error || `API error (${res.status})`)
+      }
       const data = await res.json()
 
       if (data.podcast_id) {
         router.push(`/podcasts/${data.podcast_id}`)
       } else {
         setFeedback("脚本生成を開始しました")
+        setFeedbackIsError(false)
         fetchData()
         setTimeout(() => setFeedback(null), 3000)
       }
     } catch (error) {
       console.error("Failed to generate script:", error)
-      setFeedback("脚本生成の開始に失敗しました")
-      setTimeout(() => setFeedback(null), 3000)
+      const message = error instanceof Error ? error.message : "不明なエラー"
+      setFeedback(`脚本生成の開始に失敗しました: ${message}`)
+      setFeedbackIsError(true)
+      setTimeout(() => setFeedback(null), 5000)
     } finally {
       setGenerating(false)
     }
@@ -188,8 +195,16 @@ export default function PodcastsPage() {
 
         {/* フィードバック */}
         {feedback && (
-          <div className="fixed top-20 right-4 z-50 px-4 py-3 bg-teal/20 border border-teal/30 rounded-sm animate-in fade-in slide-in-from-right-5">
-            <p className="text-sm text-[#5fb3a1] font-mono">{feedback}</p>
+          <div className={cn(
+            "fixed top-20 right-4 z-50 px-4 py-3 rounded-sm animate-in fade-in slide-in-from-right-5",
+            feedbackIsError
+              ? "bg-blood-red/10 border border-blood-red/30"
+              : "bg-teal/20 border border-teal/30"
+          )}>
+            <p className={cn(
+              "text-sm font-mono",
+              feedbackIsError ? "text-[#ff6b6b]" : "text-[#5fb3a1]"
+            )}>{feedback}</p>
           </div>
         )}
 

--- a/web-admin/src/app/api/mysteries/investigate/route.ts
+++ b/web-admin/src/app/api/mysteries/investigate/route.ts
@@ -52,9 +52,14 @@ export async function POST(request: NextRequest) {
     if (!response.ok) {
       const errorBody = await response.text();
       console.error(`Pipeline service error (${response.status}):`, errorBody);
+      let detail = errorBody;
+      try {
+        const parsed = JSON.parse(errorBody);
+        detail = parsed.detail || parsed.error || parsed.message || errorBody;
+      } catch { /* テキストのまま */ }
       return NextResponse.json(
-        { error: "Failed to start blog pipeline" },
-        { status: 500 }
+        { error: "Failed to start blog pipeline", detail },
+        { status: response.status }
       );
     }
 
@@ -68,7 +73,7 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     console.error("Failed to start blog pipeline:", error);
     return NextResponse.json(
-      { error: "Failed to start blog pipeline" },
+      { error: "Failed to start blog pipeline", detail: String(error) },
       { status: 500 }
     );
   }

--- a/web-admin/src/app/api/podcast/generate-audio/route.ts
+++ b/web-admin/src/app/api/podcast/generate-audio/route.ts
@@ -60,9 +60,14 @@ export async function POST(request: NextRequest) {
         `Pipeline service error (${response.status}):`,
         errorBody
       );
+      let detail = errorBody;
+      try {
+        const parsed = JSON.parse(errorBody);
+        detail = parsed.detail || parsed.error || parsed.message || errorBody;
+      } catch { /* テキストのまま */ }
       return NextResponse.json(
-        { error: "Failed to start podcast audio generation" },
-        { status: 500 }
+        { error: "Failed to start podcast audio generation", detail },
+        { status: response.status }
       );
     }
 
@@ -75,7 +80,7 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     console.error("Failed to start podcast audio generation:", error);
     return NextResponse.json(
-      { error: "Failed to start podcast audio generation" },
+      { error: "Failed to start podcast audio generation", detail: String(error) },
       { status: 500 }
     );
   }

--- a/web-admin/src/app/api/podcast/generate-script/route.ts
+++ b/web-admin/src/app/api/podcast/generate-script/route.ts
@@ -59,9 +59,14 @@ export async function POST(request: NextRequest) {
         `Pipeline service error (${response.status}):`,
         errorBody
       );
+      let detail = errorBody;
+      try {
+        const parsed = JSON.parse(errorBody);
+        detail = parsed.detail || parsed.error || parsed.message || errorBody;
+      } catch { /* テキストのまま */ }
       return NextResponse.json(
-        { error: "Failed to start podcast script generation" },
-        { status: 500 }
+        { error: "Failed to start podcast script generation", detail },
+        { status: response.status }
       );
     }
 
@@ -76,7 +81,7 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     console.error("Failed to start podcast script generation:", error);
     return NextResponse.json(
-      { error: "Failed to start podcast script generation" },
+      { error: "Failed to start podcast script generation", detail: String(error) },
       { status: 500 }
     );
   }

--- a/web-admin/src/app/api/themes/suggest/route.ts
+++ b/web-admin/src/app/api/themes/suggest/route.ts
@@ -40,9 +40,14 @@ export async function POST() {
     if (!response.ok) {
       const errorBody = await response.text();
       console.error(`Curator service error (${response.status}):`, errorBody);
+      let detail = errorBody;
+      try {
+        const parsed = JSON.parse(errorBody);
+        detail = parsed.detail || parsed.error || parsed.message || errorBody;
+      } catch { /* テキストのまま */ }
       return NextResponse.json(
-        { error: "Failed to generate theme suggestions" },
-        { status: 500 }
+        { error: "Failed to generate theme suggestions", detail },
+        { status: response.status }
       );
     }
 
@@ -51,7 +56,7 @@ export async function POST() {
   } catch (error) {
     console.error("Failed to generate theme suggestions:", error);
     return NextResponse.json(
-      { error: "Failed to generate theme suggestions" },
+      { error: "Failed to generate theme suggestions", detail: String(error) },
       { status: 500 }
     );
   }


### PR DESCRIPTION
## Summary

- API ルート4箇所（generate-script, generate-audio, investigate, suggest）でパイプラインサービスのエラー詳細を `detail` フィールドで転送し、ステータスコードもそのまま返すように変更
- フロントエンド3ページ（管理トップ, Podcast一覧, Podcast詳細）でエラー時にレスポンスボディを読み取り、具体的なエラーメッセージを toast に表示
- toast の視覚区別: 成功=緑(teal)、エラー=赤(blood-red) で色分け。エラーは5秒表示（成功は3秒）

## Test plan

- [ ] Pipeline サービスを停止した状態で脚本生成を実行 → 赤い toast に接続エラー詳細が表示されること
- [ ] Pipeline サービスを起動して正常に脚本生成を実行 → 緑の toast で成功メッセージ
- [ ] 調査パイプライン・テーマ提案・記事承認でも同様に確認
- [ ] `npm run build` でビルドエラーがないことを確認 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)