### PR TITLE
feat: Featured Mystery Card 分割レイアウト（PC: 左画像・右テキスト）

### DIFF
--- a/web-public/src/components/featured-mystery-card-skeleton.tsx
+++ b/web-public/src/components/featured-mystery-card-skeleton.tsx
@@ -1,10 +1,10 @@
 export function FeaturedMysteryCardSkeleton() {
   return (
-    <div className="aged-card letterpress-border rounded-sm overflow-hidden animate-pulse">
+    <div className="aged-card letterpress-border rounded-sm overflow-hidden animate-pulse lg:grid lg:grid-cols-2">
       {/* 画像プレースホルダー */}
-      <div className="h-64 md:h-80 bg-muted" />
+      <div className="h-56 sm:h-64 lg:h-auto lg:min-h-[280px] bg-muted" />
 
-      <div className="p-6 md:p-8">
+      <div className="p-6 md:p-8 lg:flex lg:flex-col lg:justify-center lg:py-10 lg:px-10">
         <div className="h-3 bg-muted rounded w-1/4 mb-4" />
         <div className="h-4 bg-muted rounded w-1/3 mb-4" />
         <div className="h-8 bg-muted rounded w-3/4 mb-3" />

--- a/web-public/src/components/featured-mystery-card.tsx
+++ b/web-public/src/components/featured-mystery-card.tsx
@@ -3,6 +3,7 @@ import { FileText, MapPin, Calendar, Star } from "lucide-react"
 import { ResponsiveHeroImage } from "@/components/responsive-hero-image"
 import type { FirestoreMystery } from "@ghost/shared/src/types/mystery"
 import { localizeMystery } from "@ghost/shared/src/lib/localize"
+import { cn } from "@ghost/shared/src/lib/utils"
 import type { SupportedLang } from "@/lib/i18n/config"
 
 interface FeaturedMysteryCardProps {
@@ -16,24 +17,35 @@ export function FeaturedMysteryCard({ mystery, lang, label }: FeaturedMysteryCar
 
   const location = mystery.historical_context?.geographic_scope?.[0] || ""
   const timePeriod = mystery.historical_context?.time_period || ""
+  const hasImage = !!mystery.images?.hero
 
   return (
     <Link href={`/${lang}/mystery/${mystery.mystery_id}`} className="block group no-underline">
-      <article className="aged-card letterpress-border rounded-sm overflow-hidden transition-all duration-300 hover:shadow-lg hover:shadow-black/20">
+      <article className={cn(
+        "aged-card letterpress-border rounded-sm overflow-hidden transition-all duration-300 hover:shadow-lg hover:shadow-black/20",
+        hasImage && "lg:grid lg:grid-cols-2"
+      )}>
         {/* ヒーロー画像 */}
-        {mystery.images?.hero && (
-          <div className="relative overflow-hidden">
+        {hasImage && (
+          <div className="relative overflow-hidden max-h-56 sm:max-h-64 lg:max-h-none lg:h-full">
             <ResponsiveHeroImage
-              hero={mystery.images.hero}
-              variants={mystery.images.variants}
+              hero={mystery.images!.hero}
+              variants={mystery.images!.variants}
               alt={title}
               priority
+              className="w-full h-full object-cover"
             />
-            <div className="absolute bottom-0 left-0 right-0 h-24 bg-gradient-to-t from-[hsl(var(--card))] to-transparent pointer-events-none" />
+            {/* モバイル: 下方向グラデーション */}
+            <div className="absolute bottom-0 left-0 right-0 h-24 bg-gradient-to-t from-[hsl(var(--card))] to-transparent pointer-events-none lg:hidden" />
+            {/* PC: 右方向グラデーション（画像右端） */}
+            <div className="hidden lg:block absolute top-0 right-0 bottom-0 w-24 bg-gradient-to-l from-[hsl(var(--card))] to-transparent pointer-events-none" />
           </div>
         )}
 
-        <div className="p-6 md:p-8">
+        <div className={cn(
+          "p-6 md:p-8",
+          hasImage && "lg:flex lg:flex-col lg:justify-center lg:py-10 lg:px-10"
+        )}>
           {/* フィーチャーバッジ */}
           <div className="flex items-center gap-2 mb-4">
             <Star className="w-4 h-4 text-gold" />

--- a/web-public/src/components/responsive-hero-image.tsx
+++ b/web-public/src/components/responsive-hero-image.tsx
@@ -12,6 +12,7 @@ interface ResponsiveHeroImageProps {
   variants?: ImageVariants
   alt: string
   priority?: boolean
+  className?: string
 }
 
 export function ResponsiveHeroImage({
@@ -19,6 +20,7 @@ export function ResponsiveHeroImage({
   variants,
   alt,
   priority = false,
+  className,
 }: ResponsiveHeroImageProps) {
   const hasVariants = variants && Object.keys(variants).length > 0
 
@@ -29,7 +31,7 @@ export function ResponsiveHeroImage({
         alt={alt}
         width={1200}
         height={675}
-        className="w-full h-auto"
+        className={className ?? "w-full h-auto"}
         priority={priority}
         unoptimized={hero.includes("localhost")}
       />
@@ -75,7 +77,7 @@ export function ResponsiveHeroImage({
         alt={alt}
         width={1200}
         height={675}
-        className="w-full h-auto"
+        className={className ?? "w-full h-auto"}
         priority={priority}
         unoptimized={isLocal}
       />


### PR DESCRIPTION
## Summary

- PC (lg+) でトップページの Featured Mystery Card を **左=画像 / 右=テキスト** の2カラム Grid レイアウトに変更
- モバイルは従来通り縦積みで、画像高さを `max-h-56 sm:max-h-64` に制限してスクロール量を軽減
- PC グラデーションを下方向→右方向に切替え、画像→テキストの水平遷移を滑らかに

## 変更ファイル（3ファイル）

| ファイル | 変更内容 |
|---------|---------|
| `responsive-hero-image.tsx` | `className` prop 追加（デフォルト `"w-full h-auto"` で後方互換） |
| `featured-mystery-card.tsx` | `lg:grid-cols-2` + グラデーション方向切替 + テキスト垂直中央寄せ |
| `featured-mystery-card-skeleton.tsx` | 分割レイアウト対応 |

## Test plan

- [ ] PC (1024px+): 画像が左、テキストが右に並ぶことを確認
- [ ] タブレット (768-1023px): 従来通り縦積み、画像高さ 256px 制限
- [ ] スマホ (< 640px): 縦積み、画像高さ 224px 制限
- [ ] 画像なしの記事: テキストが全幅表示（Grid 非適用）
- [ ] スケルトン表示もレスポンシブに切り替わること

🤖 Generated with [Claude Code](https://claude.com/claude-code)