### PR TITLE
fix: Podcast パイプライン初期状態の Context variable not found エラー修正

### DIFF
--- a/podcast_agents/cli.py
+++ b/podcast_agents/cli.py
@@ -109,6 +109,10 @@ async def generate_script(
             initial_state={
                 "creative_content": narrative_content,
                 "custom_instructions": custom_instructions,
+                # 後続エージェントの instruction プレースホルダー解決用に初期化
+                # ScriptPlanner/Scriptwriter が output_key で上書きする
+                "script_outline": "",
+                "podcast_script": "",
             },
             run_id=run_id,
             run_type="podcast",


### PR DESCRIPTION
## Summary

- `initial_state` に `script_outline` と `podcast_script` を空文字列で初期化
- ScriptPlanner が失敗した場合に Scriptwriter が `{script_outline}` プレースホルダーを解決できず `Context variable not found` エラーになる問題を修正

## 背景

ADK の `LlmAgent` は instruction 内の `{variable_name}` プレースホルダーをセッション状態から解決する。SequentialAgent で ScriptPlanner → Scriptwriter の順に実行されるが、ScriptPlanner が何らかの理由で失敗すると `output_key="script_outline"` が設定されず、後続の Scriptwriter で `Context variable not found: 'script_outline'` エラーが発生する。

初期状態に空文字列で初期化することで、前段エージェントの失敗時もプレースホルダー解決が成功し、Scriptwriter の失敗マーカーチェック（NO_SCRIPT 検出）で適切に中断される。

## Test plan

- [x] `pytest tests/unit/ -k podcast -v` — 全30テスト通過
- [ ] Docker 再ビルド・再起動後に管理画面から Podcast 脚本生成を再実行

🤖 Generated with [Claude Code](https://claude.com/claude-code)