### PR TITLE
fix: About ページ Hero「一次資料」テキスト削除 + ギャップ詰め

### DIFF
--- a/web-public/src/components/hero.tsx
+++ b/web-public/src/components/hero.tsx
@@ -83,7 +83,6 @@ export function Hero({ dict }: HeroProps) {
   const title = dict?.hero.title ?? "Ghost in the Archive"
   const subtitle = dict?.hero.subtitle ?? "AI-driven excavation of historical ghosts from the depths of the archives"
   const description = dict?.hero.description ?? "Unearthing contradictions, anomalies, and unexplained patterns buried in the depths of public digital archives. Where historical record meets folkloric mystery."
-  const sources = dict?.hero.sources ?? "LOC • DPLA • NYPL • Internet Archive"
 
   return (
     <section className="relative z-20 min-h-[70vh] flex items-center justify-center overflow-hidden">
@@ -112,17 +111,9 @@ export function Hero({ dict }: HeroProps) {
           {subtitle}
         </p>
 
-        <p className="text-base md:text-lg text-foreground/70 max-w-2xl mx-auto leading-relaxed mb-8 text-pretty">
+        <p className="text-base md:text-lg text-foreground/70 max-w-2xl mx-auto leading-relaxed mb-0 text-pretty">
           {description}
         </p>
-
-        <div className="flex items-center justify-center gap-4 text-muted-foreground">
-          <div className="h-px w-16 bg-gradient-to-r from-transparent to-border" />
-          <span className="text-xs font-mono uppercase tracking-widest">
-            {sources}
-          </span>
-          <div className="h-px w-16 bg-gradient-to-l from-transparent to-border" />
-        </div>
       </div>
 
       <div className="absolute bottom-0 left-0 right-0 h-32 bg-gradient-to-t from-background to-transparent pointer-events-none" />

--- a/web-public/src/lib/i18n/dictionaries/de.ts
+++ b/web-public/src/lib/i18n/dictionaries/de.ts
@@ -8,7 +8,6 @@ const dict: Dictionary = {
       "Historische Mysterien, ausgegraben von autonomen KI-Agenten",
     description:
       "Vergessene Anomalien, verschwundene Personen und unerklärliche Ereignisse, verborgen in den digitalen Archiven der Welt, werden ans Licht gebracht.",
-    sources: "Primärquellen",
   },
   disclosure: {
     title: "Operative Offenlegung",

--- a/web-public/src/lib/i18n/dictionaries/en.ts
+++ b/web-public/src/lib/i18n/dictionaries/en.ts
@@ -7,7 +7,6 @@ const dict: Dictionary = {
     subtitle: "Historical mysteries unearthed by autonomous AI agents",
     description:
       "Uncovering forgotten anomalies, vanished persons, and unexplained events buried in the world's digital archives.",
-    sources: "Primary Sources",
   },
   disclosure: {
     title: "Operational Disclosure",

--- a/web-public/src/lib/i18n/dictionaries/es.ts
+++ b/web-public/src/lib/i18n/dictionaries/es.ts
@@ -8,7 +8,6 @@ const dict: Dictionary = {
       "Misterios históricos desenterrados por agentes de IA autónomos",
     description:
       "Descubriendo anomalías olvidadas, personas desaparecidas y eventos inexplicables enterrados en los archivos digitales del mundo.",
-    sources: "Fuentes primarias",
   },
   disclosure: {
     title: "Divulgación operativa",

--- a/web-public/src/lib/i18n/dictionaries/fr.ts
+++ b/web-public/src/lib/i18n/dictionaries/fr.ts
@@ -8,7 +8,6 @@ const dict: Dictionary = {
       "Mystères historiques exhumés par des agents IA autonomes",
     description:
       "Mise au jour d'anomalies oubliées, de personnes disparues et d'événements inexpliqués enfouis dans les archives numériques du monde.",
-    sources: "Sources primaires",
   },
   disclosure: {
     title: "Divulgation opérationnelle",

--- a/web-public/src/lib/i18n/dictionaries/ja.ts
+++ b/web-public/src/lib/i18n/dictionaries/ja.ts
@@ -7,7 +7,6 @@ const dict: Dictionary = {
     subtitle: "自律型AIエージェントが発掘する歴史のミステリー",
     description:
       "世界のデジタルアーカイブに埋もれた、忘れ去られた異常、消えた人物、説明のつかない事件を発掘する。",
-    sources: "一次資料",
   },
   disclosure: {
     title: "運用情報の開示",

--- a/web-public/src/lib/i18n/dictionaries/nl.ts
+++ b/web-public/src/lib/i18n/dictionaries/nl.ts
@@ -8,7 +8,6 @@ const dict: Dictionary = {
       "Historische mysteries opgegraven door autonome AI-agenten",
     description:
       "Het blootleggen van vergeten anomalieën, verdwenen personen en onverklaarde gebeurtenissen begraven in de digitale archieven van de wereld.",
-    sources: "Primaire bronnen",
   },
   disclosure: {
     title: "Operationele openbaarmaking",

--- a/web-public/src/lib/i18n/dictionaries/pt.ts
+++ b/web-public/src/lib/i18n/dictionaries/pt.ts
@@ -8,7 +8,6 @@ const dict: Dictionary = {
       "Mistérios históricos desenterrados por agentes de IA autônomos",
     description:
       "Descobrindo anomalias esquecidas, pessoas desaparecidas e eventos inexplicáveis enterrados nos arquivos digitais do mundo.",
-    sources: "Fontes primárias",
   },
   disclosure: {
     title: "Divulgação operacional",

--- a/web-public/src/lib/i18n/dictionaries/types.ts
+++ b/web-public/src/lib/i18n/dictionaries/types.ts
@@ -4,7 +4,6 @@ export interface Dictionary {
     title: string;
     subtitle: string;
     description: string;
-    sources: string;
   };
   disclosure: {
     title: string;


### PR DESCRIPTION
## Summary
- Hero セクション下部の「一次資料」テキスト（装飾線付き）を削除
- description の下マージンを `mb-8` → `mb-0` に変更し、ヒーロー画像バナーとの間隔を詰めた
- 辞書ファイル（7言語）と型定義から `hero.sources` キーを削除

## Test plan
- [ ] About ページで「一次資料」テキストが表示されないことを確認
- [ ] Hero テキストとヒーロー画像の間のギャップが詰まっていることを確認
- [ ] 7言語すべてで表示崩れがないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)