### PR TITLE
fix: Cloud Run ingress を ALL に変更し curator/pipeline の 404 を解消

### DIFF
--- a/terraform/cloud-run.tf
+++ b/terraform/cloud-run.tf
@@ -111,7 +111,7 @@ resource "google_cloud_run_v2_service" "web_admin" {
 resource "google_cloud_run_v2_service" "curator" {
   name     = "curator"
   location = var.region
-  ingress  = "INGRESS_TRAFFIC_INTERNAL_ONLY"
+  ingress  = "INGRESS_TRAFFIC_ALL"
 
   template {
     service_account = google_service_account.pipelines.email
@@ -180,7 +180,7 @@ resource "google_cloud_run_v2_service" "curator" {
 resource "google_cloud_run_v2_service" "pipeline" {
   name     = "pipeline"
   location = var.region
-  ingress  = "INGRESS_TRAFFIC_INTERNAL_ONLY"
+  ingress  = "INGRESS_TRAFFIC_ALL"
 
   template {
     service_account = google_service_account.pipelines.email


### PR DESCRIPTION
## Summary

- curator / pipeline の Cloud Run サービスの ingress を `INGRESS_TRAFFIC_INTERNAL_ONLY` → `INGRESS_TRAFFIC_ALL` に変更
- web-admin から `.run.app` URL への HTTPS リクエストが VPC コネクタ未設定のため外部経由となり、404 で拒否されていた問題を修正

## 影響範囲

以下の全 API ルートが本番で 404 → 正常動作に復旧：
- `POST /api/themes/suggest` → curator
- `POST /api/mysteries/investigate` → pipeline
- `POST /api/mysteries/translate` → pipeline
- `POST /api/podcast/generate-script` → pipeline
- `POST /api/podcast/generate-audio` → pipeline

## セキュリティ

ingress を `ALL` に変更しても安全：
- Cloud Run サービスは IAM 認証必須（`allUsers` に `run.invoker` 未付与）
- `web-admin-sa` にのみ `roles/run.invoker` を付与済み（`iam.tf:28-32`）
- 未認証リクエストは IAM 層で 403 として拒否される

## 適用方法

\`\`\`bash
./scripts/deploy.sh infra
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)