### PR TITLE
fix: 記事公開ビルドの不整合修正と、環境変数管理のセキュア化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,8 @@ storage-debug.log
 
 # Terraform
 .terraform/
+*.tfvars
+*.tfvars.json
 
 # Firebase cache
 .firebase/

--- a/terraform/cloud-build.tf
+++ b/terraform/cloud-build.tf
@@ -14,47 +14,21 @@ resource "google_cloudbuild_trigger" "web_public" {
     repo_type = "GITHUB"
   }
 
-  build {
-    step {
-      name       = "node:20"
-      entrypoint = "npm"
-      args       = ["ci"]
-      dir        = "web-public"
-    }
+  filename = "web-public/cloudbuild.yaml"
 
-    step {
-      name       = "node:20"
-      entrypoint = "npm"
-      args       = ["run", "build"]
-      dir        = "web-public"
-      env = [
-        "GOOGLE_CLOUD_PROJECT=${var.project_id}"
-      ]
-    }
-
-    step {
-      name = "us-docker.pkg.dev/firebase-cli/us/firebase"
-      args = ["deploy", "--only", "hosting", "--project", var.project_id]
-      dir  = "web-public"
-    }
-
-    options {
-      logging = "CLOUD_LOGGING_ONLY"
-    }
-
-    timeout = "600s"
+  substitutions = {
+    _NEXT_PUBLIC_GTM_ID                       = var.next_public_gtm_id
+    _NEXT_PUBLIC_FIREBASE_API_KEY             = var.next_public_firebase_api_key
+    _NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN          = var.next_public_firebase_auth_domain
+    _NEXT_PUBLIC_FIREBASE_PROJECT_ID           = var.next_public_firebase_project_id
+    _NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET       = var.next_public_firebase_storage_bucket
+    _NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID = var.next_public_firebase_messaging_sender_id
+    _NEXT_PUBLIC_FIREBASE_APP_ID               = var.next_public_firebase_app_id
   }
 
   service_account = google_service_account.cloud_build.id
 
   depends_on = [google_project_service.apis]
-}
-
-# Variable for GitHub repository
-variable "github_repo" {
-  description = "GitHub repository in format 'owner/repo'"
-  type        = string
-  default     = "yuichi1000/ghostinthearchive"
 }
 
 output "cloud_build_trigger_id" {
@@ -82,6 +56,16 @@ resource "google_cloudbuild_trigger" "web_public_on_push" {
   ]
 
   filename = "web-public/cloudbuild.yaml"
+
+  substitutions = {
+    _NEXT_PUBLIC_GTM_ID                       = var.next_public_gtm_id
+    _NEXT_PUBLIC_FIREBASE_API_KEY             = var.next_public_firebase_api_key
+    _NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN          = var.next_public_firebase_auth_domain
+    _NEXT_PUBLIC_FIREBASE_PROJECT_ID           = var.next_public_firebase_project_id
+    _NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET       = var.next_public_firebase_storage_bucket
+    _NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID = var.next_public_firebase_messaging_sender_id
+    _NEXT_PUBLIC_FIREBASE_APP_ID               = var.next_public_firebase_app_id
+  }
 
   service_account = google_service_account.cloud_build.id
 

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,17 @@
+# terraform/terraform.tfvars.example
+# このファイルを terraform.tfvars にコピーして、実際の値を入力してください。
+
+project_id      = "your-project-id"
+domain          = "example.com"
+github_repo     = "owner/repo"
+
+# Firebase Hosting 用の環境変数 (Firebase Console > プロジェクト設定 から取得)
+next_public_firebase_api_key             = ""
+next_public_firebase_auth_domain          = ""
+next_public_firebase_project_id           = ""
+next_public_firebase_storage_bucket       = ""
+next_public_firebase_messaging_sender_id = ""
+next_public_firebase_app_id               = ""
+
+# オプション: Google Tag Manager ID
+# next_public_gtm_id                     = "GTM-XXXXXXX"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -3,7 +3,6 @@
 variable "project_id" {
   description = "Google Cloud Project ID"
   type        = string
-  default     = "ghostinthearchive"
 }
 
 variable "region" {
@@ -15,11 +14,52 @@ variable "region" {
 variable "domain" {
   description = "Primary domain name"
   type        = string
-  default     = "ghostinthearchive.ai"
 }
 
 variable "admin_subdomain" {
   description = "Admin subdomain"
   type        = string
   default     = "admin"
+}
+
+variable "github_repo" {
+  description = "GitHub repository in format 'owner/repo'"
+  type        = string
+}
+
+# Web Public Environment Variables (passed to Cloud Build as substitutions)
+variable "next_public_gtm_id" {
+  description = "Google Tag Manager ID"
+  type        = string
+  default     = ""
+}
+
+variable "next_public_firebase_api_key" {
+  description = "Firebase API Key"
+  type        = string
+}
+
+variable "next_public_firebase_auth_domain" {
+  description = "Firebase Auth Domain"
+  type        = string
+}
+
+variable "next_public_firebase_project_id" {
+  description = "Firebase Project ID"
+  type        = string
+}
+
+variable "next_public_firebase_storage_bucket" {
+  description = "Firebase Storage Bucket"
+  type        = string
+}
+
+variable "next_public_firebase_messaging_sender_id" {
+  description = "Firebase Messaging Sender ID"
+  type        = string
+}
+
+variable "next_public_firebase_app_id" {
+  description = "Firebase App ID"
+  type        = string
 }


### PR DESCRIPTION
## 変更内容
管理画面から記事を「承認（Approve）」した際に、公開サイトの更新（SSGビルド）が正常に動作しない問題を修正し、あわせてインフラ設定の保守性とセキュリティを向上させました。

### 1. Cloud Build トリガー構成の一本化
- Terraform 内に記述されていた重複したビルド手順（インライン定義）を廃止しました。
-  を参照するように変更し、npm workspaces（）の解決エラーを解消しました。

### 2. 環境変数とシークレットの管理改善
-  からデフォルト値を削除し、 から注入する方式に変更しました。
- Firebase の API キー等を Cloud Build の置換変数（substitutions）として渡すようにしました。
-  の追加と  の更新を行いました。

### 3. リビルド機構の堅牢化
- 管理画面（web-admin）が、トリガーの「ID（UUID）」だけでなく「名前（web-public-deploy）」でも動作するようロジックを改善しました。
- Terraform 側でも ID ではなく名前を渡すように変更し、リソース再作成時の影響を排除しました。

## 確認事項
- [ ]  を作成し、必要な Firebase のキーを設定すること
- [ ]  を実行し、設定を反映すること