### PR TITLE
fix: Cloud Build ログバケット制約に対応

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -242,6 +242,7 @@ deploy_web_public() {
         --config web-public/cloudbuild.yaml \
         --substitutions "$subs" \
         --service-account "projects/${PROJECT_ID}/serviceAccounts/cloud-build-sa@${PROJECT_ID}.iam.gserviceaccount.com" \
+        --default-buckets-behavior=REGIONAL_USER_OWNED_BUCKET \
         --project "$PROJECT_ID" \
         "$PROJECT_ROOT"
 

--- a/terraform/cloud-build.tf
+++ b/terraform/cloud-build.tf
@@ -38,6 +38,10 @@ resource "google_cloudbuild_trigger" "web_public" {
       dir  = "web-public"
     }
 
+    options {
+      logging = "CLOUD_LOGGING_ONLY"
+    }
+
     timeout = "600s"
   }
 


### PR DESCRIPTION
## Summary
- `deploy.sh` の `gcloud builds submit` に `--default-buckets-behavior=REGIONAL_USER_OWNED_BUCKET` を追加し、`--service-account` 指定時のログバケット制約エラーを解消
- Terraform の Cloud Build トリガーから誤って削除した `CLOUD_LOGGING_ONLY` オプションを復元

## 根本原因
`--service-account` を指定した場合、Cloud Build はデフォルトのログバケットを使用できず、以下のいずれかが必要:
1. `build.logs_bucket` を明示指定
2. `REGIONAL_USER_OWNED_BUCKET` を使用
3. `CLOUD_LOGGING_ONLY` / `NONE` ロギングオプションを使用

PR #147 で `--service-account` を追加したがこの制約に対応していなかったため `INVALID_ARGUMENT` エラーが発生していた。

## Test plan
- [ ] `./scripts/deploy.sh web-public` を実行し Firebase Hosting デプロイが成功することを確認
- [ ] `terraform plan` で差分がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)