### PR TITLE
fix: Podcast 音声デフォルトボイス修正（route.ts の旧値削除）

### DIFF
--- a/web-admin/src/app/api/podcast/generate-audio/route.ts
+++ b/web-admin/src/app/api/podcast/generate-audio/route.ts
@@ -48,7 +48,7 @@ export async function POST(request: NextRequest) {
         body: JSON.stringify({
           podcast_id,
           script: script || null,
-          voice_name: voice_name || "en-US-Studio-O",
+          ...(voice_name ? { voice_name } : {}),
         }),
         signal: AbortSignal.timeout(30000),
       }


### PR DESCRIPTION
## Summary

- web-admin の API ルート (`route.ts`) に旧デフォルト `en-US-Studio-O`（女性ボイス）がハードコードされており、PR #115 で変更した `en-US-Chirp3-HD-Enceladus`（Enceladus 男性ボイス）が管理画面からの音声生成時に適用されなかった
- フロントエンドから `voice_name` が未指定の場合、パイプラインサーバーの Pydantic デフォルト値に委譲するよう修正（二重デフォルト管理の解消）

## Test plan

- [ ] 管理画面から Podcast 音声を再生成し、男性ボイス（Enceladus）で出力されることを確認
- [ ] パイプラインサーバーのログに `voice=en-US-Chirp3-HD-Enceladus` が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)