### PR TITLE
ci: Next.js TypeScript 型チェックジョブを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,22 @@ jobs:
       - run: pip install ruff
       - run: ruff check .
 
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - name: web-public typecheck
+        run: npx next typegen && npx tsc --noEmit
+        working-directory: web-public
+      - name: web-admin typecheck
+        run: npx next typegen && npx tsc --noEmit
+        working-directory: web-admin
+
   docker-build:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- CI に `typecheck` ジョブを追加し、web-public / web-admin の TypeScript 型エラーを PR 時に早期検出する
- `next typegen` で Next.js 固有の型定義を生成した後、`tsc --noEmit` で型チェックのみ実行（フルビルド不要）
- PR #135 で発覚した Cloud Build での型エラー再発を防止

## 背景
`FeaturedMysteryCard` の型エラーがローカル `next dev` では検知されず、Cloud Build の `next build` で初めて失敗した。`next build` は SSG/SSR のデータ取得（Firestore 接続）も実行するため CI では不適切。`next typegen` + `tsc --noEmit` の組み合わせにより、外部依存なしで型チェックが可能。

## Test plan
- [x] GitHub Actions で `typecheck` ジョブが実行されることを確認
- [x] web-public / web-admin の型チェックがパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)