### PR TITLE
fix: 不要なステータスフィルタ（translating / error）を削除

### DIFF
--- a/web-admin/src/app/(main)/page.tsx
+++ b/web-admin/src/app/(main)/page.tsx
@@ -29,7 +29,7 @@ import {
   Sparkles,
 } from "lucide-react"
 
-type FilterStatus = "all" | MysteryStatus | "translating"
+type FilterStatus = "all" | "pending" | "published" | "archived"
 
 export default function AdminPage() {
   const { lang } = useLanguage()
@@ -106,10 +106,8 @@ export default function AdminPage() {
   const counts = {
     all: mysteries.length,
     pending: mysteries.filter((m) => m.status === "pending").length,
-    translating: mysteries.filter((m) => m.status === "translating").length,
     published: mysteries.filter((m) => m.status === "published").length,
     archived: mysteries.filter((m) => m.status === "archived").length,
-    error: mysteries.filter((m) => m.status === "error").length,
   }
 
   // リビルド失敗は approve/archive の成否に影響しない（fire-and-forget）
@@ -349,7 +347,7 @@ export default function AdminPage() {
         {/* Filter tabs */}
         <div className="flex flex-wrap items-center gap-2 mb-8 pb-4 border-b border-border">
           <Filter className="w-4 h-4 text-muted-foreground mr-2" />
-          {(["all", "pending", "translating", "published", "archived", "error"] as FilterStatus[]).map((status) => (
+          {(["all", "pending", "published", "archived"] as FilterStatus[]).map((status) => (
             <button
               key={status}
               onClick={() => setFilter(status)}
@@ -430,7 +428,6 @@ interface AdminMysteryCardProps {
 
 function AdminMysteryCard({ mystery, lang, onApprove, onArchive }: AdminMysteryCardProps) {
   const isPending = mystery.status === "pending"
-  const isTranslating = mystery.status === "translating"
   const location = mystery.historical_context?.geographic_scope?.[0] || ""
   const timePeriod = mystery.historical_context?.time_period || ""
   const { title, summary } = localizeMystery(mystery, lang)
@@ -523,13 +520,6 @@ function AdminMysteryCard({ mystery, lang, onApprove, onArchive }: AdminMysteryC
           </div>
         )}
 
-        {isTranslating && (
-          <span className="inline-flex items-center gap-1.5 text-xs text-gold font-mono">
-            <Loader2 className="w-3.5 h-3.5 animate-spin" />
-            Translating...
-          </span>
-        )}
-
         {mystery.status === "archived" && (
           <Button
             variant="ghost"
@@ -541,27 +531,6 @@ function AdminMysteryCard({ mystery, lang, onApprove, onArchive }: AdminMysteryC
           </Button>
         )}
 
-        {mystery.status === "error" && (
-          <div className="flex items-center gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={onArchive}
-              className="border-blood-red/30 text-[#ff6b6b] hover:bg-blood-red/20 hover:text-[#ff6b6b] bg-transparent"
-            >
-              <XCircle className="w-4 h-4 mr-1" />
-              Archive
-            </Button>
-            <Button
-              size="sm"
-              onClick={onApprove}
-              className="bg-teal/20 border border-teal/30 text-[#5fb3a1] hover:bg-teal/30"
-            >
-              <RefreshCw className="w-4 h-4 mr-1" />
-              Retry Translation
-            </Button>
-          </div>
-        )}
       </div>
     </article>
   )

--- a/web-admin/src/components/status-badge.tsx
+++ b/web-admin/src/components/status-badge.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { cn } from "@ghost/shared/src/lib/utils"
 import type { DiscrepancyType, ConfidenceLevel, MysteryStatus } from "@ghost/shared/src/types/mystery"
 import { DISCREPANCY_TYPE_LABELS } from "@ghost/shared/src/types/mystery"
-import { Clock, Ghost, FileQuestion, AlertTriangle, MapPin, User, CheckCircle, XCircle, Clock3, Languages } from "lucide-react"
+import { Clock, Ghost, FileQuestion, AlertTriangle, MapPin, User, CheckCircle, XCircle, Clock3 } from "lucide-react"
 
 // Discrepancy type badge
 const discrepancyConfig: Record<DiscrepancyType, { icon: React.ReactNode; className: string }> = {
@@ -90,15 +90,11 @@ export function ConfidenceBadge({ level, className }: ConfidenceBadgeProps) {
 }
 
 // Status badge (for admin)
-const statusConfig: Record<MysteryStatus, { icon: React.ReactNode; label: string; className: string }> = {
+// レガシーデータ（translating, error）が来た場合のフォールバック付き
+const statusConfig: Partial<Record<MysteryStatus, { icon: React.ReactNode; label: string; className: string }>> = {
   pending: {
     icon: <Clock3 className="w-3.5 h-3.5" />,
     label: "Pending Review",
-    className: "bg-gold/20 text-[#d4af37] border-gold/30",
-  },
-  translating: {
-    icon: <Languages className="w-3.5 h-3.5" />,
-    label: "Translating",
     className: "bg-gold/20 text-[#d4af37] border-gold/30",
   },
   published: {
@@ -111,11 +107,11 @@ const statusConfig: Record<MysteryStatus, { icon: React.ReactNode; label: string
     label: "Archived",
     className: "bg-blood-red/20 text-[#ff6b6b] border-blood-red/30",
   },
-  error: {
-    icon: <AlertTriangle className="w-3.5 h-3.5" />,
-    label: "Error",
-    className: "bg-blood-red/20 text-[#ff6b6b] border-blood-red/30",
-  },
+}
+
+const fallbackConfig = {
+  icon: <Clock3 className="w-3.5 h-3.5" />,
+  className: "bg-muted text-muted-foreground border-border",
 }
 
 interface StatusBadgeProps {
@@ -129,12 +125,12 @@ export function StatusBadge({ status, className }: StatusBadgeProps) {
     <span
       className={cn(
         "inline-flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-sm border font-mono uppercase tracking-wide",
-        config.className,
+        config?.className ?? fallbackConfig.className,
         className
       )}
     >
-      {config.icon}
-      {config.label}
+      {config?.icon ?? fallbackConfig.icon}
+      {config?.label ?? status}
     </span>
   )
 }


### PR DESCRIPTION
## Summary

- 管理画面のフィルタタブから `TRANSLATING` / `ERROR` を削除（パイプラインで使用されないデッドコード）
- カード内の Translating... スピナーと Error 時の Archive / Retry Translation ボタンを削除
- `StatusBadge` にレガシーデータ用フォールバック表示を追加（未知のステータスが来てもクラッシュしない）
- 型定義（`MysteryStatus`）は後方互換のため変更なし

## Test plan

- [x] TypeScript コンパイルチェック通過（`tsc --noEmit`）
- [ ] dev サーバーでフィルタタブが ALL CASES / PENDING / PUBLISHED / ARCHIVED の4つのみ表示されることを確認
- [ ] 既存記事の表示に問題がないことを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)