### PR TITLE
fix: Illustrator フォールバックリージョンを asia-northeast1 に修正

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@
 # === Google Cloud ===
 # Vertex AI / ADK で使用するプロジェクト ID
 GOOGLE_CLOUD_PROJECT=your_project_id
-# Vertex AI リージョン（例: us-central1）
+# Vertex AI リージョン（例: asia-northeast1）
 GOOGLE_CLOUD_LOCATION=your_region
 # Vertex AI バックエンド使用（TRUE を設定）
 GOOGLE_GENAI_USE_VERTEXAI=TRUE

--- a/mystery_agents/tools/illustrator_tools.py
+++ b/mystery_agents/tools/illustrator_tools.py
@@ -369,7 +369,7 @@ def _get_client() -> genai.Client:
         return genai.Client(
             vertexai=True,
             project=os.environ.get("GOOGLE_CLOUD_PROJECT"),
-            location=os.environ.get("GOOGLE_CLOUD_LOCATION", "us-central1"),
+            location=os.environ.get("GOOGLE_CLOUD_LOCATION", "asia-northeast1"),
         )
     return genai.Client()
 


### PR DESCRIPTION
## Summary

- Illustrator の `_get_client()` で `GOOGLE_CLOUD_LOCATION` 未設定時のフォールバックを `us-central1` → `asia-northeast1` に修正
- `.env.example` のコメント例も `asia-northeast1` に統一

## Background

プロジェクトの他インフラ（Cloud Run, Artifact Registry, Terraform）は全て `asia-northeast1` を使用しているが、Illustrator のフォールバックのみ `us-central1` になっていた。

## Test plan

- [x] `grep -r "us-central1"` で残存箇所がないことを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)