### PR TITLE
feat: 構造化 JSON ログ基盤導入 + パイプライン実行ログ強化（Phase 1+2）

### DIFF
--- a/mystery_agents/agents/pipeline_gate.py
+++ b/mystery_agents/agents/pipeline_gate.py
@@ -42,7 +42,10 @@ def _is_meaningful(value: str) -> bool:
 
 def _log_and_record_failure(callback_context: CallbackContext, stage: str, message: str) -> None:
     """パイプライン失敗をログに記録し、Firestore にも書き込む。"""
-    logger.warning("Pipeline gate [%s]: %s", stage, message)
+    logger.warning(
+        "Pipeline gate [%s]: %s", stage, message,
+        extra={"gate_name": stage, "decision": "skip", "reason": message},
+    )
     try:
         from shared.pipeline_failure import log_pipeline_failure
 
@@ -70,6 +73,10 @@ def make_scholar_gate():
         for lang in selected:
             docs = callback_context.state.get(f"collected_documents_{lang}", "")
             if _is_meaningful(docs):
+                logger.info(
+                    "Pipeline gate [scholar]: 通過（%s に有意なデータあり）", lang,
+                    extra={"gate_name": "scholar", "decision": "pass"},
+                )
                 return None  # 有意なデータあり → 実行
 
         message = (
@@ -96,6 +103,10 @@ def make_polymath_gate():
         for lang in selected:
             analysis = callback_context.state.get(f"scholar_analysis_{lang}", "")
             if _is_meaningful(analysis):
+                logger.info(
+                    "Pipeline gate [polymath]: 通過（%s に有意な分析あり）", lang,
+                    extra={"gate_name": "polymath", "decision": "pass"},
+                )
                 return None
 
         message = (
@@ -117,6 +128,10 @@ def make_storyteller_gate():
     def gate(callback_context: CallbackContext) -> Optional[types.Content]:
         report = callback_context.state.get("mystery_report", "")
         if _is_meaningful(report):
+            logger.info(
+                "Pipeline gate [storyteller]: 通過",
+                extra={"gate_name": "storyteller", "decision": "pass"},
+            )
             return None
 
         message = "NO_CONTENT: No mystery report available. Pipeline terminated."
@@ -135,6 +150,10 @@ def make_post_story_gate():
     def gate(callback_context: CallbackContext) -> Optional[types.Content]:
         content = callback_context.state.get("creative_content", "")
         if _is_meaningful(content):
+            logger.info(
+                "Pipeline gate [post_story]: 通過",
+                extra={"gate_name": "post_story", "decision": "pass"},
+            )
             return None
 
         message = "NO_CONTENT: No story content available. Skipped."

--- a/mystery_agents/cli.py
+++ b/mystery_agents/cli.py
@@ -15,13 +15,11 @@ from dotenv import load_dotenv
 load_dotenv(Path(__file__).parent.parent / ".env")
 
 from .agent import ghost_commander, SKIP_AUTHORS
+from shared.logging_config import setup_logging
 from shared.orchestrator import run_pipeline
 
-# プロジェクト全体のログを有効化（Publisher, Illustrator 等の既存ログが出力される）
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(name)s [%(levelname)s] %(message)s",
-)
+# プロジェクト全体のログを有効化（Cloud Run: JSON / ローカル: プレーンテキスト）
+setup_logging()
 
 PIPELINE_TIMEOUT_SECONDS = 1800  # 30 minutes
 

--- a/mystery_agents/tools/debate_tools.py
+++ b/mystery_agents/tools/debate_tools.py
@@ -114,6 +114,7 @@ def check_debate_convergence(tool_context: ToolContext) -> str:
     new_words = curr_words - prev_words
     new_word_ratio = len(new_words) / len(curr_words)
 
+    converged = new_word_ratio < _CONVERGENCE_THRESHOLD
     logger.info(
         "Convergence check: round %d→%d, prev_words=%d, curr_words=%d, "
         "new_words=%d, ratio=%.1f%%",
@@ -123,9 +124,14 @@ def check_debate_convergence(tool_context: ToolContext) -> str:
         len(curr_words),
         len(new_words),
         new_word_ratio * 100,
+        extra={
+            "convergence_round": sorted_round_nums[-1],
+            "convergence_score": round(new_word_ratio, 3),
+            "converged": converged,
+        },
     )
 
-    if new_word_ratio < _CONVERGENCE_THRESHOLD:
+    if converged:
         tool_context.actions.escalate = True
         return (
             f"Debate has CONVERGED. New word ratio: {new_word_ratio:.1%} "

--- a/services/curator.py
+++ b/services/curator.py
@@ -30,7 +30,11 @@ from curator_agents.queries import (
 )
 from curator_agents.schemas import strip_markdown_codeblock, validate_suggestions
 from mystery_agents.agents.translator import translator_agent
+from shared.logging_config import PipelineContext, set_pipeline_context, setup_logging
 from shared.pipeline_failure import get_recent_failures
+
+# プロジェクト全体のログを有効化（Cloud Run: JSON / ローカル: プレーンテキスト）
+setup_logging()
 
 logger = logging.getLogger(__name__)
 
@@ -205,6 +209,7 @@ async def health():
 
 @app.post("/suggest-theme")
 async def suggest_theme():
+    set_pipeline_context(PipelineContext(pipeline_type="curator"))
     try:
         # Step 1: Generate English suggestions
         suggestions = await run_curator()

--- a/services/pipeline_server.py
+++ b/services/pipeline_server.py
@@ -29,13 +29,11 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 import uvicorn
 
+from shared.logging_config import setup_logging
 from shared.pipeline_run import create_pipeline_run, error_pipeline_run
 
-# プロジェクト全体のログを有効化（Publisher, Illustrator 等の既存ログが出力される）
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(name)s [%(levelname)s] %(message)s",
-)
+# プロジェクト全体のログを有効化（Cloud Run: JSON / ローカル: プレーンテキスト）
+setup_logging()
 
 logger = logging.getLogger(__name__)
 

--- a/shared/logging_config.py
+++ b/shared/logging_config.py
@@ -1,0 +1,175 @@
+"""構造化ログ設定 — Cloud Run JSON ログ + ローカル プレーンテキスト自動切替。
+
+Cloud Run では stdout に JSON を出力すると Cloud Logging が自動パースする。
+ローカルでは従来の "%(asctime)s %(name)s [%(levelname)s] %(message)s" を維持する。
+
+コンテキスト伝搬:
+    contextvars を使い、run_id / pipeline_type / mystery_id を
+    全 LogRecord に自動付与する（logging.Filter 経由）。
+    asyncio.create_task() でコンテキストが自動コピーされるため、
+    既存の logger.info() 呼び出しを変更する必要がない。
+"""
+
+import json
+import logging
+import os
+import sys
+from contextvars import ContextVar
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+
+@dataclass
+class PipelineContext:
+    """パイプライン実行コンテキスト。"""
+
+    run_id: str = ""
+    pipeline_type: str = ""  # "blog", "podcast", "curator"
+    mystery_id: str = ""
+
+
+_pipeline_context: ContextVar[PipelineContext] = ContextVar(
+    "pipeline_context", default=PipelineContext()
+)
+
+
+def set_pipeline_context(ctx: PipelineContext) -> None:
+    """現在の asyncio タスクにパイプラインコンテキストを設定する。"""
+    _pipeline_context.set(ctx)
+
+
+def get_pipeline_context() -> PipelineContext:
+    """現在のパイプラインコンテキストを取得する。"""
+    return _pipeline_context.get()
+
+
+# logging.LogRecord の標準属性（CloudJsonFormatter で除外対象）
+_STANDARD_LOG_ATTRS = frozenset({
+    "name", "msg", "args", "created", "relativeCreated", "exc_info",
+    "exc_text", "stack_info", "lineno", "funcName", "levelno", "levelname",
+    "pathname", "filename", "module", "thread", "threadName", "process",
+    "processName", "msecs", "message", "taskName",
+    # StructuredLogFilter が付与するフィールド（JSON では別途処理）
+    "run_id", "pipeline_type", "mystery_id",
+})
+
+
+class StructuredLogFilter(logging.Filter):
+    """全 LogRecord にパイプラインコンテキストを自動付与する Filter。"""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        ctx = _pipeline_context.get()
+        record.run_id = ctx.run_id
+        record.pipeline_type = ctx.pipeline_type
+        record.mystery_id = ctx.mystery_id
+        return True
+
+
+class CloudJsonFormatter(logging.Formatter):
+    """Cloud Logging 互換 JSON フォーマッタ。
+
+    severity キーで Cloud Logging の重大度が自動認識される。
+    record.__dict__ から標準属性以外を自動抽出して JSON に含める
+    （extra={} で渡した任意フィールドを構造化出力）。
+    """
+
+    # Python → Cloud Logging severity マッピング
+    _SEVERITY_MAP: dict[str, str] = {
+        "DEBUG": "DEBUG",
+        "INFO": "INFO",
+        "WARNING": "WARNING",
+        "ERROR": "ERROR",
+        "CRITICAL": "CRITICAL",
+    }
+
+    def format(self, record: logging.LogRecord) -> str:
+        # メッセージ組み立て（% フォーマット適用）
+        record.message = record.getMessage()
+
+        payload: dict[str, Any] = {
+            "severity": self._SEVERITY_MAP.get(record.levelname, "DEFAULT"),
+            "message": record.message,
+            "logger": record.name,
+            "timestamp": self.formatTime(record, self.datefmt),
+        }
+
+        # コンテキストフィールド（空文字は除外）
+        for key in ("run_id", "pipeline_type", "mystery_id"):
+            value = getattr(record, key, "")
+            if value:
+                payload[key] = value
+
+        # extra フィールド自動展開
+        for key, value in record.__dict__.items():
+            if key not in _STANDARD_LOG_ATTRS and key not in payload:
+                payload[key] = value
+
+        # 例外情報
+        if record.exc_info and not record.exc_text:
+            record.exc_text = self.formatException(record.exc_info)
+        if record.exc_text:
+            payload["exception"] = record.exc_text
+
+        return json.dumps(payload, ensure_ascii=False, default=str)
+
+
+class PlainTextFormatter(logging.Formatter):
+    """ローカル用プレーンテキストフォーマッタ（既存互換）。
+
+    コンテキストフィールド（run_id 等）がある場合は末尾に付与する。
+    """
+
+    def __init__(self) -> None:
+        super().__init__("%(asctime)s %(name)s [%(levelname)s] %(message)s")
+
+    def format(self, record: logging.LogRecord) -> str:
+        base = super().format(record)
+
+        # コンテキスト情報を末尾に付与
+        ctx_parts = []
+        for key in ("run_id", "pipeline_type", "mystery_id"):
+            value = getattr(record, key, "")
+            if value:
+                ctx_parts.append(f"{key}={value}")
+        if ctx_parts:
+            return f"{base} [{', '.join(ctx_parts)}]"
+        return base
+
+
+def _is_cloud_run() -> bool:
+    """Cloud Run 環境かどうかを判定する。"""
+    return bool(os.environ.get("K_SERVICE"))
+
+
+def setup_logging(*, force: bool = False) -> None:
+    """root logger を初期化する。
+
+    Cloud Run（K_SERVICE 環境変数あり）では JSON フォーマッタ、
+    ローカルではプレーンテキストフォーマッタを使用する。
+
+    Args:
+        force: True の場合、既存ハンドラを削除して再初期化する。
+    """
+    root = logging.getLogger()
+
+    # 既に初期化済みの場合はスキップ（force=True でない限り）
+    if root.handlers and not force:
+        return
+
+    # 既存ハンドラを削除
+    for handler in root.handlers[:]:
+        root.removeHandler(handler)
+
+    # ハンドラ設定
+    handler = logging.StreamHandler(sys.stdout)
+
+    if _is_cloud_run():
+        handler.setFormatter(CloudJsonFormatter())
+    else:
+        handler.setFormatter(PlainTextFormatter())
+
+    # 全 LogRecord にコンテキストを付与する Filter
+    handler.addFilter(StructuredLogFilter())
+
+    root.addHandler(handler)
+    root.setLevel(logging.INFO)

--- a/shared/orchestrator.py
+++ b/shared/orchestrator.py
@@ -12,6 +12,7 @@ CLI と Cloud Run Service の両方から呼ばれるビジネスロジック層
 import asyncio
 import json
 import logging
+import time
 from dataclasses import dataclass, field
 from typing import Callable
 
@@ -22,6 +23,7 @@ from google.genai import types
 
 from mystery_agents.agents.pipeline_gate import _is_meaningful
 from mystery_agents.utils.pipeline_logger import PipelineLogger
+from shared.logging_config import PipelineContext, set_pipeline_context
 from shared.pipeline_run import (
     create_pipeline_run,
     update_agent_started,
@@ -147,6 +149,14 @@ def _complete_agent(
             pipeline_logger.remove_last_log(agent_name)
             return
 
+    # 完了ログ出力
+    if completed_log:
+        duration = completed_log.get("duration_seconds") or 0
+        logger.info(
+            "エージェント完了: %s (%.1fs)", agent_name, duration,
+            extra={"agent_name": agent_name, "status": "completed", "duration_seconds": duration},
+        )
+
     # Firestore に完了を通知
     completed_logs = pipeline_logger.get_logs()
     if completed_logs:
@@ -208,6 +218,12 @@ async def run_pipeline(
     if run_id is None:
         create_kwargs = {"query": user_message} if run_type == "blog" else {}
         run_id = create_pipeline_run(run_type, **create_kwargs)
+
+    # 構造化ログコンテキスト設定
+    set_pipeline_context(PipelineContext(run_id=run_id, pipeline_type=run_type))
+
+    pipeline_start_time = time.monotonic()
+    logger.info("パイプライン開始: %s", run_type, extra={"status": "started"})
 
     # Runner + Session セットアップ
     session_service = InMemorySessionService()
@@ -284,6 +300,10 @@ async def run_pipeline(
                 if author not in agent_texts:
                     agent_texts[author] = []
                     pipeline_logger.start_agent(author)
+                    logger.info(
+                        "エージェント開始: %s", author,
+                        extra={"agent_name": author, "status": "started"},
+                    )
                     agent_log_indices[author] = update_agent_started(
                         run_id, author, pipeline_logger.get_logs()[-1]
                     )
@@ -338,11 +358,31 @@ async def run_pipeline(
                 elif isinstance(published, dict):
                     mystery_id = published.get("mystery_id")
 
+        # mystery_id をコンテキストに追加
+        if mystery_id:
+            set_pipeline_context(PipelineContext(
+                run_id=run_id, pipeline_type=run_type, mystery_id=mystery_id,
+            ))
+
         # blog パイプラインで記事未生成の場合、ゲート失敗を検出してエラーマーク
         if run_type == "blog" and mystery_id is None:
             failure_reason, detail = _detect_gate_failure(session_state)
             error_pipeline_run(run_id, failure_reason, error_detail=detail)
         else:
+            # パイプライン正常完了サマリ
+            completed_logs = pipeline_logger.get_logs()
+            total_agents = len(completed_logs)
+            total_duration = round(time.monotonic() - pipeline_start_time, 1)
+            logger.info(
+                "パイプライン完了: %s (エージェント数=%d, 合計%.1fs)",
+                run_type, total_agents, total_duration,
+                extra={
+                    "status": "completed",
+                    "agent_count": total_agents,
+                    "total_duration_seconds": total_duration,
+                    "mystery_id": mystery_id or "",
+                },
+            )
             complete_pipeline_run(run_id, mystery_id=mystery_id)
 
         return PipelineResult(
@@ -360,7 +400,10 @@ async def run_pipeline(
         raise
     except Exception as e:
         error_message = _format_exception_group(e)
-        logger.error("Pipeline failed: %s", error_message, exc_info=True)
+        logger.error(
+            "Pipeline failed: %s", error_message, exc_info=True,
+            extra={"status": "error", "exception_class": type(e).__name__},
+        )
         error_pipeline_run(run_id, error_message, error_detail={
             "error_type": "exception",
             "exception_class": type(e).__name__,

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -1,0 +1,314 @@
+"""Unit tests for shared/logging_config.py"""
+
+import asyncio
+import json
+import logging
+import os
+from unittest.mock import patch
+
+import pytest
+
+from shared.logging_config import (
+    CloudJsonFormatter,
+    PipelineContext,
+    PlainTextFormatter,
+    StructuredLogFilter,
+    get_pipeline_context,
+    set_pipeline_context,
+    setup_logging,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_context():
+    """テストごとにコンテキストをリセットする。"""
+    set_pipeline_context(PipelineContext())
+    yield
+    set_pipeline_context(PipelineContext())
+
+
+@pytest.fixture(autouse=True)
+def _reset_root_logger():
+    """テストごとに root logger をリセットする。"""
+    root = logging.getLogger()
+    original_handlers = root.handlers[:]
+    original_level = root.level
+    yield
+    root.handlers = original_handlers
+    root.level = original_level
+
+
+class TestPipelineContext:
+    """PipelineContext と contextvars の基本テスト"""
+
+    def test_default_context_is_empty(self):
+        ctx = get_pipeline_context()
+        assert ctx.run_id == ""
+        assert ctx.pipeline_type == ""
+        assert ctx.mystery_id == ""
+
+    def test_set_and_get_context(self):
+        set_pipeline_context(
+            PipelineContext(run_id="run-123", pipeline_type="blog", mystery_id="OCC-MA-617-20260220")
+        )
+        ctx = get_pipeline_context()
+        assert ctx.run_id == "run-123"
+        assert ctx.pipeline_type == "blog"
+        assert ctx.mystery_id == "OCC-MA-617-20260220"
+
+    def test_partial_context(self):
+        set_pipeline_context(PipelineContext(pipeline_type="curator"))
+        ctx = get_pipeline_context()
+        assert ctx.run_id == ""
+        assert ctx.pipeline_type == "curator"
+
+
+class TestContextVarsAsyncIsolation:
+    """contextvars のタスク間スコープ分離テスト"""
+
+    @pytest.mark.asyncio
+    async def test_context_copied_to_child_task(self):
+        """asyncio.create_task() でコンテキストが子タスクにコピーされる。"""
+        set_pipeline_context(PipelineContext(run_id="parent-run"))
+
+        child_run_id = None
+
+        async def child():
+            nonlocal child_run_id
+            child_run_id = get_pipeline_context().run_id
+
+        await asyncio.create_task(child())
+        assert child_run_id == "parent-run"
+
+    @pytest.mark.asyncio
+    async def test_child_task_mutation_does_not_affect_parent(self):
+        """子タスクでのコンテキスト変更が親に影響しない。"""
+        set_pipeline_context(PipelineContext(run_id="parent-run"))
+
+        async def child():
+            set_pipeline_context(PipelineContext(run_id="child-run"))
+
+        await asyncio.create_task(child())
+        assert get_pipeline_context().run_id == "parent-run"
+
+
+class TestStructuredLogFilter:
+    """StructuredLogFilter のテスト"""
+
+    def test_injects_context_fields(self):
+        set_pipeline_context(
+            PipelineContext(run_id="run-456", pipeline_type="podcast")
+        )
+        record = logging.LogRecord(
+            name="test", level=logging.INFO, pathname="", lineno=0,
+            msg="hello", args=(), exc_info=None,
+        )
+        f = StructuredLogFilter()
+        assert f.filter(record) is True
+        assert record.run_id == "run-456"
+        assert record.pipeline_type == "podcast"
+        assert record.mystery_id == ""
+
+    def test_empty_context_still_sets_attributes(self):
+        record = logging.LogRecord(
+            name="test", level=logging.INFO, pathname="", lineno=0,
+            msg="hello", args=(), exc_info=None,
+        )
+        f = StructuredLogFilter()
+        f.filter(record)
+        assert record.run_id == ""
+        assert record.pipeline_type == ""
+        assert record.mystery_id == ""
+
+
+class TestCloudJsonFormatter:
+    """CloudJsonFormatter の JSON 出力テスト"""
+
+    def _make_record(self, msg="test message", level=logging.INFO, **extra):
+        record = logging.LogRecord(
+            name="shared.orchestrator", level=level, pathname="", lineno=0,
+            msg=msg, args=(), exc_info=None,
+        )
+        # extra フィールドをシミュレート
+        for k, v in extra.items():
+            setattr(record, k, v)
+        # StructuredLogFilter の効果をシミュレート
+        if not hasattr(record, "run_id"):
+            record.run_id = ""
+        if not hasattr(record, "pipeline_type"):
+            record.pipeline_type = ""
+        if not hasattr(record, "mystery_id"):
+            record.mystery_id = ""
+        return record
+
+    def test_basic_json_output(self):
+        formatter = CloudJsonFormatter()
+        record = self._make_record()
+        output = formatter.format(record)
+        data = json.loads(output)
+        assert data["severity"] == "INFO"
+        assert data["message"] == "test message"
+        assert data["logger"] == "shared.orchestrator"
+        assert "timestamp" in data
+
+    def test_severity_mapping(self):
+        formatter = CloudJsonFormatter()
+        for level, expected in [
+            (logging.DEBUG, "DEBUG"),
+            (logging.INFO, "INFO"),
+            (logging.WARNING, "WARNING"),
+            (logging.ERROR, "ERROR"),
+            (logging.CRITICAL, "CRITICAL"),
+        ]:
+            record = self._make_record(level=level)
+            data = json.loads(formatter.format(record))
+            assert data["severity"] == expected
+
+    def test_context_fields_included_when_set(self):
+        formatter = CloudJsonFormatter()
+        record = self._make_record(
+            run_id="run-789",
+            pipeline_type="blog",
+            mystery_id="HIS-NY-212-20260220",
+        )
+        data = json.loads(formatter.format(record))
+        assert data["run_id"] == "run-789"
+        assert data["pipeline_type"] == "blog"
+        assert data["mystery_id"] == "HIS-NY-212-20260220"
+
+    def test_empty_context_fields_excluded(self):
+        formatter = CloudJsonFormatter()
+        record = self._make_record()
+        data = json.loads(formatter.format(record))
+        assert "run_id" not in data
+        assert "pipeline_type" not in data
+        assert "mystery_id" not in data
+
+    def test_extra_fields_included(self):
+        formatter = CloudJsonFormatter()
+        record = self._make_record(
+            agent_name="Scholar",
+            duration_seconds=12.5,
+            status="completed",
+        )
+        data = json.loads(formatter.format(record))
+        assert data["agent_name"] == "Scholar"
+        assert data["duration_seconds"] == 12.5
+        assert data["status"] == "completed"
+
+    def test_exception_included(self):
+        formatter = CloudJsonFormatter()
+        try:
+            raise ValueError("test error")
+        except ValueError:
+            import sys
+            record = self._make_record()
+            record.exc_info = sys.exc_info()
+        data = json.loads(formatter.format(record))
+        assert "exception" in data
+        assert "ValueError: test error" in data["exception"]
+
+    def test_percent_formatting_applied(self):
+        """% フォーマットが正しく適用される。"""
+        record = logging.LogRecord(
+            name="test", level=logging.INFO, pathname="", lineno=0,
+            msg="Agent %s completed in %.1fs", args=("Scholar", 12.5),
+            exc_info=None,
+        )
+        record.run_id = ""
+        record.pipeline_type = ""
+        record.mystery_id = ""
+        formatter = CloudJsonFormatter()
+        data = json.loads(formatter.format(record))
+        assert data["message"] == "Agent Scholar completed in 12.5s"
+
+
+class TestPlainTextFormatter:
+    """PlainTextFormatter のテスト"""
+
+    def test_basic_format(self):
+        formatter = PlainTextFormatter()
+        record = logging.LogRecord(
+            name="test.module", level=logging.INFO, pathname="", lineno=0,
+            msg="hello world", args=(), exc_info=None,
+        )
+        record.run_id = ""
+        record.pipeline_type = ""
+        record.mystery_id = ""
+        output = formatter.format(record)
+        assert "test.module" in output
+        assert "[INFO]" in output
+        assert "hello world" in output
+        # コンテキストなしなら [] 部分は付かない
+        assert output.endswith("hello world")
+
+    def test_context_appended(self):
+        formatter = PlainTextFormatter()
+        record = logging.LogRecord(
+            name="test", level=logging.INFO, pathname="", lineno=0,
+            msg="hello", args=(), exc_info=None,
+        )
+        record.run_id = "run-123"
+        record.pipeline_type = "blog"
+        record.mystery_id = ""
+        output = formatter.format(record)
+        assert "[run_id=run-123, pipeline_type=blog]" in output
+
+
+class TestSetupLogging:
+    """setup_logging() のテスト"""
+
+    def test_local_uses_plain_text(self):
+        with patch.dict(os.environ, {}, clear=True):
+            # K_SERVICE がない → ローカル
+            os.environ.pop("K_SERVICE", None)
+            setup_logging(force=True)
+
+        root = logging.getLogger()
+        assert len(root.handlers) == 1
+        assert isinstance(root.handlers[0].formatter, PlainTextFormatter)
+
+    def test_cloud_run_uses_json(self):
+        with patch.dict(os.environ, {"K_SERVICE": "pipeline-service"}):
+            setup_logging(force=True)
+
+        root = logging.getLogger()
+        assert len(root.handlers) == 1
+        assert isinstance(root.handlers[0].formatter, CloudJsonFormatter)
+
+    def test_filter_attached(self):
+        setup_logging(force=True)
+        root = logging.getLogger()
+        filters = root.handlers[0].filters
+        assert any(isinstance(f, StructuredLogFilter) for f in filters)
+
+    def test_idempotent_without_force(self):
+        setup_logging(force=True)
+        root = logging.getLogger()
+        handler_count = len(root.handlers)
+        setup_logging()  # force=False → 追加しない
+        assert len(root.handlers) == handler_count
+
+    def test_force_replaces_handlers(self):
+        setup_logging(force=True)
+        setup_logging(force=True)
+        root = logging.getLogger()
+        assert len(root.handlers) == 1
+
+    def test_integration_json_output(self):
+        """setup_logging → logger.info → JSON 出力の統合テスト。"""
+        with patch.dict(os.environ, {"K_SERVICE": "test-service"}):
+            setup_logging(force=True)
+
+        set_pipeline_context(PipelineContext(run_id="int-test", pipeline_type="blog"))
+
+        test_logger = logging.getLogger("integration_test")
+        # ハンドラの出力をキャプチャ
+        handler = logging.getLogger().handlers[0]
+        record = test_logger.makeRecord(
+            "integration_test", logging.INFO, "", 0,
+            "Agent started", (), None,
+        )
+        record.agent_name = "Scholar"  # extra フィールド
+        handler.handle(record)
+        # テストは例外なく完了すれば OK（出力は stdout に書かれる）


### PR DESCRIPTION
## Summary

Cloud Run 上のパイプラインログを Cloud Logging で `run_id` / `mystery_id` / `severity` でフィルタリング可能にするため、構造化 JSON ログ基盤を導入する。

- `shared/logging_config.py` 新設: `CloudJsonFormatter`（JSON）/ `PlainTextFormatter`（ローカル）を `K_SERVICE` 環境変数で自動切替
- `contextvars` + `logging.Filter` で `run_id` / `pipeline_type` / `mystery_id` を全 LogRecord に自動付与
- `orchestrator.py`: エージェント開始/完了/パイプラインサマリの構造化ログ追加
- `pipeline_gate.py`: ゲート通過/失敗に `extra` フィールド追加
- `debate_tools.py`: 収束判定に `extra` フィールド追加
- 3つのエントリポイント（`pipeline_server.py` / `curator.py` / `cli.py`）を `setup_logging()` に移行

## Cloud Logging フィルタ例

```
jsonPayload.run_id="xxx"
jsonPayload.mystery_id="OCC-MA-617-xxx"
severity>=ERROR AND jsonPayload.pipeline_type="blog"
jsonPayload.agent_name="Storyteller" AND jsonPayload.status="completed"
```

## Test plan

- [x] `test_logging_config.py`: 22 件の新規テスト（全 PASS）
- [x] 既存ユニットテスト 574 件が全 PASS（リグレッションなし）
- [ ] ローカル実行でプレーンテキスト出力を確認
- [ ] `K_SERVICE=test` で JSON 出力を確認
- [ ] Cloud Run デプロイ後に Cloud Logging コンソールで検証

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)