### PR TITLE
fix: Cloud Build で .dockerignore を web-admin 用に差し替え

### DIFF
--- a/web-admin/cloudbuild.yaml
+++ b/web-admin/cloudbuild.yaml
@@ -3,7 +3,9 @@
 # Firebase 設定値は deploy.sh が .env.production から置換変数として注入
 
 steps:
-  # .env.production を置換変数から生成
+  # .env.production 生成 + .dockerignore を web-admin 用に差し替え
+  # Cloud Build の Docker は BuildKit が無効のため Dockerfile.dockerignore を読まない
+  # ルートの .dockerignore は pipelines 用で web-admin/ を除外しているためコピーが必要
   - name: 'node:20'
     entrypoint: 'bash'
     args:
@@ -17,10 +19,10 @@ steps:
         NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=$_NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID
         NEXT_PUBLIC_FIREBASE_APP_ID=$_NEXT_PUBLIC_FIREBASE_APP_ID
         ENVEOF
+        cp web-admin/Dockerfile.dockerignore .dockerignore
 
   # Docker build
   - name: 'gcr.io/cloud-builders/docker'
-    env: ['DOCKER_BUILDKIT=1']
     args: ['build', '-f', 'web-admin/Dockerfile', '-t',
            'asia-northeast1-docker.pkg.dev/ghostinthearchive/ghostinthearchive/web-admin:latest', '.']
 


### PR DESCRIPTION
## Summary

- Cloud Build の `gcr.io/cloud-builders/docker` は `DOCKER_BUILDKIT=1` が無効のため、`Dockerfile.dockerignore` を読み込まない
- ルートの `.dockerignore` が `web-admin/` を除外しており、`COPY web-admin/package.json` で Docker ビルドが失敗していた
- ビルド前ステップで `cp web-admin/Dockerfile.dockerignore .dockerignore` して解決
- 効かない `DOCKER_BUILDKIT=1` env 設定も削除

## Test plan

- [ ] `./scripts/deploy.sh web-admin` で Cloud Build が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)