### PR TITLE
fix: TTS 403 SERVICE_DISABLED エラー修正（クォータプロジェクト明示設定）

### DIFF
--- a/podcast_agents/tools/tts.py
+++ b/podcast_agents/tools/tts.py
@@ -37,7 +37,16 @@ DEFAULT_SAMPLE_RATE = 24000
 
 
 def _get_tts_client() -> texttospeech.TextToSpeechClient:
-    """TTS クライアントを取得する。"""
+    """TTS クライアントを取得する。
+
+    GOOGLE_CLOUD_PROJECT が設定されている場合、クォータプロジェクトとして
+    明示的に指定する（ADC のデフォルトクォータプロジェクトに依存しない）。
+    """
+    project = os.environ.get("GOOGLE_CLOUD_PROJECT")
+    if project:
+        from google.api_core.client_options import ClientOptions
+        client_options = ClientOptions(quota_project_id=project)
+        return texttospeech.TextToSpeechClient(client_options=client_options)
     return texttospeech.TextToSpeechClient()
 
 


### PR DESCRIPTION
## Summary

- TTS クライアント生成時に `GOOGLE_CLOUD_PROJECT` 環境変数からクォータプロジェクトを明示設定
- ADC のデフォルトクォータプロジェクトが個人プロジェクトに設定されている Docker 環境で発生する 403 `SERVICE_DISABLED` エラーを解消

## 背景

ローカル Docker 環境で ADC（Application Default Credentials）のクォータプロジェクトが個人プロジェクト（`projects/76408605...`）に設定されており、そのプロジェクトでは TTS API が無効のため 403 エラーが発生していた。

`docker-compose.yml` で既に `GOOGLE_CLOUD_PROJECT=ghostinthearchive` が設定されているため、`ClientOptions(quota_project_id=project)` で正しいプロジェクトを使用するようになる。

## 変更ファイル

- `podcast_agents/tools/tts.py` — `_get_tts_client()` にクォータプロジェクト設定を追加

## Test plan

- [x] `pytest tests/unit/test_tts.py -v` — 全14テスト通過
- [x] `gcloud services enable texttospeech.googleapis.com --project=ghostinthearchive` を実行
- [x] `docker compose build pipeline-server` で再ビルド
- [ ] 管理画面から Podcast 音声生成を再実行して 403 エラーが解消されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)