### PR TITLE
fix: globals.css の @source パスを修正（フッター3カラム復旧）

### DIFF
--- a/web-admin/src/app/globals.css
+++ b/web-admin/src/app/globals.css
@@ -1,7 +1,7 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
 @plugin '@tailwindcss/typography';
-@source "../../../../packages/shared/src";
+@source "../../../packages/shared/src";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/web-public/src/app/globals.css
+++ b/web-public/src/app/globals.css
@@ -1,7 +1,7 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
 @plugin '@tailwindcss/typography';
-@source "../../../../packages/shared/src";
+@source "../../../packages/shared/src";
 
 @custom-variant dark (&:is(.dark *));
 


### PR DESCRIPTION
## Summary

- `web-public/src/app/globals.css` と `web-admin/src/app/globals.css` の `@source` ディレクティブのパスが `../` 1つ分余計だった
- `packages/shared/src` を正しく指すよう修正し、shared パッケージ内の Tailwind クラス（`md:grid-cols-3` 等）が CSS に含まれるようにした
- これによりフッターが大画面で3カラム横並びに復旧する

## 根本原因

```
globals.css の場所: web-public/src/app/globals.css
修正前: ../../../../packages/shared/src → リポ外の存在しないパス
修正後: ../../../packages/shared/src    → packages/shared/src（正しい）
```

## Test plan

- [x] `web-public` を `npm run dev` で起動し、フッターが `md` 以上で3カラム横並びになることを確認
- [x] `web-admin` を `npm run dev` で起動し、同様にフッターが3カラムになることを確認
- [x] DevTools でフッターの `grid-template-columns` が `repeat(3, minmax(0, 1fr))` であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)