### PR TITLE
fix: About ページ 404 修正（revalidate = 0 を削除）

### DIFF
--- a/web-public/src/app/[lang]/about/page.tsx
+++ b/web-public/src/app/[lang]/about/page.tsx
@@ -10,9 +10,6 @@ import { getDictionary } from "@/lib/i18n/dictionaries"
 // SSG: ビルド時に生成されたページ以外は 404
 export const dynamicParams = false
 
-// output: "export" では generateStaticParams が空配列だとビルドエラーになる
-export const revalidate = 0
-
 export async function generateStaticParams() {
   return SUPPORTED_LANGS.map((lang) => ({ lang }))
 }


### PR DESCRIPTION
## Summary

- `web-public/src/app/[lang]/about/page.tsx` から `export const revalidate = 0` を削除
- `output: "export"`（SSG）モードでは `revalidate` がサポートされないため、About ページがビルド時に静的生成されず 404 になっていた
- Home ページ・Mystery ページには `revalidate` がなく正常動作していた

## Test plan

- [ ] マージ後 `scripts/deploy.sh web-public` で再デプロイ
- [ ] `https://ghostinthearchive.ai/ja/about/` → About ページ表示確認
- [ ] `https://ghostinthearchive.ai/en/about/` → 英語版も確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)