### PR TITLE
fix: View Published リンクを別タブで開き正しい公開 URL に修正

### DIFF
--- a/web-admin/.env.example
+++ b/web-admin/.env.example
@@ -20,4 +20,4 @@ GOOGLE_CLOUD_REGION=asia-northeast1
 CURATOR_SERVICE_URL=http://localhost:8001
 
 # 公開サイト URL（記事公開後のリダイレクト用）
-PUBLIC_SITE_URL=https://ghostinthearchive.ai
+NEXT_PUBLIC_SITE_URL=https://ghostinthearchive.ai

--- a/web-admin/src/app/(main)/page.tsx
+++ b/web-admin/src/app/(main)/page.tsx
@@ -476,13 +476,15 @@ function AdminMysteryCard({ mystery, lang, onApprove, onArchive }: AdminMysteryC
       <div className="flex items-center justify-between gap-4">
         {mystery.status === "published" ? (
           <div className="flex items-center gap-3">
-            <Link
-              href={`/mystery/${mystery.mystery_id}`}
+            <a
+              href={`${process.env.NEXT_PUBLIC_SITE_URL || ""}/en/mystery/${mystery.mystery_id}`}
+              target="_blank"
+              rel="noopener noreferrer"
               className="inline-flex items-center gap-2 text-sm text-gold hover:text-parchment transition-colors no-underline"
             >
               <Eye className="w-4 h-4" />
               View Published
-            </Link>
+            </a>
           </div>
         ) : (
           <div className="flex items-center gap-3">


### PR DESCRIPTION
## Summary
- 記事カードの「View Published」リンクが同じタブで開く問題を修正（`<Link>` → `<a target="_blank">`）
- URL が `/mystery/{id}` で 404 になる問題を修正（`/{lang}/mystery/{id}` に変更）
- 環境変数を `PUBLIC_SITE_URL` → `NEXT_PUBLIC_SITE_URL` にリネーム（`"use client"` コンポーネントから参照するため `NEXT_PUBLIC_` プレフィックスが必要）

## Test plan
- [ ] web-admin でステータスが `published` の記事カードの「View Published」リンクをクリック
- [ ] 別タブで開くことを確認
- [ ] URL が `{NEXT_PUBLIC_SITE_URL}/en/mystery/{id}` となることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)