### PR TITLE
fix: pipelines-sa に serviceUsageConsumer ロール追加

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -74,6 +74,12 @@ resource "google_project_iam_member" "pipelines_cloudbuild" {
   member  = "serviceAccount:${google_service_account.pipelines.email}"
 }
 
+resource "google_project_iam_member" "pipelines_service_usage" {
+  project = var.project_id
+  role    = "roles/serviceusage.serviceUsageConsumer"
+  member  = "serviceAccount:${google_service_account.pipelines.email}"
+}
+
 # IAM roles for Cloud Build
 resource "google_project_iam_member" "cloud_build_firebase" {
   project = var.project_id


### PR DESCRIPTION
## Summary

- Podcast パイプラインの TTS 音声生成で `quota_project_id` を指定した際に 403 エラーが発生していた
- `pipelines-sa` に `roles/serviceusage.serviceUsageConsumer` を付与して解消

## 適用手順

1. `terraform plan` で差分確認
2. `terraform apply` で IAM バインディング追加
3. 管理画面から Podcast 生成を再実行して TTS エラーが解消されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)