### PR TITLE
fix: firebase/firestore モジュール重複解決（web-public 記事表示バグ修正）

### DIFF
--- a/packages/shared/src/lib/firestore/queries.ts
+++ b/packages/shared/src/lib/firestore/queries.ts
@@ -9,7 +9,19 @@ import type {
   MysteryStatus,
   MysteryCardData,
 } from "../../types/mystery";
-import { Timestamp, DocumentData } from "firebase/firestore";
+import {
+  Timestamp,
+  DocumentData,
+  collection,
+  getDocs,
+  getDoc,
+  doc,
+  query,
+  where,
+  orderBy,
+  limit,
+} from "firebase/firestore";
+import { getFirestoreDb, COLLECTIONS } from "../firebase/config";
 
 /**
  * 公開済みミステリー一覧を取得
@@ -18,9 +30,6 @@ import { Timestamp, DocumentData } from "firebase/firestore";
 export async function getPublishedMysteries(
   maxCount: number = 50
 ): Promise<FirestoreMystery[]> {
-  const { collection, getDocs, query, where, orderBy, limit } = await import("firebase/firestore");
-  const { getFirestoreDb, COLLECTIONS } = await import("../firebase/config");
-
   const db = getFirestoreDb();
   const mysteriesRef = collection(db, COLLECTIONS.MYSTERIES);
 
@@ -32,7 +41,7 @@ export async function getPublishedMysteries(
   );
 
   const snapshot = await getDocs(q);
-  return snapshot.docs.map((doc) => docToMystery(doc.data()));
+  return snapshot.docs.map((d) => docToMystery(d.data()));
 }
 
 /**
@@ -41,9 +50,6 @@ export async function getPublishedMysteries(
 export async function getMysteryById(
   mysteryId: string
 ): Promise<FirestoreMystery | null> {
-  const { doc, getDoc } = await import("firebase/firestore");
-  const { getFirestoreDb, COLLECTIONS } = await import("../firebase/config");
-
   const db = getFirestoreDb();
   const docRef = doc(db, COLLECTIONS.MYSTERIES, mysteryId);
   const docSnap = await getDoc(docRef);
@@ -60,9 +66,6 @@ export async function getMysteryById(
  * generateStaticParams用
  */
 export async function getPublishedMysteryIds(): Promise<string[]> {
-  const { collection, getDocs, query, where } = await import("firebase/firestore");
-  const { getFirestoreDb, COLLECTIONS } = await import("../firebase/config");
-
   const db = getFirestoreDb();
   const mysteriesRef = collection(db, COLLECTIONS.MYSTERIES);
 
@@ -72,7 +75,7 @@ export async function getPublishedMysteryIds(): Promise<string[]> {
   );
 
   const snapshot = await getDocs(q);
-  return snapshot.docs.map((doc) => doc.id);
+  return snapshot.docs.map((d) => d.id);
 }
 
 /**

--- a/web-admin/src/lib/firestore/mysteries.ts
+++ b/web-admin/src/lib/firestore/mysteries.ts
@@ -9,6 +9,18 @@ import type {
   MysteryStatus,
 } from "@ghost/shared/src/types/mystery";
 import { docToMystery } from "@ghost/shared/src/lib/firestore/queries";
+import {
+  collection,
+  getDocs,
+  doc,
+  query,
+  where,
+  orderBy,
+  limit,
+  updateDoc,
+  Timestamp,
+} from "firebase/firestore";
+import { getFirestoreDb, COLLECTIONS } from "@ghost/shared/src/lib/firebase/config";
 
 // 共通の読み取りクエリを re-export
 export { getPublishedMysteries, getMysteryById, getPublishedMysteryIds, toCardData } from "@ghost/shared/src/lib/firestore/queries";
@@ -24,9 +36,6 @@ export { getPublishedMysteries, getMysteryById, getPublishedMysteryIds, toCardDa
 export async function getPendingMysteries(
   maxCount: number = 50
 ): Promise<FirestoreMystery[]> {
-  const { collection, getDocs, query, where, orderBy, limit } = await import("firebase/firestore");
-  const { getFirestoreDb, COLLECTIONS } = await import("@ghost/shared/src/lib/firebase/config");
-
   const db = getFirestoreDb();
   const mysteriesRef = collection(db, COLLECTIONS.MYSTERIES);
 
@@ -38,7 +47,7 @@ export async function getPendingMysteries(
   );
 
   const snapshot = await getDocs(q);
-  return snapshot.docs.map((doc) => docToMystery(doc.data()));
+  return snapshot.docs.map((d) => docToMystery(d.data()));
 }
 
 /**
@@ -47,16 +56,13 @@ export async function getPendingMysteries(
 export async function getAllMysteries(
   maxCount: number = 100
 ): Promise<FirestoreMystery[]> {
-  const { collection, getDocs, query, orderBy, limit } = await import("firebase/firestore");
-  const { getFirestoreDb, COLLECTIONS } = await import("@ghost/shared/src/lib/firebase/config");
-
   const db = getFirestoreDb();
   const mysteriesRef = collection(db, COLLECTIONS.MYSTERIES);
 
   const q = query(mysteriesRef, orderBy("createdAt", "desc"), limit(maxCount));
 
   const snapshot = await getDocs(q);
-  return snapshot.docs.map((doc) => docToMystery(doc.data()));
+  return snapshot.docs.map((d) => docToMystery(d.data()));
 }
 
 // ============================================
@@ -70,9 +76,6 @@ export async function getAllMysteries(
  * Approve は即座に公開する。
  */
 export async function approveMystery(mysteryId: string): Promise<void> {
-  const { doc, updateDoc, Timestamp } = await import("firebase/firestore");
-  const { getFirestoreDb, COLLECTIONS } = await import("@ghost/shared/src/lib/firebase/config");
-
   const db = getFirestoreDb();
   const docRef = doc(db, COLLECTIONS.MYSTERIES, mysteryId);
 
@@ -87,9 +90,6 @@ export async function approveMystery(mysteryId: string): Promise<void> {
  * ミステリーをアーカイブ（非公開化）
  */
 export async function archiveMystery(mysteryId: string): Promise<void> {
-  const { doc, updateDoc, Timestamp } = await import("firebase/firestore");
-  const { getFirestoreDb, COLLECTIONS } = await import("@ghost/shared/src/lib/firebase/config");
-
   const db = getFirestoreDb();
   const docRef = doc(db, COLLECTIONS.MYSTERIES, mysteryId);
 


### PR DESCRIPTION
## Summary

- web-public で公開済み記事が表示されない問題を修正
- `packages/shared` の `queries.ts` と `web-admin` の `mysteries.ts` で `firebase/firestore` の動的インポート (`await import(...)`) を静的インポートに変更
- Next.js サーバーコンポーネント環境（Turbopack + `transpilePackages`）で動的インポートと静的インポートが異なるモジュールインスタンスに解決され、`collection()` が `Firestore` インスタンスを認識できなかった

## 根本原因

`config.ts` が静的インポートで `firebase/firestore` を使用する一方、`queries.ts` が動的インポートで同モジュールを使用していた。ブラウザ環境ではバンドラがモジュールを重複排除するため問題にならないが、Next.js SSG/サーバー環境では異なるインスタンスとして解決される。

## 変更対象

- `packages/shared/src/lib/firestore/queries.ts` — 動的→静的インポート
- `web-admin/src/lib/firestore/mysteries.ts` — 同上（一貫性のため）

## Test plan

- [x] ユニットテスト全505件パス確認済み
- [x] Firebase Emulator + web-public dev サーバーで記事表示を確認
- [x] web-admin の記事一覧・承認・アーカイブ操作が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)