### PR TITLE
fix: Cloud Build のログ制約と権限エラーの修正

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -43,6 +43,13 @@ resource "google_project_iam_member" "web_admin_cloudbuild" {
   member  = "serviceAccount:${google_service_account.web_admin.email}"
 }
 
+# Allow web-admin to impersonate cloud-build-sa when triggering builds
+resource "google_service_account_iam_member" "web_admin_impersonate_cloud_build" {
+  service_account_id = google_service_account.cloud_build.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.web_admin.email}"
+}
+
 # IAM roles for pipelines
 resource "google_project_iam_member" "pipelines_firestore" {
   project = var.project_id

--- a/web-public/cloudbuild.yaml
+++ b/web-public/cloudbuild.yaml
@@ -54,5 +54,6 @@ substitutions:
 
 options:
   machineType: E2_HIGHCPU_8
+  logging: CLOUD_LOGGING_ONLY
 
 timeout: '1800s'


### PR DESCRIPTION
## 概要
管理画面からのリビルド発火時に発生していた以下の2つのエラーを修正しました。

1. **403 Permission Denied**:  のサービスアカウントが  を使ってビルドを実行するための権限（Service Account User）が不足していたため追加。
2. **Invalid Argument (Logging)**: カスタムサービスアカウント使用時の Cloud Build ログ制約に対応するため、 オプションを追加。

## 変更点
- **terraform/iam.tf**:  ロールを  サービスアカウントに付与。
- **web-public/cloudbuild.yaml**:  に  を追加。