### PR TITLE
feat: 外部 API 構造化ログ + ヘルスチェックログ抑制（Phase 3+4）

### DIFF
--- a/mystery_agents/tools/dpla.py
+++ b/mystery_agents/tools/dpla.py
@@ -5,6 +5,7 @@ and museums across the United States.
 """
 
 import json
+import logging
 import os
 import time
 from typing import Any, Dict, List, Optional
@@ -12,6 +13,8 @@ from typing import Any, Dict, List, Optional
 import requests
 
 from shared.http_retry import create_retry_session
+
+logger = logging.getLogger(__name__)
 
 from ..schemas.document import ArchiveDocument, SourceLanguage, SourceType
 from .search_utils import build_search_query
@@ -85,6 +88,7 @@ def search_dpla(
         params["sourceResource.language.name"] = _DPLA_LANG_NAMES[language][0]
 
     _rate_limit()
+    start = time.monotonic()
 
     try:
         response = _session.get(
@@ -150,9 +154,22 @@ def search_dpla(
             documents.append(doc)
 
         total_hits = data.get("count", 0)
+
+        latency_ms = round((time.monotonic() - start) * 1000)
+        logger.info(
+            "DPLA 検索完了: %d 件 (%dms)", len(documents), latency_ms,
+            extra={"api_name": "dpla", "result_count": len(documents),
+                   "total_hits": total_hits, "latency_ms": latency_ms},
+        )
+
         return {"documents": documents, "total_hits": total_hits, "error": None}
 
     except (requests.RequestException, json.JSONDecodeError) as e:
+        latency_ms = round((time.monotonic() - start) * 1000)
+        logger.warning(
+            "DPLA API エラー: %s (%dms)", e, latency_ms,
+            extra={"api_name": "dpla", "latency_ms": latency_ms, "error": str(e)},
+        )
         return {"documents": [], "total_hits": 0, "error": f"DPLA API error: {e}"}
 
 

--- a/mystery_agents/tools/illustrator_tools.py
+++ b/mystery_agents/tools/illustrator_tools.py
@@ -458,6 +458,7 @@ def generate_image(
     client = _get_client()
     last_error = None
     prompt_sanitized = False
+    _imagen_start = time.monotonic()
 
     for attempt in range(MAX_RETRIES):
         try:
@@ -479,8 +480,19 @@ def generate_image(
 
             if response.generated_images:
                 # Success - save image
+                latency_ms = round((time.monotonic() - _imagen_start) * 1000)
                 image = response.generated_images[0].image
                 image.save(str(filepath))
+                logger.info(
+                    "画像生成成功: attempt=%d, %dms, prompt_len=%d",
+                    attempt + 1, latency_ms, len(current_prompt),
+                    extra={
+                        "api_name": "imagen", "status": "success",
+                        "attempt": attempt + 1, "latency_ms": latency_ms,
+                        "prompt_length": len(current_prompt),
+                        "prompt_sanitized": prompt_sanitized,
+                    },
+                )
 
                 # Generate responsive variants
                 variants, variant_error = _get_variants(str(filepath))
@@ -510,6 +522,7 @@ def generate_image(
             logger.warning(
                 "Safety filter blocked image generation (attempt %d/%d). prompt=%s",
                 attempt + 1, MAX_RETRIES, current_prompt[:100],
+                extra={"api_name": "imagen", "attempt": attempt + 1, "reason": "safety_filter"},
             )
 
             # LLM ベースのプログレッシブ・リトライ戦略:
@@ -532,6 +545,7 @@ def generate_image(
                 logger.warning(
                     "Rate limit hit (attempt %d/%d): %s",
                     attempt + 1, MAX_RETRIES, last_error,
+                    extra={"api_name": "imagen", "attempt": attempt + 1, "reason": "rate_limit"},
                 )
                 time.sleep(RETRY_DELAY_SECONDS * (attempt + 1) * 2)
                 continue

--- a/mystery_agents/tools/internet_archive.py
+++ b/mystery_agents/tools/internet_archive.py
@@ -5,12 +5,15 @@ web pages, and other digitized materials.
 """
 
 import json
+import logging
 import time
 from typing import Any, Dict, List, Optional
 
 import requests
 
 from shared.http_retry import create_retry_session
+
+logger = logging.getLogger(__name__)
 
 from ..schemas.document import ArchiveDocument, SourceLanguage, SourceType
 from .search_utils import build_search_query
@@ -84,6 +87,7 @@ def search_internet_archive(
     }
 
     _rate_limit()
+    start = time.monotonic()
 
     try:
         response = _session.get(
@@ -138,9 +142,22 @@ def search_internet_archive(
             documents.append(doc)
 
         total_hits = resp.get("numFound", 0)
+
+        latency_ms = round((time.monotonic() - start) * 1000)
+        logger.info(
+            "Internet Archive 検索完了: %d 件 (%dms)", len(documents), latency_ms,
+            extra={"api_name": "internet_archive", "result_count": len(documents),
+                   "total_hits": total_hits, "latency_ms": latency_ms},
+        )
+
         return {"documents": documents, "total_hits": total_hits, "error": None}
 
     except (requests.RequestException, json.JSONDecodeError) as e:
+        latency_ms = round((time.monotonic() - start) * 1000)
+        logger.warning(
+            "Internet Archive API エラー: %s (%dms)", e, latency_ms,
+            extra={"api_name": "internet_archive", "latency_ms": latency_ms, "error": str(e)},
+        )
         return {"documents": [], "total_hits": 0, "error": f"Internet Archive API error: {e}"}
 
 

--- a/mystery_agents/tools/librarian_tools.py
+++ b/mystery_agents/tools/librarian_tools.py
@@ -5,11 +5,14 @@ string-based interface for the LLM to use.
 """
 
 import json
+import logging
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
 from google.adk.tools.tool_context import ToolContext
+
+logger = logging.getLogger(__name__)
 
 from .bilingual_search import KEYWORD_PAIRS, expand_keywords_bilingual
 from .chronicling_america import search_chronicling_america
@@ -100,6 +103,11 @@ def search_newspapers(
 
     # Level 2: Individual keywords (if not enough results)
     if len(all_docs) < min_results and len(en_keywords) > 1:
+        logger.info(
+            "Chronicling America フォールバック L2 発動: L1結果=%d件 < min=%d",
+            len(all_docs), min_results,
+            extra={"search_level": "L2", "l1_count": len(all_docs)},
+        )
         levels_used.append("L2_individual_keywords")
         for kw in en_keywords:
             _search_and_collect([kw])
@@ -113,6 +121,11 @@ def search_newspapers(
 
     # Level 3: Remove geographic restriction (search all states)
     if len(all_docs) < min_results and state_list is not None:
+        logger.info(
+            "Chronicling America フォールバック L3 発動: 結果=%d件, 地理制限解除",
+            len(all_docs),
+            extra={"search_level": "L3", "current_count": len(all_docs)},
+        )
         levels_used.append("L3_all_states")
         for kw_list in [en_keywords, es_keywords]:
             _search_and_collect(kw_list, search_states=None)
@@ -124,6 +137,11 @@ def search_newspapers(
         expanded_start = str(max(1700, int(date_start) - 10))
         expanded_end = str(min(1920, int(date_end) + 10))
         if expanded_start != date_start or expanded_end != date_end:
+            logger.info(
+                "Chronicling America フォールバック L4 発動: 日付範囲拡大 %s-%s",
+                expanded_start, expanded_end,
+                extra={"search_level": "L4", "current_count": len(all_docs)},
+            )
             levels_used.append(f"L4_date_expanded_{expanded_start}_{expanded_end}")
             for kw_list in [en_keywords, es_keywords]:
                 _search_and_collect(kw_list, search_states=None, start=expanded_start, end=expanded_end)
@@ -140,6 +158,17 @@ def search_newspapers(
             domain_mismatch=0, removed_urls=[], duration_ms=0,
             verified_documents=list(all_docs),
         )
+    logger.info(
+        "Chronicling America 検索完了: %d 件 (検証後), levels=%s, リンク検証=%d/%d",
+        len(all_docs), levels_used, validation.reachable, validation.total_checked,
+        extra={
+            "api_name": "chronicling_america", "result_count": len(all_docs),
+            "search_levels": levels_used,
+            "links_verified": validation.reachable,
+            "links_checked": validation.total_checked,
+        },
+    )
+
     docs = [doc.model_dump() for doc in all_docs]
 
     result = {
@@ -377,6 +406,19 @@ def search_archives(
             domain_mismatch=0, removed_urls=[], duration_ms=0,
             verified_documents=list(all_docs),
         )
+    logger.info(
+        "アーカイブ検索完了: %d 件 (検証後), sources=%s, リンク検証=%d/%d",
+        len(all_docs), list(source_results.keys()),
+        validation.reachable, validation.total_checked,
+        extra={
+            "api_name": "archives_combined", "result_count": len(all_docs),
+            "sources_searched": list(source_results.keys()),
+            "fallback_used": fallback_used,
+            "links_verified": validation.reachable,
+            "links_checked": validation.total_checked,
+        },
+    )
+
     all_docs_dicts = [doc.model_dump() for doc in all_docs]
 
     # Build warnings for missing API keys

--- a/mystery_agents/tools/loc_digital.py
+++ b/mystery_agents/tools/loc_digital.py
@@ -5,12 +5,15 @@ Uses the loc.gov JSON API to search across all LOC digital collections
 """
 
 import json
+import logging
 import time
 from typing import Any, Dict, List, Optional
 
 import requests
 
 from shared.http_retry import create_retry_session
+
+logger = logging.getLogger(__name__)
 
 from ..schemas.document import ArchiveDocument, SourceLanguage, SourceType
 from .search_utils import build_search_query
@@ -64,6 +67,7 @@ def search_loc_digital(
     }
 
     _rate_limit()
+    start = time.monotonic()
 
     try:
         response = _session.get(
@@ -113,9 +117,21 @@ def search_loc_digital(
         pagination = data.get("pagination", {})
         total_hits = pagination.get("total", pagination.get("of", 0))
 
+        latency_ms = round((time.monotonic() - start) * 1000)
+        logger.info(
+            "LOC 検索完了: %d 件 (%dms)", len(documents), latency_ms,
+            extra={"api_name": "loc", "result_count": len(documents),
+                   "total_hits": total_hits, "latency_ms": latency_ms},
+        )
+
         return {"documents": documents, "total_hits": total_hits, "error": None}
 
     except (requests.RequestException, json.JSONDecodeError) as e:
+        latency_ms = round((time.monotonic() - start) * 1000)
+        logger.warning(
+            "LOC API エラー: %s (%dms)", e, latency_ms,
+            extra={"api_name": "loc", "latency_ms": latency_ms, "error": str(e)},
+        )
         return {"documents": [], "total_hits": 0, "error": f"LOC API error: {e}"}
 
 

--- a/mystery_agents/tools/nypl_digital.py
+++ b/mystery_agents/tools/nypl_digital.py
@@ -5,6 +5,7 @@ including manuscripts, maps, photographs, and rare materials.
 """
 
 import json
+import logging
 import os
 import time
 from typing import Any, Dict, List, Optional
@@ -12,6 +13,8 @@ from typing import Any, Dict, List, Optional
 import requests
 
 from shared.http_retry import create_retry_session
+
+logger = logging.getLogger(__name__)
 
 from ..schemas.document import ArchiveDocument, SourceLanguage, SourceType
 from .search_utils import build_search_query
@@ -69,6 +72,7 @@ def search_nypl(
     }
 
     _rate_limit()
+    start = time.monotonic()
 
     try:
         response = _session.get(
@@ -115,9 +119,22 @@ def search_nypl(
             documents.append(doc)
 
         total_hits = int(nypl_response.get("numResults", 0))
+
+        latency_ms = round((time.monotonic() - start) * 1000)
+        logger.info(
+            "NYPL 検索完了: %d 件 (%dms)", len(documents), latency_ms,
+            extra={"api_name": "nypl", "result_count": len(documents),
+                   "total_hits": total_hits, "latency_ms": latency_ms},
+        )
+
         return {"documents": documents, "total_hits": total_hits, "error": None}
 
     except (requests.RequestException, json.JSONDecodeError, ValueError) as e:
+        latency_ms = round((time.monotonic() - start) * 1000)
+        logger.warning(
+            "NYPL API エラー: %s (%dms)", e, latency_ms,
+            extra={"api_name": "nypl", "latency_ms": latency_ms, "error": str(e)},
+        )
         return {"documents": [], "total_hits": 0, "error": f"NYPL API error: {e}"}
 
 

--- a/podcast_agents/tools/tts.py
+++ b/podcast_agents/tools/tts.py
@@ -278,6 +278,8 @@ def generate_podcast_audio(
     logger.info(
         "Podcast 音声生成開始: podcast_id=%s, segments=%d, voice=%s",
         podcast_id, len(segments), voice_name,
+        extra={"api_name": "tts", "podcast_id": podcast_id,
+               "segment_count": len(segments), "voice_name": voice_name},
     )
 
     pause = AudioSegment.silent(duration=PAUSE_BETWEEN_SEGMENTS_MS)
@@ -348,6 +350,10 @@ def generate_podcast_audio(
     logger.info(
         "音声合成完了: %d セグメント, %.1f秒, %.1f MB",
         synthesized_count, duration_seconds, len(mp3_bytes) / (1024 * 1024),
+        extra={"api_name": "tts", "podcast_id": podcast_id,
+               "segment_count": synthesized_count,
+               "duration_seconds": round(duration_seconds, 1),
+               "file_size_bytes": len(mp3_bytes)},
     )
 
     # 6. GCS アップロード
@@ -372,7 +378,10 @@ def generate_podcast_audio(
 
     gcs_path = f"gs://{bucket.name}/{blob_name}"
 
-    logger.info("GCS アップロード完了: %s", gcs_path)
+    logger.info(
+        "GCS アップロード完了: %s", gcs_path,
+        extra={"api_name": "tts", "podcast_id": podcast_id, "gcs_path": gcs_path},
+    )
 
     return {
         "gcs_path": gcs_path,

--- a/services/curator.py
+++ b/services/curator.py
@@ -38,6 +38,21 @@ setup_logging()
 
 logger = logging.getLogger(__name__)
 
+
+class _HealthCheckFilter(logging.Filter):
+    """ヘルスチェック（/health）の INFO ログを抑制する。"""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.levelno >= logging.WARNING:
+            return True
+        msg = record.getMessage()
+        if "/health" in msg:
+            return False
+        return True
+
+
+logging.getLogger("uvicorn.access").addFilter(_HealthCheckFilter())
+
 # 認証エラーを示すキーワード
 _AUTH_ERROR_KEYWORDS = ("reauthentication", "default credentials", "invalid_grant")
 

--- a/services/pipeline_server.py
+++ b/services/pipeline_server.py
@@ -37,6 +37,27 @@ setup_logging()
 
 logger = logging.getLogger(__name__)
 
+
+class _HealthCheckFilter(logging.Filter):
+    """ヘルスチェック（/health）の INFO ログを抑制する。
+
+    Cloud Run のヘルスチェックは数秒ごとに発火し、ログが大量に生成されるため
+    INFO 以下を除外する。WARNING 以上は通す。
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.levelno >= logging.WARNING:
+            return True
+        msg = record.getMessage()
+        # uvicorn のアクセスログ: "GET /health HTTP/1.1"
+        if "/health" in msg:
+            return False
+        return True
+
+
+# uvicorn のアクセスログにフィルタ適用
+logging.getLogger("uvicorn.access").addFilter(_HealthCheckFilter())
+
 app = FastAPI()
 
 

--- a/shared/http_retry.py
+++ b/shared/http_retry.py
@@ -8,9 +8,13 @@
 - create_retry_session(): 一時的なエラー（429, 5xx）に対する自動リトライ
 """
 
+import logging
+
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
+
+logger = logging.getLogger(__name__)
 
 
 def create_retry_session(
@@ -43,5 +47,10 @@ def create_retry_session(
     session = requests.Session()
     session.mount("https://", adapter)
     session.mount("http://", adapter)
+
+    logger.debug(
+        "リトライセッション作成: retries=%d, backoff=%.1f, status=%s",
+        retries, backoff_factor, status_forcelist,
+    )
 
     return session


### PR DESCRIPTION
## Summary

Issue #158 の PR2（Phase 3+4）。PR #190（Phase 1+2: 構造化ログ基盤）の上に、外部 API 可観測性とサービスレベルログを追加。

### Phase 3: 外部 API ログ
- **検索 API（LOC, DPLA, NYPL, Internet Archive）**: `api_name`, `latency_ms`, `result_count`, `total_hits` を `extra` フィールドで構造化出力
- **Librarian**: フォールバックレベル（L2/L3/L4）活性化ログ、最終結果サマリ（結果数、使用レベル、リンク検証数）
- **Illustrator**: 画像生成成功ログ追加、安全フィルタ・レート制限ログに `extra` フィールド追加
- **TTS**: `podcast_id`, `segment_count`, `duration_seconds`, `file_size_bytes` を構造化出力
- **http_retry**: セッション作成時のデバッグログ追加

### Phase 4: サービスレベルログ
- **pipeline_server / curator**: `_HealthCheckFilter` で `/health` の INFO ログを抑制（Cloud Run のヘルスチェックノイズ除去）

### Cloud Logging での活用例

```
# API レイテンシ監視
jsonPayload.api_name="loc" AND jsonPayload.latency_ms>5000

# 検索結果ゼロの API 呼び出し
jsonPayload.api_name EXISTS AND jsonPayload.result_count=0

# Librarian フォールバック活性化
jsonPayload.fallback_level EXISTS

# TTS 処理時間
jsonPayload.api_name="tts" AND jsonPayload.duration_seconds>300
```

Closes #158

## Test plan

- [x] 全 574 ユニットテスト合格（`pytest tests/unit/ -v`）
- [ ] Cloud Run デプロイ後、Cloud Logging コンソールで構造化フィールドの確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)