### PR TITLE
fix: Publisher の mystery_id 抽出を tool_context.state 経由に変更

### DIFF
--- a/mystery_agents/tools/publisher_tools.py
+++ b/mystery_agents/tools/publisher_tools.py
@@ -409,6 +409,10 @@ def publish_mystery(
         mystery_id = data["mystery_id"]
         db.collection("mysteries").document(mystery_id).set(data)
 
+        # mystery_id をセッション状態に直接保存（LLM テキスト解析に依存しない確実な受け渡し）
+        if tool_context is not None:
+            tool_context.state["published_mystery_id"] = mystery_id
+
         return json.dumps({
             "status": "success",
             "mystery_id": mystery_id,

--- a/shared/orchestrator.py
+++ b/shared/orchestrator.py
@@ -287,15 +287,22 @@ async def run_pipeline(
         # mystery_id 抽出（blog パイプラインのみ）
         mystery_id = None
         if run_type == "blog" and session_state:
-            published = session_state.get("published_episode", "")
-            if isinstance(published, str) and published.startswith("{"):
-                try:
-                    published_data = json.loads(published)
-                    mystery_id = published_data.get("mystery_id")
-                except (json.JSONDecodeError, AttributeError):
-                    pass
-            elif isinstance(published, dict):
-                mystery_id = published.get("mystery_id")
+            # 優先: ツールがセッション状態に直接書き込んだ mystery_id
+            mystery_id = session_state.get("published_mystery_id")
+
+            # フォールバック: published_episode テキストから抽出
+            if not mystery_id:
+                published = session_state.get("published_episode", "")
+                if isinstance(published, str):
+                    text = published.strip()
+                    if text.startswith("{"):
+                        try:
+                            published_data = json.loads(text)
+                            mystery_id = published_data.get("mystery_id")
+                        except (json.JSONDecodeError, AttributeError):
+                            pass
+                elif isinstance(published, dict):
+                    mystery_id = published.get("mystery_id")
 
         # blog パイプラインで記事未生成の場合、ゲート失敗を検出してエラーマーク
         if run_type == "blog" and mystery_id is None:

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -271,6 +271,62 @@ class TestRunPipeline:
 
         assert result.mystery_id is None
 
+    @pytest.mark.asyncio
+    @patch("shared.orchestrator.complete_pipeline_run")
+    @patch("shared.orchestrator.update_agent_completed")
+    @patch("shared.orchestrator.update_agent_started", return_value=0)
+    @patch("shared.orchestrator.create_pipeline_run", return_value="run-008")
+    async def test_mystery_id_from_published_mystery_id_state(
+        self, mock_create, mock_started, mock_completed, mock_complete
+    ):
+        """published_mystery_id が優先的に使用される。"""
+        fake_session = FakeInMemorySessionService(
+            post_run_state={
+                "published_mystery_id": "HIS-NY-212-20260215100000",
+                "published_episode": "The mystery has been published successfully!",
+            }
+        )
+
+        with patch("shared.orchestrator.Runner", return_value=_make_runner()), \
+             patch("shared.orchestrator.InMemorySessionService", return_value=fake_session):
+            result = await run_pipeline(
+                agent=MagicMock(),
+                app_name="test_app",
+                user_message="test",
+                initial_state={},
+                run_type="blog",
+            )
+
+        assert result.mystery_id == "HIS-NY-212-20260215100000"
+        mock_complete.assert_called_once_with("run-008", mystery_id="HIS-NY-212-20260215100000")
+
+    @pytest.mark.asyncio
+    @patch("shared.orchestrator.complete_pipeline_run")
+    @patch("shared.orchestrator.update_agent_completed")
+    @patch("shared.orchestrator.update_agent_started", return_value=0)
+    @patch("shared.orchestrator.create_pipeline_run", return_value="run-009")
+    async def test_fallback_to_published_episode_with_leading_whitespace(
+        self, mock_create, mock_started, mock_completed, mock_complete
+    ):
+        """published_mystery_id がない場合、published_episode を strip してフォールバック。"""
+        fake_session = FakeInMemorySessionService(
+            post_run_state={
+                "published_episode": '\n{"mystery_id": "FLK-MA-978-20260215120000", "status": "success"}'
+            }
+        )
+
+        with patch("shared.orchestrator.Runner", return_value=_make_runner()), \
+             patch("shared.orchestrator.InMemorySessionService", return_value=fake_session):
+            result = await run_pipeline(
+                agent=MagicMock(),
+                app_name="test_app",
+                user_message="test",
+                initial_state={},
+                run_type="blog",
+            )
+
+        assert result.mystery_id == "FLK-MA-978-20260215120000"
+
 
 class TestParallelAgentTracking:
     """並列エージェントのインターリーブイベント追跡テスト"""

--- a/tests/unit/test_publisher_tools.py
+++ b/tests/unit/test_publisher_tools.py
@@ -749,3 +749,39 @@ class TestPublishMysteryEvidenceFiltering:
         # 警告ログが出力されている
         assert any("evidence_a" in r.message and "relevant_excerpt" in r.message for r in caplog.records)
 
+
+class TestPublishMysteryStateWriteback:
+    """publish_mystery が tool_context.state に published_mystery_id を書き込むテスト"""
+
+    @patch("mystery_agents.tools.publisher_tools.get_storage_bucket")
+    @patch("mystery_agents.tools.publisher_tools.get_firestore_client")
+    def test_sets_published_mystery_id_in_state(self, mock_get_db, mock_get_bucket):
+        """成功時に tool_context.state["published_mystery_id"] が設定される。"""
+        mock_get_db.return_value = MagicMock()
+        mock_get_bucket.return_value = MagicMock()
+
+        state = {}
+        tool_context = MagicMock()
+        tool_context.state = state
+
+        result = publish_mystery(_make_mystery_json(), "", tool_context)
+        result_data = json.loads(result)
+
+        assert result_data["status"] == "success"
+        assert "published_mystery_id" in state
+        assert state["published_mystery_id"] == result_data["mystery_id"]
+        # mystery_id 形式チェック
+        assert state["published_mystery_id"].startswith("OCC-MA-617-")
+
+    @patch("mystery_agents.tools.publisher_tools.get_storage_bucket")
+    @patch("mystery_agents.tools.publisher_tools.get_firestore_client")
+    def test_no_state_write_without_tool_context(self, mock_get_db, mock_get_bucket):
+        """tool_context が None の場合でもエラーにならない。"""
+        mock_get_db.return_value = MagicMock()
+        mock_get_bucket.return_value = MagicMock()
+
+        result = publish_mystery(_make_mystery_json(), "", None)
+        result_data = json.loads(result)
+
+        assert result_data["status"] == "success"
+


### PR DESCRIPTION
## Summary

- `publish_mystery` ツールが Firestore 書き込み成功後に `tool_context.state["published_mystery_id"]` へ mystery_id を直接保存するよう修正
- `Orchestrator` が `published_mystery_id` を最優先で参照し、従来の `published_episode` テキストパースをフォールバックに変更
- フォールバック側に `strip()` を追加し、先頭に改行がある JSON にも対応

## 背景

`published_episode` は Publisher LLM の `output_key` で設定されるため、ツールが返した生 JSON ではなく LLM のテキスト応答が入る。LLM が散文で返すと `startswith("{")` が False になり、Firestore への書き込みは成功しているのに管理画面で「記事の公開処理で問題が発生しました」エラーが表示されていた。

## Test plan

- [x] `publish_mystery` が `tool_context.state["published_mystery_id"]` を設定することを検証
- [x] `tool_context` が None でもエラーにならないことを検証
- [x] Orchestrator が `published_mystery_id` を優先参照することを検証
- [x] `published_episode` に先頭空白がある場合のフォールバックを検証
- [x] 既存テスト全 538 件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)