### PR TITLE
fix: TaskGroup ExceptionGroup のサブ例外展開 + ツール例外防御化

### DIFF
--- a/mystery_agents/tools/librarian_tools.py
+++ b/mystery_agents/tools/librarian_tools.py
@@ -16,7 +16,7 @@ from .chronicling_america import search_chronicling_america
 from .ddb import search_ddb
 from .dpla import search_dpla
 from .internet_archive import search_internet_archive
-from .link_validator import validate_documents
+from .link_validator import ValidationSummary, validate_documents
 from .loc_digital import search_loc_digital
 from .nypl_digital import search_nypl
 
@@ -75,20 +75,23 @@ def search_newspapers(
         nonlocal total_hits, error
         if not kw_list:
             return
-        results = search_chronicling_america(
-            keywords=kw_list,
-            date_start=start,
-            date_end=end,
-            states=search_states,
-            rows=max_results,
-        )
-        total_hits += results["total_hits"]
-        if results.get("error"):
-            error = results["error"]
-        for doc in results.get("documents", []):
-            if doc.source_url not in seen_urls:
-                seen_urls.add(doc.source_url)
-                all_docs.append(doc)
+        try:
+            results = search_chronicling_america(
+                keywords=kw_list,
+                date_start=start,
+                date_end=end,
+                states=search_states,
+                rows=max_results,
+            )
+            total_hits += results["total_hits"]
+            if results.get("error"):
+                error = results["error"]
+            for doc in results.get("documents", []):
+                if doc.source_url not in seen_urls:
+                    seen_urls.add(doc.source_url)
+                    all_docs.append(doc)
+        except Exception as e:
+            error = str(e)
 
     # Level 1: All keywords together (bilingual)
     levels_used.append("L1_bilingual_combined")
@@ -127,9 +130,16 @@ def search_newspapers(
                 if len(all_docs) >= min_results:
                     break
 
-    # リンク品質検証
-    validation = validate_documents(all_docs)
-    all_docs = validation.verified_documents
+    # リンク品質検証（失敗時は検証スキップで全ドキュメント保持）
+    try:
+        validation = validate_documents(all_docs)
+        all_docs = validation.verified_documents
+    except Exception:
+        validation = ValidationSummary(
+            total_checked=0, reachable=0, unreachable=0,
+            domain_mismatch=0, removed_urls=[], duration_ms=0,
+            verified_documents=list(all_docs),
+        )
     docs = [doc.model_dump() for doc in all_docs]
 
     result = {
@@ -357,9 +367,16 @@ def search_archives(
     for kw_group in keyword_groups:
         all_keywords_used.extend(kw_group)
 
-    # リンク品質検証
-    validation = validate_documents(all_docs)
-    all_docs = validation.verified_documents
+    # リンク品質検証（失敗時は検証スキップで全ドキュメント保持）
+    try:
+        validation = validate_documents(all_docs)
+        all_docs = validation.verified_documents
+    except Exception:
+        validation = ValidationSummary(
+            total_checked=0, reachable=0, unreachable=0,
+            domain_mismatch=0, removed_urls=[], duration_ms=0,
+            verified_documents=list(all_docs),
+        )
     all_docs_dicts = [doc.model_dump() for doc in all_docs]
 
     # Build warnings for missing API keys

--- a/mystery_agents/tools/link_validator.py
+++ b/mystery_agents/tools/link_validator.py
@@ -123,7 +123,7 @@ def verify_link(
             check_duration_ms=elapsed_ms,
         )
 
-    except (requests.exceptions.Timeout, requests.exceptions.ConnectionError) as exc:
+    except requests.exceptions.RequestException as exc:
         elapsed_ms = int((time.monotonic() - start) * 1000)
         logger.warning("Link check failed: %s (%s)", url, exc)
         return LinkCheckResult(

--- a/shared/orchestrator.py
+++ b/shared/orchestrator.py
@@ -32,6 +32,20 @@ from shared.pipeline_run import (
 
 logger = logging.getLogger(__name__)
 
+
+def _format_exception_group(exc: BaseException) -> str:
+    """ExceptionGroup からサブ例外を再帰的に抽出し、可読文字列に整形する。"""
+    if not isinstance(exc, ExceptionGroup):
+        return str(exc)
+    parts = []
+    for sub in exc.exceptions:
+        if isinstance(sub, ExceptionGroup):
+            parts.append(_format_exception_group(sub))
+        else:
+            parts.append(f"{type(sub).__name__}: {sub}")
+    return " | ".join(parts)
+
+
 # スキップされたエージェント判定の閾値（秒）
 _SKIP_DURATION_THRESHOLD = 0.5
 
@@ -304,5 +318,7 @@ async def run_pipeline(
         error_pipeline_run(run_id, f"Pipeline timed out after {timeout_seconds}s")
         raise
     except Exception as e:
-        error_pipeline_run(run_id, str(e))
+        error_message = _format_exception_group(e)
+        logger.error("Pipeline failed: %s", error_message, exc_info=True)
+        error_pipeline_run(run_id, error_message)
         raise

--- a/tests/unit/test_librarian_tools.py
+++ b/tests/unit/test_librarian_tools.py
@@ -1,0 +1,106 @@
+"""Unit tests for mystery_agents/tools/librarian_tools.py"""
+
+import json
+from unittest.mock import patch
+
+from mystery_agents.schemas.document import ArchiveDocument, SourceLanguage, SourceType
+
+
+def _make_doc(url="https://www.loc.gov/item/test/", title="Test Doc"):
+    return ArchiveDocument(
+        title=title,
+        source_url=url,
+        summary="A test document",
+        language=SourceLanguage.EN,
+        location="Test",
+        source_type=SourceType.LOC_DIGITAL,
+    )
+
+
+class TestSearchNewspapersValidationFallback:
+    """search_newspapers の validate_documents 例外時フォールバック"""
+
+    @patch("mystery_agents.tools.librarian_tools.validate_documents")
+    @patch("mystery_agents.tools.librarian_tools.search_chronicling_america")
+    def test_validate_documents_exception_preserves_all_docs(
+        self, mock_search, mock_validate
+    ):
+        """validate_documents が例外を投げても全ドキュメントが保持される。"""
+        doc = _make_doc()
+        mock_search.return_value = {
+            "total_hits": 1,
+            "documents": [doc],
+            "error": None,
+        }
+        mock_validate.side_effect = RuntimeError("unexpected error in validation")
+
+        from mystery_agents.tools.librarian_tools import search_newspapers
+
+        result_json = search_newspapers(keywords="test keyword")
+        result = json.loads(result_json)
+
+        assert result["documents_returned"] == 1
+        assert result["documents"][0]["title"] == "Test Doc"
+        # リンク検証はスキップされる
+        assert result["link_validation"]["total_checked"] == 0
+
+
+class TestSearchArchivesValidationFallback:
+    """search_archives の validate_documents 例外時フォールバック"""
+
+    @patch("mystery_agents.tools.librarian_tools.validate_documents")
+    def test_validate_documents_exception_preserves_all_docs(
+        self, mock_validate
+    ):
+        """validate_documents が例外を投げても全ドキュメントが保持される。"""
+        doc = _make_doc()
+
+        def fake_search_fn(**kwargs):
+            return {
+                "total_hits": 1,
+                "documents": [doc],
+                "error": None,
+            }
+
+        mock_validate.side_effect = RuntimeError("unexpected error in validation")
+
+        from mystery_agents.tools.librarian_tools import _ARCHIVE_SOURCES, search_archives
+
+        original = _ARCHIVE_SOURCES["loc"]
+        _ARCHIVE_SOURCES["loc"] = ("LOC Digital Collections", fake_search_fn)
+        try:
+            result_json = search_archives(keywords="test keyword", sources="loc")
+        finally:
+            _ARCHIVE_SOURCES["loc"] = original
+
+        result = json.loads(result_json)
+
+        assert result["total_documents"] == 1
+        assert result["documents"][0]["title"] == "Test Doc"
+        # リンク検証はスキップされる
+        assert result["link_validation"]["total_checked"] == 0
+
+
+class TestSearchAndCollectFallback:
+    """_search_and_collect 内部関数の例外時フォールバック"""
+
+    @patch("mystery_agents.tools.librarian_tools.validate_documents")
+    @patch("mystery_agents.tools.librarian_tools.search_chronicling_america")
+    def test_search_exception_captured_as_error(
+        self, mock_search, mock_validate
+    ):
+        """search_chronicling_america が例外を投げるとエラーメッセージが記録される。"""
+        mock_search.side_effect = ConnectionError("API unreachable")
+        # validate_documents は呼ばれないはずだが念のためモック
+        mock_validate.return_value = type("Summary", (), {
+            "total_checked": 0, "reachable": 0, "unreachable": 0,
+            "removed_urls": [], "duration_ms": 0, "verified_documents": [],
+        })()
+
+        from mystery_agents.tools.librarian_tools import search_newspapers
+
+        result_json = search_newspapers(keywords="test keyword")
+        result = json.loads(result_json)
+
+        assert result["error"] == "API unreachable"
+        assert result["documents_returned"] == 0

--- a/tests/unit/test_link_validator.py
+++ b/tests/unit/test_link_validator.py
@@ -3,7 +3,7 @@
 from unittest.mock import patch
 
 import responses
-from requests.exceptions import ConnectionError, Timeout
+from requests.exceptions import ConnectionError, InvalidURL, Timeout, TooManyRedirects
 
 from mystery_agents.schemas.document import (
     ArchiveDocument,
@@ -155,6 +155,30 @@ class TestVerifyLink:
 
         assert result.is_reachable is True
         assert result.is_domain_consistent is True
+
+    @responses.activate
+    def test_too_many_redirects_handling(self):
+        """TooManyRedirects 例外 → is_reachable=False + error 記録。"""
+        url = "https://www.loc.gov/item/loop/"
+        responses.add(responses.HEAD, url, body=TooManyRedirects("Exceeded redirects"))
+
+        result = verify_link(url, SourceType.LOC_DIGITAL)
+
+        assert result.is_reachable is False
+        assert result.status_code is None
+        assert result.error is not None
+
+    @responses.activate
+    def test_invalid_url_handling(self):
+        """InvalidURL 例外 → is_reachable=False + error 記録。"""
+        url = "https://www.loc.gov/item/bad\x00url/"
+        responses.add(responses.HEAD, url, body=InvalidURL("Invalid URL"))
+
+        result = verify_link(url, SourceType.LOC_DIGITAL)
+
+        assert result.is_reachable is False
+        assert result.status_code is None
+        assert result.error is not None
 
 
 class TestValidateDocuments:

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -4,7 +4,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from shared.orchestrator import PipelineResult, _detect_gate_failure, run_pipeline
+from shared.orchestrator import (
+    PipelineResult,
+    _detect_gate_failure,
+    _format_exception_group,
+    run_pipeline,
+)
 from tests.fakes import FakeInMemorySessionService
 
 
@@ -635,3 +640,78 @@ class TestGateFailureIntegration:
         assert result.mystery_id is None
         mock_complete.assert_called_once_with("run-303", mystery_id=None)
         mock_error.assert_not_called()
+
+
+class TestFormatExceptionGroup:
+    """_format_exception_group() の単体テスト"""
+
+    def test_plain_exception_returns_str(self):
+        """通常例外は str(exc) を返す。"""
+        exc = RuntimeError("something broke")
+        assert _format_exception_group(exc) == "something broke"
+
+    def test_single_sub_exception(self):
+        """サブ例外1個の ExceptionGroup を展開する。"""
+        inner = ValueError("bad value")
+        group = ExceptionGroup("group", [inner])
+        result = _format_exception_group(group)
+        assert "ValueError: bad value" in result
+
+    def test_multiple_sub_exceptions(self):
+        """サブ例外複数の ExceptionGroup を展開する。"""
+        group = ExceptionGroup("group", [
+            RuntimeError("err1"),
+            TypeError("err2"),
+        ])
+        result = _format_exception_group(group)
+        assert "RuntimeError: err1" in result
+        assert "TypeError: err2" in result
+        assert " | " in result
+
+    def test_nested_exception_group(self):
+        """ネストした ExceptionGroup を再帰的に展開する。"""
+        inner_group = ExceptionGroup("inner", [KeyError("missing")])
+        outer_group = ExceptionGroup("outer", [
+            inner_group,
+            IOError("disk full"),
+        ])
+        result = _format_exception_group(outer_group)
+        assert "KeyError" in result
+        assert "IOError" in result or "OSError" in result
+
+
+class TestExceptionGroupInPipeline:
+    """run_pipeline で ExceptionGroup 発生時のサブ例外展開テスト"""
+
+    @pytest.mark.asyncio
+    @patch("shared.orchestrator.error_pipeline_run")
+    @patch("shared.orchestrator.create_pipeline_run", return_value="run-400")
+    async def test_exception_group_unwrapped_in_error_message(
+        self, mock_create, mock_error
+    ):
+        """ExceptionGroup 発生時に error_pipeline_run にサブ例外詳細が渡される。"""
+        async def error_run_async(**kwargs):
+            raise ExceptionGroup("TaskGroup errors", [
+                RuntimeError("tool X failed"),
+                ValueError("invalid input"),
+            ])
+            yield
+
+        runner = MagicMock()
+        runner.run_async = error_run_async
+        fake_session = FakeInMemorySessionService()
+
+        with patch("shared.orchestrator.Runner", return_value=runner), \
+             patch("shared.orchestrator.InMemorySessionService", return_value=fake_session):
+            with pytest.raises(ExceptionGroup):
+                await run_pipeline(
+                    agent=MagicMock(),
+                    app_name="test_app",
+                    user_message="test",
+                    initial_state={},
+                )
+
+        # サブ例外の詳細が error_pipeline_run に渡される
+        error_msg = mock_error.call_args[0][1]
+        assert "RuntimeError: tool X failed" in error_msg
+        assert "ValueError: invalid input" in error_msg


### PR DESCRIPTION
## Summary

ParallelAgent 内で asyncio.TaskGroup の ExceptionGroup が発生した際、サブ例外の詳細が失われる問題を修正。

- `_format_exception_group()` ヘルパーで ExceptionGroup を再帰的に展開し、Firestore エラーログに詳細を記録
- `link_validator.py` の例外捕捉を `RequestException` 基底クラスに拡大（TooManyRedirects, InvalidURL 等も捕捉）
- `librarian_tools.py` の `validate_documents()` と `_search_and_collect()` を try/except で防御化（失敗時は検証スキップで全ドキュメント保持）

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `shared/orchestrator.py` | `_format_exception_group()` 追加、except ブロック更新 |
| `mystery_agents/tools/link_validator.py` | `Timeout, ConnectionError` → `RequestException` |
| `mystery_agents/tools/librarian_tools.py` | `validate_documents` / `_search_and_collect` 防御化 |
| `tests/unit/test_orchestrator.py` | ExceptionGroup 展開テスト 5件追加 |
| `tests/unit/test_link_validator.py` | RequestException テスト 2件追加 |
| `tests/unit/test_librarian_tools.py` | 新規: validate_documents フォールバックテスト 3件 |

## Test plan

- [x] `python -m pytest tests/unit/ -v` — 全 534 テスト通過
- [x] 新規テスト 10件すべて通過
- [ ] パイプライン実行時に意図的にツール例外を発生させ、Firestore のエラーログにサブ例外詳細が記録されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)