### PR TITLE
fix: Curator テーマ提案の日本語訳が表示されない問題（根本修正）

### DIFF
--- a/services/curator.py
+++ b/services/curator.py
@@ -142,7 +142,14 @@ async def translate_suggestions(suggestions: list[dict]) -> list[dict]:
         app_name="ghost_in_the_archive_curator_translator",
         user_id=user_id,
         session_id=session_id,
-        state={},
+        # Translator のインストラクションが {creative_content}, {mystery_report},
+        # {structured_report} を参照するため、空文字で初期化する。
+        # Curator 経由の場合はユーザーメッセージの JSON が翻訳ソースとなる。
+        state={
+            "creative_content": "",
+            "mystery_report": "",
+            "structured_report": "",
+        },
     )
 
     result_text = ""


### PR DESCRIPTION
## Summary

- `translate_suggestions()` のセッション状態に `creative_content`, `mystery_report`, `structured_report` を空文字で追加
- Translator のインストラクションがこれらのテンプレート変数を参照するため、`state={}` だと ADK が KeyError を発生させ翻訳が常に失敗していた
- PR #130 で `category` を除去したが根本原因はこちらだった

## Root Cause

```
翻訳失敗、英語のみで返却: 'Context variable not found: `creative_content`.'
```

Translator の instruction 内の `{creative_content}` / `{mystery_report}` / `{structured_report}` プレースホルダーを ADK が解決しようとして KeyError → 例外 → 英語のみフォールバック。

## Test plan

- [x] `pytest tests/unit/test_curator_server.py -v` — 全18テスト パス
- [ ] Docker 再起動後、管理画面でテーマ提案ボタンを押し日本語訳が表示されることを確認
- [ ] Docker ログに「翻訳失敗」「Context variable not found」が出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)