### PR TITLE
fix: deploy.sh の Cloud Build に専用サービスアカウントを指定

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -241,6 +241,7 @@ deploy_web_public() {
     gcloud builds submit \
         --config web-public/cloudbuild.yaml \
         --substitutions "$subs" \
+        --service-account "projects/${PROJECT_ID}/serviceAccounts/cloud-build-sa@${PROJECT_ID}.iam.gserviceaccount.com" \
         --project "$PROJECT_ID" \
         "$PROJECT_ROOT"
 

--- a/terraform/cloud-build.tf
+++ b/terraform/cloud-build.tf
@@ -38,10 +38,6 @@ resource "google_cloudbuild_trigger" "web_public" {
       dir  = "web-public"
     }
 
-    options {
-      logging = "CLOUD_LOGGING_ONLY"
-    }
-
     timeout = "600s"
   }
 


### PR DESCRIPTION
## Summary
- `deploy.sh` の `deploy_web_public()` で `gcloud builds submit` に `--service-account` を追加し、Terraform で管理している `cloud-build-sa`（`roles/firebase.admin` 付き）を使用するよう修正
- Terraform の Cloud Build トリガー（`cloud-build.tf`）からインラインビルド定義の `CLOUD_LOGGING_ONLY` オプションを削除し、`cloudbuild.yaml` と設定を同期

## 根本原因
`deploy.sh` が `--service-account` を指定していないため、デフォルトの Compute Engine SA（`403989512601-compute@developer.gserviceaccount.com`）で実行され、Firebase Hosting デプロイステップが権限不足（403）で失敗していた。

## Test plan
- [ ] `./scripts/deploy.sh web-public` を実行し、ビルドが `cloud-build-sa` で実行されることを確認
- [ ] Firebase Hosting デプロイが成功することを確認
- [ ] `terraform plan` で Terraform の差分が options 削除のみであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)