### PR TITLE
fix: Cloud Build デプロイ失敗の原因調査を可能にする

### DIFF
--- a/web-public/cloudbuild.yaml
+++ b/web-public/cloudbuild.yaml
@@ -53,7 +53,6 @@ substitutions:
   _NEXT_PUBLIC_FIREBASE_APP_ID: ''
 
 options:
-  logging: CLOUD_LOGGING_ONLY
   machineType: E2_HIGHCPU_8
 
 timeout: '1800s'

--- a/web-public/src/app/[lang]/mystery/[id]/page.tsx
+++ b/web-public/src/app/[lang]/mystery/[id]/page.tsx
@@ -20,13 +20,15 @@ import { getDictionary } from "@/lib/i18n/dictionaries"
 // SSG: ビルド時に生成されたページ以外は 404
 export const dynamicParams = false
 
-// output: "export" では generateStaticParams が空配列だとビルドエラーになる
-// revalidate = 0 でこのチェックをバイパス（静的出力では実行時に影響なし）
-export const revalidate = 0
-
 export async function generateStaticParams() {
-  // Firestore 接続エラー時はビルドを失敗させる（空デプロイ防止）
-  const ids = await getPublishedMysteryIds()
+  let ids: string[]
+  try {
+    ids = await getPublishedMysteryIds()
+  } catch (error) {
+    console.error("[SSG] Firestore クエリ失敗:", error)
+    throw new Error(`[SSG] Firestore から記事IDを取得できませんでした: ${error}`)
+  }
+  console.log(`[SSG] 公開済み記事: ${ids.length} 件 (${ids.join(", ")})`)
   return SUPPORTED_LANGS.flatMap((lang) =>
     ids.map((id) => ({ lang, id }))
   )

--- a/web-public/src/app/[lang]/page.tsx
+++ b/web-public/src/app/[lang]/page.tsx
@@ -19,7 +19,11 @@ async function MysteryList({ lang, dict }: { lang: SupportedLang; dict: Dictiona
   try {
     mysteries = await getPublishedMysteries(HOMEPAGE_MYSTERY_LIMIT)
   } catch (error) {
-    console.error("[MysteryList] Failed to fetch mysteries:", error)
+    console.error("[MysteryList] Firestore クエリ失敗:", error)
+    // SSG ビルドエラーの診断用に詳細を出力
+    if (error instanceof Error) {
+      console.error("[MysteryList] Stack:", error.stack)
+    }
   }
 
   if (mysteries.length === 0) {


### PR DESCRIPTION
## Summary

- `cloudbuild.yaml` から `logging: CLOUD_LOGGING_ONLY` を削除し、ビルドログを Cloud Storage 経由で確認可能に
- `generateStaticParams()` に try-catch を追加し、Firestore エラー時にビルドを明確に失敗させる（空デプロイ防止）
- `revalidate = 0` を削除（空配列エラー抑制の回避策だったが、空デプロイのリスクがあった）
- トップページの Firestore エラーログにスタックトレースを追加

## 背景

`./scripts/deploy.sh web-public` による本番デプロイで、Cloud Build ステップ 2（SSG 出力バリデーション）が失敗。`npm run build` は成功するが記事ページが 0 件生成されている。根本原因の調査が以下の2つの問題により阻まれていた：

1. **ログが見えない**: `logging: CLOUD_LOGGING_ONLY` + サービスアカウントに Logs Writer 権限なし → ビルド出力がどこにも記録されない
2. **エラーが静か**: `revalidate = 0` により、`generateStaticParams()` でエラーが発生しても Next.js がルートをスキップしてビルド成功扱い

## Test plan

- [ ] `./scripts/deploy.sh web-public` で Cloud Build を再実行
- [ ] `gcloud builds log <BUILD_ID>` でビルドログが確認可能なことを検証
- [ ] Firestore エラーが発生した場合、ビルドが明確に失敗することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)