### PR TITLE
fix: Podcast 脚本生成のエラーハンドリング修正 + 進捗表示追加

### DIFF
--- a/podcast_agents/cli.py
+++ b/podcast_agents/cli.py
@@ -91,12 +91,14 @@ async def generate_script(
     if run_id is None:
         run_id = create_pipeline_run("podcast", mystery_id=mystery_id)
 
-    # pipeline_run_id を podcast に紐付け
+    # pipeline_run_id を podcast に紐付け（未設定の場合のみ: CLI 利用時）
     from shared.firestore import get_firestore_client
     db = get_firestore_client()
-    db.collection("podcasts").document(podcast_id).update({
-        "pipeline_run_id": run_id,
-    })
+    doc = db.collection("podcasts").document(podcast_id).get()
+    if doc.exists and not doc.to_dict().get("pipeline_run_id"):
+        db.collection("podcasts").document(podcast_id).update({
+            "pipeline_run_id": run_id,
+        })
 
     try:
         # Orchestrator 呼び出し

--- a/podcast_agents/tools/firestore_tools.py
+++ b/podcast_agents/tools/firestore_tools.py
@@ -32,12 +32,18 @@ def load_mystery(mystery_id: str) -> dict | None:
     return doc.to_dict()
 
 
-def create_podcast(mystery_id: str, custom_instructions: str = "") -> str:
+def create_podcast(
+    mystery_id: str,
+    custom_instructions: str = "",
+    *,
+    pipeline_run_id: str | None = None,
+) -> str:
     """podcasts コレクションに新規ドキュメントを作成する。
 
     Args:
         mystery_id: 元記事の mystery ID
         custom_instructions: 管理者からのカスタム指示
+        pipeline_run_id: 事前作成済みの pipeline_run ID（即座に紐付け）
 
     Returns:
         作成された podcast_id
@@ -57,7 +63,7 @@ def create_podcast(mystery_id: str, custom_instructions: str = "") -> str:
         "script": None,
         "script_ja": None,
         "audio": None,
-        "pipeline_run_id": None,
+        "pipeline_run_id": pipeline_run_id,
         "created_at": now,
         "updated_at": now,
         "error_message": None,

--- a/services/pipeline_server.py
+++ b/services/pipeline_server.py
@@ -93,6 +93,9 @@ async def _run_generate_script(
     except Exception as e:
         logger.exception("Podcast script generation failed: %s", e)
         error_pipeline_run(run_id, str(e))
+        # podcast ドキュメントもエラーに更新（script_generating でスタック防止）
+        from podcast_agents.tools.firestore_tools import set_podcast_status
+        set_podcast_status(podcast_id, "error", str(e))
 
 
 async def _run_generate_audio(
@@ -107,6 +110,9 @@ async def _run_generate_audio(
         await generate_audio(podcast_id, script_override=script, voice_name=voice_name)
     except Exception as e:
         logger.exception("Podcast audio generation failed: %s", e)
+        # podcast ドキュメントもエラーに更新（audio_generating でスタック防止）
+        from podcast_agents.tools.firestore_tools import set_podcast_status
+        set_podcast_status(podcast_id, "error", str(e))
 
 
 @app.get("/health")
@@ -139,7 +145,9 @@ async def generate_script_endpoint(body: GenerateScriptRequest):
         from podcast_agents.tools.firestore_tools import create_podcast
 
         run_id = create_pipeline_run("podcast", mystery_id=body.mystery_id)
-        podcast_id = create_podcast(body.mystery_id, body.custom_instructions)
+        podcast_id = create_podcast(
+            body.mystery_id, body.custom_instructions, pipeline_run_id=run_id
+        )
         asyncio.create_task(
             _run_generate_script(
                 body.mystery_id, body.custom_instructions, run_id, podcast_id

--- a/tests/unit/test_podcast_firestore.py
+++ b/tests/unit/test_podcast_firestore.py
@@ -75,6 +75,26 @@ class TestCreatePodcast:
         assert call_args["custom_instructions"] == "ジョーク多めで"
         assert call_args["script"] is None
         assert call_args["audio"] is None
+        assert call_args["pipeline_run_id"] is None
+
+    def test_creates_document_with_pipeline_run_id(self, mock_db):
+        """pipeline_run_id を指定した場合、即座に紐付けされる。"""
+        mock_mystery_doc = MagicMock()
+        mock_mystery_doc.exists = True
+        mock_mystery_doc.to_dict.return_value = {"title": "The Vanishing Ship"}
+
+        mock_doc_ref = MagicMock()
+        mock_doc_ref.id = "generated-podcast-id"
+        mock_db.collection.return_value.document.return_value.get.return_value = mock_mystery_doc
+        mock_db.collection.return_value.add.return_value = (None, mock_doc_ref)
+
+        result = create_podcast(
+            "OCC-MA-617-20260207143025", pipeline_run_id="run-123"
+        )
+
+        assert result == "generated-podcast-id"
+        call_args = mock_db.collection.return_value.add.call_args[0][0]
+        assert call_args["pipeline_run_id"] == "run-123"
 
     def test_uses_mystery_id_as_title_when_mystery_not_found(self, mock_db):
         """mystery が見つからない場合は ID をタイトルとして使用する。"""

--- a/web-admin/src/lib/pipeline-phases.ts
+++ b/web-admin/src/lib/pipeline-phases.ts
@@ -23,6 +23,7 @@ export const PIPELINE_PHASES: PipelinePhase[] = [
   { id: "translation",        label: "翻訳",        match: (n) => n.startsWith("translator") },
   { id: "publish",            label: "公開処理",    match: (n) => n === "publisher" },
   // Podcast パイプライン
+  { id: "script_planning",    label: "アウトライン設計", match: (n) => n === "script_planner" },
   { id: "scriptwriting",      label: "脚本作成",    match: (n) => n === "scriptwriter" },
   { id: "script_translation", label: "脚本翻訳",    match: (n) => n === "podcast_translator_ja" },
 ]


### PR DESCRIPTION
## Summary

- **エラー伝搬バグ修正**: `_run_generate_script()` / `_run_generate_audio()` でバックグラウンドタスクが例外で失敗した場合、`pipeline_run` だけでなく podcast ドキュメントのステータスも `error` に更新するように修正。これにより `script_generating` / `audio_generating` で永久にスタックする問題を解消。
- **pipeline_run_id 即時紐付け**: `create_podcast()` に `pipeline_run_id` パラメータを追加し、podcast ドキュメント作成時に即座に紐付け。フロントエンドが詳細ページに遷移した時点で進捗パネルが表示されるように改善。
- **ScriptPlanner フェーズ追加**: `pipeline-phases.ts` に `script_planner` のフェーズ定義（「アウトライン設計」）を追加。Podcast パイプラインの3エージェント全てが進捗表示されるように。

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `services/pipeline_server.py` | except 節で `set_podcast_status(error)` 追加 + `create_podcast` に `pipeline_run_id` 渡し |
| `podcast_agents/tools/firestore_tools.py` | `create_podcast()` に `pipeline_run_id` パラメータ追加 |
| `podcast_agents/cli.py` | `pipeline_run_id` 更新を条件付きに変更（既にセット済みならスキップ） |
| `web-admin/src/lib/pipeline-phases.ts` | `script_planning` フェーズ追加 |
| `tests/unit/test_podcast_firestore.py` | `pipeline_run_id` 紐付けテスト追加 |

## Test plan

- [x] `pytest tests/unit/ -v -k "podcast"` — 30件全パス
- [ ] 管理画面で脚本生成ボタンをクリックし、進捗パネルが即座に表示されることを確認
- [ ] 「アウトライン設計」「脚本作成」「脚本翻訳」の3フェーズが表示されることを確認
- [ ] パイプライン失敗時にエラーメッセージが表示され、`script_generating` でスタックしないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)