### PR TITLE
fix: web-public ビルド失敗を修正（型エラー + Cloud Build 置換変数）

### DIFF
--- a/web-public/cloudbuild.yaml
+++ b/web-public/cloudbuild.yaml
@@ -36,6 +36,9 @@ steps:
     args: ['deploy', '--only', 'hosting:public', '--project', '$PROJECT_ID']
     dir: 'web-public'
 
+substitutions:
+  _GTM_ID: ''
+
 options:
   logging: CLOUD_LOGGING_ONLY
   machineType: E2_HIGHCPU_8

--- a/web-public/src/components/featured-mystery-card.tsx
+++ b/web-public/src/components/featured-mystery-card.tsx
@@ -29,7 +29,7 @@ export function FeaturedMysteryCard({ mystery, lang, label }: FeaturedMysteryCar
         {hasImage && (
           <div className="relative overflow-hidden max-h-56 sm:max-h-64 lg:max-h-none lg:h-full">
             <ResponsiveHeroImage
-              hero={mystery.images!.hero}
+              hero={mystery.images!.hero!}
               variants={mystery.images!.variants}
               alt={title}
               priority


### PR DESCRIPTION
## Summary
- `FeaturedMysteryCard` の `hero` prop で `string | undefined` → `string` 型エラーが発生し、`next build` が失敗していた問題を修正
- `web-public/cloudbuild.yaml` に `_GTM_ID` のデフォルト空値を追加し、手動 `gcloud builds submit` 時の `INVALID_ARGUMENT` エラーを回避

## Test plan
- [ ] `npm run build` が web-public で成功すること
- [ ] `gcloud builds submit --config web-public/cloudbuild.yaml` が置換変数エラーなく実行できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)