### PR TITLE
fix: About ページのヒーロー画像上部クリッピングを修正

### DIFF
--- a/web-public/src/app/[lang]/about/page.tsx
+++ b/web-public/src/app/[lang]/about/page.tsx
@@ -55,9 +55,7 @@ export default async function AboutPage({
         <Hero dict={dict} />
 
         {/* ヒーロー画像バナー */}
-        <section className="relative overflow-hidden -mt-32">
-          <div className="absolute top-0 left-0 right-0 h-32 bg-gradient-to-b from-background to-transparent z-10 pointer-events-none" />
-
+        <section className="relative overflow-hidden">
           <picture>
             <source media="(max-width: 640px)" srcSet="/images/hero-bg_sm.webp" type="image/webp" />
             <source media="(max-width: 828px)" srcSet="/images/hero-bg_md.webp" type="image/webp" />


### PR DESCRIPTION
## Summary

- About ページのヒーロー画像（hero-bg）の上部が切れていた問題を修正
- `-mt-32`（負マージン）を削除し、Hero テキストセクションとの重なりを解消
- 上部グラデーションオーバーレイ（`h-32 bg-gradient-to-b from-background`）を除去
- 下部グラデーション（Operational Disclosure セクションへのトランジション）は維持

## Test plan

- [ ] `npm run dev` で About ページを開き、ヒーロー画像が全体表示されていることを確認
- [ ] 画像上部が切れていないこと、Header や Hero テキストと重なっていないことを確認
- [ ] モバイル / タブレット / デスクトップの各ブレークポイントで表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)