### PR TITLE
fix: Firebase 初期化エラー修正 + SSG ビルド安全性強化

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11054,7 +11054,7 @@
         "@tailwindcss/typography": "^0.5.19",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "firebase": "^12.8.0",
+        "firebase": "^12.9.0",
         "firebase-admin": "^13.6.0",
         "google-auth-library": "^9.15.1",
         "lucide-react": "^0.563.0",

--- a/packages/shared/src/lib/firebase/config.ts
+++ b/packages/shared/src/lib/firebase/config.ts
@@ -35,6 +35,14 @@ const globalForFirebase = globalThis as unknown as {
  */
 export function getFirebaseApp(): FirebaseApp {
   if (!globalForFirebase._firebaseApp) {
+    // projectId が未設定なら環境変数の設定漏れ
+    if (!firebaseConfig.projectId) {
+      throw new Error(
+        "[Firebase] NEXT_PUBLIC_FIREBASE_PROJECT_ID が未設定です。" +
+        ".env.local（開発）または .env.production（ビルド）を確認してください。"
+      );
+    }
+
     // 既存のアプリがあれば再利用、なければ新規作成
     const existingApps = getApps();
     if (existingApps.length > 0) {

--- a/web-admin/package.json
+++ b/web-admin/package.json
@@ -15,7 +15,7 @@
     "@tailwindcss/typography": "^0.5.19",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "firebase": "^12.8.0",
+    "firebase": "^12.9.0",
     "firebase-admin": "^13.6.0",
     "lucide-react": "^0.563.0",
     "next": "16.1.4",

--- a/web-public/cloudbuild.yaml
+++ b/web-public/cloudbuild.yaml
@@ -17,6 +17,20 @@ steps:
       - 'GOOGLE_CLOUD_PROJECT=$PROJECT_ID'
       - 'NEXT_PUBLIC_GTM_ID=$_GTM_ID'
 
+  # SSG 出力に記事ページが含まれることを検証（空デプロイ防止）
+  - name: 'node:20'
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        count=$(find out/en/mystery -name "index.html" 2>/dev/null | wc -l)
+        echo "Generated article pages: $count"
+        if [ "$count" -eq "0" ]; then
+          echo "ERROR: 記事ページが0件です。Firestore 接続エラーの可能性があります。デプロイを中止します。"
+          exit 1
+        fi
+    dir: 'web-public'
+
   # Deploy to Firebase Hosting
   - name: 'us-docker.pkg.dev/firebase-cli/us/firebase'
     args: ['deploy', '--only', 'hosting:public', '--project', '$PROJECT_ID']

--- a/web-public/src/app/[lang]/mystery/[id]/page.tsx
+++ b/web-public/src/app/[lang]/mystery/[id]/page.tsx
@@ -25,14 +25,11 @@ export const dynamicParams = false
 export const revalidate = 0
 
 export async function generateStaticParams() {
-  try {
-    const ids = await getPublishedMysteryIds()
-    return SUPPORTED_LANGS.flatMap((lang) =>
-      ids.map((id) => ({ lang, id }))
-    )
-  } catch {
-    return []
-  }
+  // Firestore 接続エラー時はビルドを失敗させる（空デプロイ防止）
+  const ids = await getPublishedMysteryIds()
+  return SUPPORTED_LANGS.flatMap((lang) =>
+    ids.map((id) => ({ lang, id }))
+  )
 }
 
 export async function generateMetadata({


### PR DESCRIPTION
## Summary

- **Firebase SDK バージョン統一**: web-admin の `firebase` を `^12.8.0` → `^12.9.0` に更新し、npm workspaces で SDK が単一コピーにホイストされるようにした。これにより `collection()` に渡す `Firestore` インスタンスの型不一致エラーを解消
- **Firebase 初期化の防御的バリデーション**: `getFirebaseApp()` で `projectId` が未設定の場合に明示的なエラーメッセージをスロー（環境変数の設定漏れを即座に検出）
- **SSG ビルドの Fail Fast 化**: `generateStaticParams()` の try/catch を削除し、Firestore 接続エラー時にビルドを失敗させる（記事ゼロの空デプロイ防止）
- **Cloud Build バリデーションステップ追加**: `next build` 後・`firebase deploy` 前に記事ページの存在を検証する二重安全策

## 背景

`localhost:3000/ja/` で記事が表示されない問題の原因は、web-admin と web-public で Firebase SDK バージョンが異なり、npm workspaces で SDK が複数コピーとしてインストールされることだった。`getFirestoreDb()` が返す Firestore インスタンスと `collection()` 関数が別コピーから来るため、内部型チェックが失敗していた。

加えて、本番環境（SSG + Firebase Hosting）でも Firestore 接続エラー時に記事ゼロの静的 HTML が正常にデプロイされてしまうリスクがあったため、ビルド時のエラー伝播と Cloud Build でのバリデーションを追加した。

## Test plan

- [ ] `npm install` 後 `npm run dev` で `localhost:3000/ja/` に記事が表示されることを確認
- [ ] `NEXT_PUBLIC_FIREBASE_PROJECT_ID` を未設定にして `getFirebaseApp()` がエラーをスローすることを確認
- [ ] `web-public` の `npm run build` が Firestore 接続可能時に成功することを確認
- [ ] Cloud Build の記事ページバリデーションステップが正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)