### PR TITLE
fix: Publisher プレースホルダー完全除去 + pipeline_runs error_detail 追加

### DIFF
--- a/mystery_agents/agents/publisher.py
+++ b/mystery_agents/agents/publisher.py
@@ -21,60 +21,19 @@ from ..tools.publisher_tools import publish_mystery
 load_dotenv(Path(__file__).parent.parent / ".env")  # mystery_agents/.env
 
 # === 日本語訳 ===
-# あなたは「Ghost in the Archive」プロジェクトのパブリッシャー（Publisher Agent）です。
-# publish_mystery ツールがセッション状態からほぼすべてのデータを自動収集します。
-#
-# publish_mystery ツールが自動収集するデータ:
-# - structured_report → classification, evidence, hypothesis, title, summary 等
-# - creative_content → narrative_content（ブログ記事全文）
-# - collected_documents_en → raw_data（検索メタデータ）
-# - image_metadata → 画像アップロード
-# - translation_result_{lang} → 6言語翻訳
-#
-# ## タスク
-# 1. パイプライン失敗マーカーをチェック
-# 2. mystery_report を参照して最小限の JSON（classification, state_code, area_code）を構築
-# 3. publish_mystery を呼び出す（ツールが残りすべてを自動処理）
+# あなたはパブリッシャーエージェントです。
+# publish_mystery ツールがセッション状態から全データを自動読み取りします。
+# 空の JSON で publish_mystery を呼び出すだけで完了です: publish_mystery("{}")
+# ツールが classification、コンテンツ、画像、翻訳——すべてを処理します。
+# publish_mystery を必ず呼び出してください。出力は短く保ってください。
 # === End 日本語訳 ===
 
 PUBLISHER_INSTRUCTION = """
-You are the Publisher Agent for the "Ghost in the Archive" project.
-The publish_mystery tool automatically collects almost all required data from session state:
-- structured_report → classification, evidence, hypothesis, title, summary, etc.
-- creative_content → narrative_content (blog article)
-- collected_documents_en → raw_data (search metadata)
-- image_metadata → image upload
-- translation_result_{lang} → 6-language translations
-
-## Task
-
-### Step 1: Check for pipeline failure
-Read {mystery_report} briefly. If it is empty or contains "NO_DOCUMENTS_FOUND" or "INSUFFICIENT_DATA",
-do NOT publish — just report the failure.
-Similarly, if {creative_content} contains "NO_CONTENT", do NOT publish.
-
-### Step 2: Build minimal JSON
-From {mystery_report}, extract ONLY the geographic identifiers:
-- classification: 3-letter code (HIS/FLK/ANT/OCC/URB/CRM/REL/LOC)
-- state_code: 2-letter US state code (MA, NY, CA, etc.)
-- area_code: 3-digit telephone area code (617, 212, 215, etc.)
-
-Major area code reference:
-- BOSTON: MA-617, SALEM: MA-978, NEW_YORK: NY-212, BROOKLYN: NY-718
-- PHILADELPHIA: PA-215, CHICAGO: IL-312, NEW_ORLEANS: LA-504
-- SAN_FRANCISCO: CA-415, LOS_ANGELES: CA-213, WASHINGTON_DC: DC-202
-
-### Step 3: Call publish_mystery
-Call `publish_mystery` with a minimal JSON containing only the 3 fields above:
-```json
-{"classification": "...", "state_code": "...", "area_code": "..."}
-```
-The tool handles everything else automatically — do NOT include narrative_content,
-raw_data, translations, images, or any other large fields in the JSON.
-
-## Important
-- You MUST call the publish_mystery tool to actually save the data.
-- Keep your output SHORT — do not copy or echo any session state content.
+You are the Publisher Agent.
+The publish_mystery tool automatically reads ALL data from session state.
+Just call publish_mystery with an empty JSON: publish_mystery("{}")
+The tool handles classification, content, images, translations — everything.
+You MUST call publish_mystery. Keep your output SHORT.
 """
 
 publisher_agent = LlmAgent(

--- a/services/pipeline_server.py
+++ b/services/pipeline_server.py
@@ -77,7 +77,10 @@ async def _run_investigate(query: str, run_id: str) -> None:
         )
     except Exception as e:
         logger.exception("Blog pipeline failed: %s", e)
-        error_pipeline_run(run_id, str(e))
+        error_pipeline_run(run_id, str(e), error_detail={
+            "error_type": "exception",
+            "exception_class": type(e).__name__,
+        })
 
 
 async def _run_generate_script(

--- a/shared/orchestrator.py
+++ b/shared/orchestrator.py
@@ -53,23 +53,57 @@ _SKIP_DURATION_THRESHOLD = 0.5
 OnText = Callable[[str], None]
 
 
-def _detect_gate_failure(session_state: dict) -> str | None:
-    """セッション状態からゲート失敗を検出し、日本語のエラーメッセージを返す。
+def _build_state_summary(session_state: dict) -> dict:
+    """デバッグ用にセッション状態キーの存在と長さをサマリ化する。"""
+    keys = [
+        "mystery_report", "creative_content", "structured_report",
+        "image_metadata", "published_mystery_id", "published_episode",
+    ]
+    summary = {}
+    for k in keys:
+        v = session_state.get(k)
+        if v is None:
+            summary[k] = "missing"
+        elif isinstance(v, str):
+            summary[k] = f"present ({len(v)} chars)"
+        elif isinstance(v, dict):
+            summary[k] = f"present (dict, {len(v)} keys)"
+        else:
+            summary[k] = f"present ({type(v).__name__})"
+    return {"session_state_summary": summary}
+
+
+def _detect_gate_failure(session_state: dict) -> tuple[str, dict]:
+    """セッション状態からゲート失敗を検出し、エラーメッセージと詳細情報を返す。
 
     blog パイプラインで mystery_id が None の場合に呼ばれる。
     セッション状態の mystery_report → creative_content を順にチェックし、
-    失敗マーカーを検出した段階で対応するメッセージを返す。
+    失敗マーカーを検出した段階で対応するメッセージと error_detail を返す。
     """
+    detail = _build_state_summary(session_state)
+
     mystery_report = session_state.get("mystery_report", "")
     if not _is_meaningful(mystery_report):
-        return "十分な資料が見つからなかったため、記事を生成できませんでした"
+        return "十分な資料が見つからなかったため、記事を生成できませんでした", {
+            "error_type": "gate_failure",
+            "failed_stage": "scholar/polymath",
+            **detail,
+        }
 
     creative_content = session_state.get("creative_content", "")
     if not _is_meaningful(creative_content):
-        return "記事の生成に失敗しました"
+        return "記事の生成に失敗しました", {
+            "error_type": "gate_failure",
+            "failed_stage": "storyteller",
+            **detail,
+        }
 
     # mystery_id なし + 失敗マーカーなし → 公開処理で問題発生
-    return "記事の公開処理で問題が発生しました"
+    return "記事の公開処理で問題が発生しました", {
+        "error_type": "publish_failed",
+        "failed_stage": "publisher",
+        **detail,
+    }
 
 
 @dataclass
@@ -306,11 +340,8 @@ async def run_pipeline(
 
         # blog パイプラインで記事未生成の場合、ゲート失敗を検出してエラーマーク
         if run_type == "blog" and mystery_id is None:
-            failure_reason = _detect_gate_failure(session_state)
-            if failure_reason:
-                error_pipeline_run(run_id, failure_reason)
-            else:
-                complete_pipeline_run(run_id)
+            failure_reason, detail = _detect_gate_failure(session_state)
+            error_pipeline_run(run_id, failure_reason, error_detail=detail)
         else:
             complete_pipeline_run(run_id, mystery_id=mystery_id)
 
@@ -322,10 +353,16 @@ async def run_pipeline(
         )
 
     except TimeoutError:
-        error_pipeline_run(run_id, f"Pipeline timed out after {timeout_seconds}s")
+        error_pipeline_run(run_id, f"Pipeline timed out after {timeout_seconds}s", error_detail={
+            "error_type": "timeout",
+            "timeout_seconds": timeout_seconds,
+        })
         raise
     except Exception as e:
         error_message = _format_exception_group(e)
         logger.error("Pipeline failed: %s", error_message, exc_info=True)
-        error_pipeline_run(run_id, error_message)
+        error_pipeline_run(run_id, error_message, error_detail={
+            "error_type": "exception",
+            "exception_class": type(e).__name__,
+        })
         raise

--- a/shared/pipeline_run.py
+++ b/shared/pipeline_run.py
@@ -162,25 +162,30 @@ def complete_pipeline_run(
 def error_pipeline_run(
     run_id: str | None,
     error_message: str,
+    error_detail: dict | None = None,
 ) -> None:
     """パイプライン実行をエラーとしてマークする。
 
     Args:
         run_id: パイプライン実行ドキュメントの ID
         error_message: エラーメッセージ
+        error_detail: デバッグ用の詳細情報（セッション状態サマリ等）
     """
     if not run_id:
         return
     try:
         db = get_firestore_client()
         now = datetime.now(timezone.utc)
-        db.collection(COLLECTION).document(run_id).update({
+        update_data: dict = {
             "status": "error",
             "current_agent": None,
             "updated_at": now,
             "completed_at": now,
             "error_message": error_message[:500],
-        })
+        }
+        if error_detail:
+            update_data["error_detail"] = error_detail
+        db.collection(COLLECTION).document(run_id).update(update_data)
         logger.info("Pipeline run errored: %s", run_id)
     except Exception:
         logger.exception("Failed to mark pipeline run as error: %s", run_id)

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -6,6 +6,7 @@ import pytest
 
 from shared.orchestrator import (
     PipelineResult,
+    _build_state_summary,
     _detect_gate_failure,
     _format_exception_group,
     run_pipeline,
@@ -219,7 +220,10 @@ class TestRunPipeline:
                     initial_state={},
                 )
 
-        mock_error.assert_called_once_with("run-005", "Something went wrong")
+        mock_error.assert_called_once_with(
+            "run-005", "Something went wrong",
+            error_detail={"error_type": "exception", "exception_class": "RuntimeError"},
+        )
 
     @pytest.mark.asyncio
     @patch("shared.orchestrator.complete_pipeline_run")
@@ -544,14 +548,17 @@ class TestDetectGateFailure:
 
     def test_empty_state_returns_insufficient_data_message(self):
         """空セッション → 資料不足メッセージを返す。"""
-        result = _detect_gate_failure({})
-        assert "資料が見つからなかった" in result
+        message, detail = _detect_gate_failure({})
+        assert "資料が見つからなかった" in message
+        assert detail["error_type"] == "gate_failure"
+        assert detail["failed_stage"] == "scholar/polymath"
 
     def test_insufficient_mystery_report_returns_message(self):
         """mystery_report が INSUFFICIENT_DATA → 資料不足メッセージ。"""
         state = {"mystery_report": "INSUFFICIENT_DATA: No data available"}
-        result = _detect_gate_failure(state)
-        assert "資料が見つからなかった" in result
+        message, detail = _detect_gate_failure(state)
+        assert "資料が見つからなかった" in message
+        assert detail["error_type"] == "gate_failure"
 
     def test_no_creative_content_returns_message(self):
         """mystery_report あり + creative_content が NO_CONTENT → 記事生成失敗メッセージ。"""
@@ -559,8 +566,9 @@ class TestDetectGateFailure:
             "mystery_report": "A valid report about historical mysteries...",
             "creative_content": "NO_CONTENT: Story generation failed",
         }
-        result = _detect_gate_failure(state)
-        assert "記事の生成に失敗" in result
+        message, detail = _detect_gate_failure(state)
+        assert "記事の生成に失敗" in message
+        assert detail["failed_stage"] == "storyteller"
 
     def test_both_present_returns_publish_error(self):
         """全フィールド有意 + mystery_id なし → 公開処理失敗メッセージ。"""
@@ -568,8 +576,10 @@ class TestDetectGateFailure:
             "mystery_report": "A valid detailed analysis...",
             "creative_content": "A compelling blog post about...",
         }
-        result = _detect_gate_failure(state)
-        assert "公開処理で問題" in result
+        message, detail = _detect_gate_failure(state)
+        assert "公開処理で問題" in message
+        assert detail["error_type"] == "publish_failed"
+        assert detail["failed_stage"] == "publisher"
 
     def test_empty_creative_content_returns_message(self):
         """mystery_report あり + creative_content が空文字 → 記事生成失敗メッセージ。"""
@@ -577,8 +587,23 @@ class TestDetectGateFailure:
             "mystery_report": "A valid analysis result...",
             "creative_content": "",
         }
-        result = _detect_gate_failure(state)
-        assert "記事の生成に失敗" in result
+        message, detail = _detect_gate_failure(state)
+        assert "記事の生成に失敗" in message
+
+    def test_includes_state_summary(self):
+        """error_detail に session_state_summary が含まれる。"""
+        state = {
+            "mystery_report": "A valid detailed analysis...",
+            "creative_content": "A compelling blog post about...",
+            "structured_report": {"title": "test"},
+        }
+        _, detail = _detect_gate_failure(state)
+        summary = detail["session_state_summary"]
+        assert "present" in summary["mystery_report"]
+        assert "present" in summary["creative_content"]
+        assert "present (dict, 1 keys)" == summary["structured_report"]
+        assert summary["image_metadata"] == "missing"
+        assert summary["published_mystery_id"] == "missing"
 
 
 class TestGateFailureIntegration:
@@ -611,6 +636,10 @@ class TestGateFailureIntegration:
         assert result.mystery_id is None
         mock_error.assert_called_once()
         assert "資料が見つからなかった" in mock_error.call_args[0][1]
+        # error_detail が渡される
+        error_detail = mock_error.call_args[1]["error_detail"]
+        assert error_detail["error_type"] == "gate_failure"
+        assert "session_state_summary" in error_detail
         mock_complete.assert_not_called()
 
     @pytest.mark.asyncio
@@ -641,6 +670,9 @@ class TestGateFailureIntegration:
         assert result.mystery_id is None
         mock_error.assert_called_once()
         assert "記事の生成に失敗" in mock_error.call_args[0][1]
+        # error_detail が渡される
+        error_detail = mock_error.call_args[1]["error_detail"]
+        assert error_detail["failed_stage"] == "storyteller"
         mock_complete.assert_not_called()
 
     @pytest.mark.asyncio
@@ -771,3 +803,56 @@ class TestExceptionGroupInPipeline:
         error_msg = mock_error.call_args[0][1]
         assert "RuntimeError: tool X failed" in error_msg
         assert "ValueError: invalid input" in error_msg
+        # error_detail に exception_class が含まれる
+        error_detail = mock_error.call_args[1]["error_detail"]
+        assert error_detail["error_type"] == "exception"
+        assert error_detail["exception_class"] == "ExceptionGroup"
+
+
+class TestBuildStateSummary:
+    """_build_state_summary() の単体テスト"""
+
+    def test_missing_keys(self):
+        """存在しないキーは 'missing' と表示される。"""
+        summary = _build_state_summary({})["session_state_summary"]
+        assert summary["mystery_report"] == "missing"
+        assert summary["creative_content"] == "missing"
+        assert summary["structured_report"] == "missing"
+        assert summary["image_metadata"] == "missing"
+        assert summary["published_mystery_id"] == "missing"
+        assert summary["published_episode"] == "missing"
+
+    def test_string_values(self):
+        """文字列値は文字数付きで表示される。"""
+        state = {"mystery_report": "x" * 100, "creative_content": "hello"}
+        summary = _build_state_summary(state)["session_state_summary"]
+        assert summary["mystery_report"] == "present (100 chars)"
+        assert summary["creative_content"] == "present (5 chars)"
+
+    def test_dict_values(self):
+        """dict 値はキー数付きで表示される。"""
+        state = {"structured_report": {"a": 1, "b": 2, "c": 3}}
+        summary = _build_state_summary(state)["session_state_summary"]
+        assert summary["structured_report"] == "present (dict, 3 keys)"
+
+    def test_other_types(self):
+        """その他の型は型名付きで表示される。"""
+        state = {"image_metadata": 42}
+        summary = _build_state_summary(state)["session_state_summary"]
+        assert summary["image_metadata"] == "present (int)"
+
+    def test_mixed_state(self):
+        """複合状態が正しくサマリ化される。"""
+        state = {
+            "mystery_report": "A valid analysis...",
+            "creative_content": "A blog post...",
+            "structured_report": {"title": "test", "classification": "HIS"},
+            "image_metadata": {"url": "https://..."},
+        }
+        summary = _build_state_summary(state)["session_state_summary"]
+        assert "present" in summary["mystery_report"]
+        assert "present" in summary["creative_content"]
+        assert "present (dict, 2 keys)" == summary["structured_report"]
+        assert "present (dict, 1 keys)" == summary["image_metadata"]
+        assert summary["published_mystery_id"] == "missing"
+        assert summary["published_episode"] == "missing"

--- a/tests/unit/test_pipeline_run.py
+++ b/tests/unit/test_pipeline_run.py
@@ -367,6 +367,53 @@ class TestErrorPipelineRun:
         # Should not raise
         error_pipeline_run(None, "some error")
 
+    def test_error_pipeline_run_with_detail(self, mock_firestore_client):
+        """error_detail が Firestore に保存される。"""
+        mock_doc_ref = MagicMock()
+        mock_firestore_client.collection.return_value.document.return_value = (
+            mock_doc_ref
+        )
+
+        detail = {
+            "error_type": "gate_failure",
+            "failed_stage": "publisher",
+            "session_state_summary": {"mystery_report": "present (500 chars)"},
+        }
+
+        with patch(
+            "shared.pipeline_run.get_firestore_client",
+            return_value=mock_firestore_client,
+        ):
+            from shared.pipeline_run import error_pipeline_run
+
+            error_pipeline_run("run-123", "公開処理で問題が発生", error_detail=detail)
+
+        call_args = mock_doc_ref.update.call_args
+        update_data = call_args[0][0]
+        assert update_data["status"] == "error"
+        assert update_data["error_detail"] == detail
+        assert update_data["error_detail"]["error_type"] == "gate_failure"
+
+    def test_error_pipeline_run_without_detail(self, mock_firestore_client):
+        """error_detail なしでも従来通り動作する。"""
+        mock_doc_ref = MagicMock()
+        mock_firestore_client.collection.return_value.document.return_value = (
+            mock_doc_ref
+        )
+
+        with patch(
+            "shared.pipeline_run.get_firestore_client",
+            return_value=mock_firestore_client,
+        ):
+            from shared.pipeline_run import error_pipeline_run
+
+            error_pipeline_run("run-123", "some error")
+
+        call_args = mock_doc_ref.update.call_args
+        update_data = call_args[0][0]
+        assert update_data["status"] == "error"
+        assert "error_detail" not in update_data
+
     def test_error_pipeline_run_firestore_error(self, mock_firestore_client):
         """Should not raise when Firestore write fails."""
         mock_doc_ref = MagicMock()


### PR DESCRIPTION
## Summary

- Publisher instruction から `{mystery_report}` と `{creative_content}` プレースホルダーを完全除去し、トークンオーバーフローを防止
- `error_pipeline_run()` に `error_detail` パラメータを追加し、ゲート失敗・例外発生時のデバッグ情報を Firestore `pipeline_runs` コレクションに記録
- `_detect_gate_failure()` を `tuple[str, dict]` 返却に拡張し、`error_type` / `failed_stage` / `session_state_summary` を含む詳細情報を返却

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `mystery_agents/agents/publisher.py` | instruction からプレースホルダーを完全除去（5行のシンプルなプロンプトに） |
| `shared/pipeline_run.py` | `error_pipeline_run()` に `error_detail: dict \| None` パラメータ追加 |
| `shared/orchestrator.py` | `_build_state_summary()` 新規追加、`_detect_gate_failure()` を tuple 返却に変更、例外ハンドラに error_detail 付与 |
| `services/pipeline_server.py` | `_run_investigate` の except ブロックに error_detail 追加 |
| `tests/unit/test_pipeline_run.py` | error_detail あり/なしのテスト追加 |
| `tests/unit/test_orchestrator.py` | `_detect_gate_failure` tuple 対応 + `_build_state_summary` テスト + 統合テスト error_detail 検証 |

## Test plan

- [x] `pytest tests/unit/test_pipeline_run.py tests/unit/test_orchestrator.py -v` — 58 passed
- [x] `pytest tests/unit/ -v` — 552 passed（全ユニットテスト回帰確認）
- [ ] デプロイ後、本番パイプライン再実行
- [ ] Firebase Console で `pipeline_runs` の `error_detail` フィールドを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)