### PR TITLE
fix: パイプライン失敗の可視化 + テーマ提案エラーハンドリング

### DIFF
--- a/services/curator.py
+++ b/services/curator.py
@@ -34,7 +34,16 @@ from shared.pipeline_failure import get_recent_failures
 
 logger = logging.getLogger(__name__)
 
+# 認証エラーを示すキーワード
+_AUTH_ERROR_KEYWORDS = ("reauthentication", "default credentials", "invalid_grant")
+
 app = FastAPI()
+
+
+def _is_auth_error(error: Exception) -> bool:
+    """例外が Google Cloud 認証エラーかどうかを判定する。"""
+    msg = str(error).lower()
+    return any(kw in msg for kw in _AUTH_ERROR_KEYWORDS)
 
 
 async def run_curator() -> list[dict]:
@@ -200,6 +209,15 @@ async def suggest_theme():
             content={"error": "Failed to parse suggestions from agent", "detail": str(e)},
         )
     except Exception as e:
+        if _is_auth_error(e):
+            return JSONResponse(
+                status_code=500,
+                content={
+                    "error": "Failed to generate theme suggestions",
+                    "error_type": "auth_error",
+                    "detail": "Google Cloud の認証が切れています。サーバーで gcloud auth application-default login を実行してください。",
+                },
+            )
         return JSONResponse(
             status_code=500,
             content={"error": "Failed to generate theme suggestions", "detail": str(e)},

--- a/shared/orchestrator.py
+++ b/shared/orchestrator.py
@@ -20,6 +20,7 @@ from google.adk.runners import Runner
 from google.adk.sessions import InMemorySessionService
 from google.genai import types
 
+from mystery_agents.agents.pipeline_gate import _is_meaningful
 from mystery_agents.utils.pipeline_logger import PipelineLogger
 from shared.pipeline_run import (
     create_pipeline_run,
@@ -36,6 +37,25 @@ _SKIP_DURATION_THRESHOLD = 0.5
 
 # イベントコールバック型
 OnText = Callable[[str], None]
+
+
+def _detect_gate_failure(session_state: dict) -> str | None:
+    """セッション状態からゲート失敗を検出し、日本語のエラーメッセージを返す。
+
+    blog パイプラインで mystery_id が None の場合に呼ばれる。
+    セッション状態の mystery_report → creative_content を順にチェックし、
+    失敗マーカーを検出した段階で対応するメッセージを返す。
+    """
+    mystery_report = session_state.get("mystery_report", "")
+    if not _is_meaningful(mystery_report):
+        return "十分な資料が見つからなかったため、記事を生成できませんでした"
+
+    creative_content = session_state.get("creative_content", "")
+    if not _is_meaningful(creative_content):
+        return "記事の生成に失敗しました"
+
+    # mystery_id なし + 失敗マーカーなし → 公開処理で問題発生
+    return "記事の公開処理で問題が発生しました"
 
 
 @dataclass
@@ -263,7 +283,15 @@ async def run_pipeline(
             elif isinstance(published, dict):
                 mystery_id = published.get("mystery_id")
 
-        complete_pipeline_run(run_id, mystery_id=mystery_id)
+        # blog パイプラインで記事未生成の場合、ゲート失敗を検出してエラーマーク
+        if run_type == "blog" and mystery_id is None:
+            failure_reason = _detect_gate_failure(session_state)
+            if failure_reason:
+                error_pipeline_run(run_id, failure_reason)
+            else:
+                complete_pipeline_run(run_id)
+        else:
+            complete_pipeline_run(run_id, mystery_id=mystery_id)
 
         return PipelineResult(
             run_id=run_id,

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from shared.orchestrator import PipelineResult, run_pipeline
+from shared.orchestrator import PipelineResult, _detect_gate_failure, run_pipeline
 from tests.fakes import FakeInMemorySessionService
 
 
@@ -56,12 +56,12 @@ class TestRunPipeline:
     """run_pipeline() のテスト"""
 
     @pytest.mark.asyncio
-    @patch("shared.orchestrator.complete_pipeline_run")
+    @patch("shared.orchestrator.error_pipeline_run")
     @patch("shared.orchestrator.update_agent_completed")
     @patch("shared.orchestrator.update_agent_started", return_value=0)
     @patch("shared.orchestrator.create_pipeline_run", return_value="run-001")
     async def test_creates_pipeline_run_when_not_provided(
-        self, mock_create, mock_started, mock_completed, mock_complete
+        self, mock_create, mock_started, mock_completed, mock_error
     ):
         """run_id 未指定時に pipeline_run を自動作成する。"""
         fake_session = FakeInMemorySessionService()
@@ -80,12 +80,12 @@ class TestRunPipeline:
         assert result.run_id == "run-001"
 
     @pytest.mark.asyncio
-    @patch("shared.orchestrator.complete_pipeline_run")
+    @patch("shared.orchestrator.error_pipeline_run")
     @patch("shared.orchestrator.update_agent_completed")
     @patch("shared.orchestrator.update_agent_started", return_value=0)
     @patch("shared.orchestrator.create_pipeline_run")
     async def test_skips_create_when_run_id_provided(
-        self, mock_create, mock_started, mock_completed, mock_complete
+        self, mock_create, mock_started, mock_completed, mock_error
     ):
         """run_id 指定時は pipeline_run を新規作成しない。"""
         fake_session = FakeInMemorySessionService()
@@ -104,12 +104,12 @@ class TestRunPipeline:
         assert result.run_id == "existing-run"
 
     @pytest.mark.asyncio
-    @patch("shared.orchestrator.complete_pipeline_run")
+    @patch("shared.orchestrator.error_pipeline_run")
     @patch("shared.orchestrator.update_agent_completed")
     @patch("shared.orchestrator.update_agent_started", return_value=0)
     @patch("shared.orchestrator.create_pipeline_run", return_value="run-002")
     async def test_agent_transitions_tracked(
-        self, mock_create, mock_started, mock_completed, mock_complete
+        self, mock_create, mock_started, mock_completed, mock_error
     ):
         """エージェント遷移が正しく追跡される。"""
         events = [
@@ -135,12 +135,12 @@ class TestRunPipeline:
         assert result.logs[1]["agent_name"] == "scholar"
 
     @pytest.mark.asyncio
-    @patch("shared.orchestrator.complete_pipeline_run")
+    @patch("shared.orchestrator.error_pipeline_run")
     @patch("shared.orchestrator.update_agent_completed")
     @patch("shared.orchestrator.update_agent_started", return_value=0)
     @patch("shared.orchestrator.create_pipeline_run", return_value="run-003")
     async def test_skip_authors_are_ignored(
-        self, mock_create, mock_started, mock_completed, mock_complete
+        self, mock_create, mock_started, mock_completed, mock_error
     ):
         """skip_authors に含まれるエージェントはログ対象外。"""
         events = [
@@ -165,12 +165,12 @@ class TestRunPipeline:
         assert result.logs[0]["agent_name"] == "librarian"
 
     @pytest.mark.asyncio
-    @patch("shared.orchestrator.complete_pipeline_run")
+    @patch("shared.orchestrator.error_pipeline_run")
     @patch("shared.orchestrator.update_agent_completed")
     @patch("shared.orchestrator.update_agent_started", return_value=0)
     @patch("shared.orchestrator.create_pipeline_run", return_value="run-004")
     async def test_on_text_callback_called(
-        self, mock_create, mock_started, mock_completed, mock_complete
+        self, mock_create, mock_started, mock_completed, mock_error
     ):
         """テキスト出力時に on_text コールバックが呼ばれる。"""
         received_texts = []
@@ -271,12 +271,12 @@ class TestParallelAgentTracking:
     """並列エージェントのインターリーブイベント追跡テスト"""
 
     @pytest.mark.asyncio
-    @patch("shared.orchestrator.complete_pipeline_run")
+    @patch("shared.orchestrator.error_pipeline_run")
     @patch("shared.orchestrator.update_agent_completed")
     @patch("shared.orchestrator.update_agent_started", return_value=0)
     @patch("shared.orchestrator.create_pipeline_run", return_value="run-100")
     async def test_interleaved_parallel_events_single_entry(
-        self, mock_create, mock_started, mock_completed, mock_complete
+        self, mock_create, mock_started, mock_completed, mock_error
     ):
         """並列エージェントの交互イベントが1エントリずつに集約される。"""
         events = [
@@ -308,12 +308,12 @@ class TestParallelAgentTracking:
         assert "Buscando en DPLA..." in result.logs[1]["output_summary"]
 
     @pytest.mark.asyncio
-    @patch("shared.orchestrator.complete_pipeline_run")
+    @patch("shared.orchestrator.error_pipeline_run")
     @patch("shared.orchestrator.update_agent_completed")
     @patch("shared.orchestrator.update_agent_started", return_value=0)
     @patch("shared.orchestrator.create_pipeline_run", return_value="run-101")
     async def test_skip_author_triggers_stage_boundary(
-        self, mock_create, mock_started, mock_completed, mock_complete
+        self, mock_create, mock_started, mock_completed, mock_error
     ):
         """skip_authors イベントがステージ境界として機能し、前ステージを一括完了する。"""
         events = [
@@ -343,12 +343,12 @@ class TestParallelAgentTracking:
         assert result.logs[2]["status"] == "completed"
 
     @pytest.mark.asyncio
-    @patch("shared.orchestrator.complete_pipeline_run")
+    @patch("shared.orchestrator.error_pipeline_run")
     @patch("shared.orchestrator.update_agent_completed")
     @patch("shared.orchestrator.update_agent_started", return_value=0)
     @patch("shared.orchestrator.create_pipeline_run", return_value="run-102")
     async def test_skipped_agent_empty_text_short_duration_removed(
-        self, mock_create, mock_started, mock_completed, mock_complete
+        self, mock_create, mock_started, mock_completed, mock_error
     ):
         """空テキスト + 短時間のスキップエージェントがログから除去される。"""
         # language_gate でスキップされたエージェント: テキストなし
@@ -379,12 +379,12 @@ class TestSequentialAgentCompletion:
     """sequential_agents による直列完了テスト"""
 
     @pytest.mark.asyncio
-    @patch("shared.orchestrator.complete_pipeline_run")
+    @patch("shared.orchestrator.error_pipeline_run")
     @patch("shared.orchestrator.update_agent_completed")
     @patch("shared.orchestrator.update_agent_started", return_value=0)
     @patch("shared.orchestrator.create_pipeline_run", return_value="run-200")
     async def test_sequential_agent_auto_completes_predecessor(
-        self, mock_create, mock_started, mock_completed, mock_complete
+        self, mock_create, mock_started, mock_completed, mock_error
     ):
         """sequential_agents 内で新エージェント開始時に前のエージェントが自動完了される。"""
         events = [
@@ -416,12 +416,12 @@ class TestSequentialAgentCompletion:
         assert all(log["status"] == "completed" for log in result.logs)
 
     @pytest.mark.asyncio
-    @patch("shared.orchestrator.complete_pipeline_run")
+    @patch("shared.orchestrator.error_pipeline_run")
     @patch("shared.orchestrator.update_agent_completed")
     @patch("shared.orchestrator.update_agent_started", return_value=0)
     @patch("shared.orchestrator.create_pipeline_run", return_value="run-201")
     async def test_sequential_agents_does_not_affect_non_members(
-        self, mock_create, mock_started, mock_completed, mock_complete
+        self, mock_create, mock_started, mock_completed, mock_error
     ):
         """sequential_agents に含まれないエージェントは直列完了の対象外。"""
         events = [
@@ -450,12 +450,12 @@ class TestSequentialAgentCompletion:
         assert len(result.logs) == 3
 
     @pytest.mark.asyncio
-    @patch("shared.orchestrator.complete_pipeline_run")
+    @patch("shared.orchestrator.error_pipeline_run")
     @patch("shared.orchestrator.update_agent_completed")
     @patch("shared.orchestrator.update_agent_started", return_value=0)
     @patch("shared.orchestrator.create_pipeline_run", return_value="run-202")
     async def test_no_sequential_agents_same_behavior(
-        self, mock_create, mock_started, mock_completed, mock_complete
+        self, mock_create, mock_started, mock_completed, mock_error
     ):
         """sequential_agents 未指定時は従来と同じ挙動。"""
         events = [
@@ -476,3 +476,162 @@ class TestSequentialAgentCompletion:
         assert len(result.logs) == 2
         assert result.logs[0]["agent_name"] == "script_planner"
         assert result.logs[1]["agent_name"] == "scriptwriter"
+
+
+class TestDetectGateFailure:
+    """_detect_gate_failure() の単体テスト"""
+
+    def test_empty_state_returns_insufficient_data_message(self):
+        """空セッション → 資料不足メッセージを返す。"""
+        result = _detect_gate_failure({})
+        assert "資料が見つからなかった" in result
+
+    def test_insufficient_mystery_report_returns_message(self):
+        """mystery_report が INSUFFICIENT_DATA → 資料不足メッセージ。"""
+        state = {"mystery_report": "INSUFFICIENT_DATA: No data available"}
+        result = _detect_gate_failure(state)
+        assert "資料が見つからなかった" in result
+
+    def test_no_creative_content_returns_message(self):
+        """mystery_report あり + creative_content が NO_CONTENT → 記事生成失敗メッセージ。"""
+        state = {
+            "mystery_report": "A valid report about historical mysteries...",
+            "creative_content": "NO_CONTENT: Story generation failed",
+        }
+        result = _detect_gate_failure(state)
+        assert "記事の生成に失敗" in result
+
+    def test_both_present_returns_publish_error(self):
+        """全フィールド有意 + mystery_id なし → 公開処理失敗メッセージ。"""
+        state = {
+            "mystery_report": "A valid detailed analysis...",
+            "creative_content": "A compelling blog post about...",
+        }
+        result = _detect_gate_failure(state)
+        assert "公開処理で問題" in result
+
+    def test_empty_creative_content_returns_message(self):
+        """mystery_report あり + creative_content が空文字 → 記事生成失敗メッセージ。"""
+        state = {
+            "mystery_report": "A valid analysis result...",
+            "creative_content": "",
+        }
+        result = _detect_gate_failure(state)
+        assert "記事の生成に失敗" in result
+
+
+class TestGateFailureIntegration:
+    """blog パイプラインのゲート失敗 → error_pipeline_run の統合テスト"""
+
+    @pytest.mark.asyncio
+    @patch("shared.orchestrator.error_pipeline_run")
+    @patch("shared.orchestrator.complete_pipeline_run")
+    @patch("shared.orchestrator.create_pipeline_run", return_value="run-300")
+    async def test_blog_gate_failure_marks_error(
+        self, mock_create, mock_complete, mock_error
+    ):
+        """mystery_report が INSUFFICIENT_DATA → error_pipeline_run が呼ばれる。"""
+        fake_session = FakeInMemorySessionService(
+            post_run_state={
+                "mystery_report": "INSUFFICIENT_DATA: All scholars failed",
+            }
+        )
+
+        with patch("shared.orchestrator.Runner", return_value=_make_runner()), \
+             patch("shared.orchestrator.InMemorySessionService", return_value=fake_session):
+            result = await run_pipeline(
+                agent=MagicMock(),
+                app_name="test_app",
+                user_message="test",
+                initial_state={},
+                run_type="blog",
+            )
+
+        assert result.mystery_id is None
+        mock_error.assert_called_once()
+        assert "資料が見つからなかった" in mock_error.call_args[0][1]
+        mock_complete.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("shared.orchestrator.error_pipeline_run")
+    @patch("shared.orchestrator.complete_pipeline_run")
+    @patch("shared.orchestrator.create_pipeline_run", return_value="run-301")
+    async def test_blog_gate_failure_no_creative_content(
+        self, mock_create, mock_complete, mock_error
+    ):
+        """creative_content が NO_CONTENT → error_pipeline_run が呼ばれる。"""
+        fake_session = FakeInMemorySessionService(
+            post_run_state={
+                "mystery_report": "Valid analysis content here...",
+                "creative_content": "NO_CONTENT: generation failed",
+            }
+        )
+
+        with patch("shared.orchestrator.Runner", return_value=_make_runner()), \
+             patch("shared.orchestrator.InMemorySessionService", return_value=fake_session):
+            result = await run_pipeline(
+                agent=MagicMock(),
+                app_name="test_app",
+                user_message="test",
+                initial_state={},
+                run_type="blog",
+            )
+
+        assert result.mystery_id is None
+        mock_error.assert_called_once()
+        assert "記事の生成に失敗" in mock_error.call_args[0][1]
+        mock_complete.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("shared.orchestrator.error_pipeline_run")
+    @patch("shared.orchestrator.complete_pipeline_run")
+    @patch("shared.orchestrator.update_agent_completed")
+    @patch("shared.orchestrator.update_agent_started", return_value=0)
+    @patch("shared.orchestrator.create_pipeline_run", return_value="run-302")
+    async def test_blog_success_not_affected(
+        self, mock_create, mock_started, mock_completed, mock_complete, mock_error
+    ):
+        """mystery_id あり → 従来通り complete_pipeline_run が呼ばれる。"""
+        fake_session = FakeInMemorySessionService(
+            post_run_state={
+                "published_episode": '{"mystery_id": "HIS-NY-212-20260210120000"}',
+            }
+        )
+
+        with patch("shared.orchestrator.Runner", return_value=_make_runner()), \
+             patch("shared.orchestrator.InMemorySessionService", return_value=fake_session):
+            result = await run_pipeline(
+                agent=MagicMock(),
+                app_name="test_app",
+                user_message="test",
+                initial_state={},
+                run_type="blog",
+            )
+
+        assert result.mystery_id == "HIS-NY-212-20260210120000"
+        mock_complete.assert_called_once_with("run-302", mystery_id="HIS-NY-212-20260210120000")
+        mock_error.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("shared.orchestrator.error_pipeline_run")
+    @patch("shared.orchestrator.complete_pipeline_run")
+    @patch("shared.orchestrator.create_pipeline_run", return_value="run-303")
+    async def test_podcast_not_affected(
+        self, mock_create, mock_complete, mock_error
+    ):
+        """podcast パイプラインは mystery_id なしでも complete_pipeline_run。"""
+        fake_session = FakeInMemorySessionService()
+
+        with patch("shared.orchestrator.Runner", return_value=_make_runner()), \
+             patch("shared.orchestrator.InMemorySessionService", return_value=fake_session):
+            result = await run_pipeline(
+                agent=MagicMock(),
+                app_name="test_app",
+                user_message="test",
+                initial_state={},
+                run_type="podcast",
+            )
+
+        assert result.mystery_id is None
+        mock_complete.assert_called_once_with("run-303", mystery_id=None)
+        mock_error.assert_not_called()

--- a/web-admin/src/app/(main)/page.tsx
+++ b/web-admin/src/app/(main)/page.tsx
@@ -193,6 +193,9 @@ export default function AdminPage() {
       const res = await fetch("/api/themes/suggest", { method: "POST" })
       if (!res.ok) {
         const errorData = await res.json().catch(() => ({}))
+        if (errorData.error_type === "auth_error") {
+          throw new Error("Google Cloud の認証が切れています。サーバーで再認証を実行してください。")
+        }
         throw new Error(errorData.detail || errorData.error || `API error (${res.status})`)
       }
       const data = await res.json()

--- a/web-admin/src/app/api/themes/suggest/route.ts
+++ b/web-admin/src/app/api/themes/suggest/route.ts
@@ -41,12 +41,14 @@ export async function POST() {
       const errorBody = await response.text();
       console.error(`Curator service error (${response.status}):`, errorBody);
       let detail = errorBody;
+      let errorType: string | undefined;
       try {
         const parsed = JSON.parse(errorBody);
         detail = parsed.detail || parsed.error || parsed.message || errorBody;
+        errorType = parsed.error_type;
       } catch { /* テキストのまま */ }
       return NextResponse.json(
-        { error: "Failed to generate theme suggestions", detail },
+        { error: "Failed to generate theme suggestions", detail, ...(errorType && { error_type: errorType }) },
         { status: response.status }
       );
     }


### PR DESCRIPTION
## Summary

- ゲート発動でパイプラインが中断した際、管理画面で「完了」ではなく「エラー」（赤アイコン + 日本語理由）が表示されるように修正
- テーマ提案時の gcloud ADC 認証切れエラーを検出し、日本語のユーザーフレンドリーなメッセージを表示

## 変更内容

### 修正1: ゲート失敗時に `status: "error"` をセット

- `shared/orchestrator.py`: `_detect_gate_failure()` 関数を追加。blog パイプラインで `mystery_id` が `None` の場合、セッション状態の `mystery_report` → `creative_content` を順にチェックし、失敗マーカーを検出したら `error_pipeline_run()` を呼ぶ
- 日本語のエラーメッセージ:
  - `mystery_report` が無意味 → 「十分な資料が見つからなかったため、記事を生成できませんでした」
  - `creative_content` が無意味 → 「記事の生成に失敗しました」
  - それ以外 → 「記事の公開処理で問題が発生しました」
- UI 側は変更なし（`active-pipeline-panel.tsx` は `status === "error"` + `error_message` の表示を既にサポート）

### 修正2: テーマ提案の認証エラーハンドリング

- `services/curator.py`: `_is_auth_error()` ヘルパーを追加。`reauthentication` / `default credentials` / `invalid_grant` を検出
- `web-admin/src/app/api/themes/suggest/route.ts`: `error_type` フィールドを透過的に返却
- `web-admin/src/app/(main)/page.tsx`: `error_type === "auth_error"` の場合に日本語メッセージを表示

## Test plan

- [x] `pytest tests/unit/test_orchestrator.py -v` — 全24テスト合格（新規9テスト追加）
- [x] `pytest tests/unit/ -v` — 全524テスト合格（既存テストへの影響なし）
- [ ] 手動確認: 存在しないテーマで調査パイプラインを実行 → ダッシュボードにエラーが表示される
- [ ] 手動確認: gcloud ADC 切れ状態でテーマ提案 → 日本語エラーメッセージが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)