### PR TITLE
fix: Evidence Block の corner-fold（黒い三角形）を削除

### DIFF
--- a/packages/shared/src/components/evidence-block.tsx
+++ b/packages/shared/src/components/evidence-block.tsx
@@ -41,9 +41,6 @@ export function EvidenceBlock({ evidence, label, translatedExcerpt, labels, clas
         {/* Top edge wear effect */}
         <div className="absolute top-0 left-0 right-0 h-1 bg-gradient-to-b from-parchment/10 to-transparent" />
 
-        {/* Corner fold effect */}
-        <div className="absolute top-0 right-0 w-6 h-6 corner-fold" />
-
         {/* Date badge + Quote marks row */}
         <div className="flex items-start justify-between mb-1">
           {(hasExcerpt || hasTranslatedExcerpt) && (

--- a/web-public/src/app/globals.css
+++ b/web-public/src/app/globals.css
@@ -163,11 +163,6 @@
   border-radius: 1px;
 }
 
-/* Corner fold effect for evidence blocks */
-.corner-fold {
-  background: linear-gradient(135deg, transparent 50%, #1A1A1A 50%);
-}
-
 /* Typography */
 .font-jp {
   font-family: var(--font-jp);


### PR DESCRIPTION
## Summary

- Evidence Block（引用カード）右上角の黒い三角形（corner-fold）を削除
- 「古い紙の折れた角」を表現する意図的デザインだったが、視覚的にバグに見えるため撤去

## Changes

- `packages/shared/src/components/evidence-block.tsx`: corner-fold の `<div>` 要素とコメントを削除
- `web-public/src/app/globals.css`: `.corner-fold` CSS 定義を削除

## Test plan

- [ ] `corner-fold` の grep で残存参照がないこと（確認済み）
- [ ] web-public ビルドでエラーがないこと

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)