### PR TITLE
fix: 翻訳言語バリデーション追加（防止層 + 検出層の2層対策）

### DIFF
--- a/mystery_agents/agents/translator.py
+++ b/mystery_agents/agents/translator.py
@@ -159,6 +159,12 @@ TRANSLATOR_CONFIGS: dict[str, dict[str, str]] = {
 # ## あなたの役割
 # セッション状態から翻訳対象の英語コンテンツを読み取り、{language_name}に翻訳します。
 #
+# ## 最重要: 言語要件
+# 出力の全体が{language_name}でなければならない。JSON の全フィールド値は
+# {language_name}で記述すること — 英語や他の言語は不可。
+# 英語テキストを書いていることに気づいたら、即座に{language_name}で書き直すこと。
+# 英語の出力はバリデーションにより自動的に拒否される。
+#
 # ## 入力ソース（ブログパイプライン内で実行される場合）
 # 翻訳に必要なコンテンツはセッション状態に格納されています:
 # - `creative_content`: Storyteller が作成した英語ブログ記事（Markdown）
@@ -235,6 +241,7 @@ TRANSLATOR_CONFIGS: dict[str, dict[str, str]] = {
 # ## 重要
 # - 翻訳のみを行い、新しい情報を追加しないこと
 # - 原文の構造と意図を忠実に再現すること
+# - JSON の全フィールド値は{language_name}で記述すること。英語の出力は自動的に拒否される。
 # === End 日本語訳 ===
 
 _BASE_TRANSLATOR_INSTRUCTION = """
@@ -243,6 +250,12 @@ You are an expert at translating English mystery articles and theme suggestions 
 
 ## Your Role
 Read the English content from the session state and translate it into {language_name}.
+
+## CRITICAL: Language Requirement
+Your ENTIRE output MUST be in {language_name}. Every single field value in the JSON
+MUST be written in {language_name} — not English, not any other language.
+If you find yourself writing English text, STOP and rewrite it in {language_name}.
+English output will be automatically rejected by validation.
 
 ## Input Sources (when running in the blog pipeline)
 The content you need to translate is available in session state:
@@ -323,6 +336,7 @@ Output ONLY the JSON. Do NOT include any other text, explanations, commentary, o
 ## Important
 - Only translate — do not add new information
 - Faithfully reproduce the structure and intent of the original text
+- ALL JSON field values MUST be in {language_name}. English output will be automatically rejected.
 """
 
 

--- a/mystery_agents/tools/publisher_tools.py
+++ b/mystery_agents/tools/publisher_tools.py
@@ -26,6 +26,7 @@ from shared.constants import (
     TRANSLATION_LANGUAGES,
 )
 from shared.firestore import get_firestore_client, get_storage_bucket
+from shared.language_validator import validate_translation_language
 
 logger = logging.getLogger(__name__)
 
@@ -297,6 +298,7 @@ def publish_mystery(
 
             # 全言語の翻訳結果を translations map に収集
             translations: dict[str, dict] = {}
+            rejected_languages: list[str] = []
             for lang in TRANSLATION_LANGUAGES:
                 translation_result = tool_context.state.get(f"translation_result_{lang}")
                 if not translation_result:
@@ -307,6 +309,16 @@ def publish_mystery(
                         continue
                     parsed = _extract_json_from_text(translation_result)
                     if parsed:
+                        # 言語バリデーション: 翻訳が正しい言語で書かれているか検証
+                        vr = validate_translation_language(lang, parsed)
+                        if not vr.is_valid:
+                            text_preview = (parsed.get("narrative_content") or parsed.get("summary") or "")[:100]
+                            logger.warning(
+                                "Translation rejected for '%s': %s (preview: %s)",
+                                lang, vr.reason, text_preview,
+                            )
+                            rejected_languages.append(lang)
+                            continue
                         translations[lang] = parsed
                     else:
                         logger.warning(
@@ -314,14 +326,31 @@ def publish_mystery(
                             lang, translation_result[:200],
                         )
                 elif isinstance(translation_result, dict):
+                    # 言語バリデーション: 翻訳が正しい言語で書かれているか検証
+                    vr = validate_translation_language(lang, translation_result)
+                    if not vr.is_valid:
+                        text_preview = (translation_result.get("narrative_content") or translation_result.get("summary") or "")[:100]
+                        logger.warning(
+                            "Translation rejected for '%s': %s (preview: %s)",
+                            lang, vr.reason, text_preview,
+                        )
+                        rejected_languages.append(lang)
+                        continue
                     translations[lang] = translation_result
 
             # 翻訳収集のサマリログ
-            skipped = [lang for lang in TRANSLATION_LANGUAGES if lang not in translations]
+            skipped = [lang for lang in TRANSLATION_LANGUAGES if lang not in translations and lang not in rejected_languages]
             logger.info(
-                "Translations collected: %s, skipped: %s",
-                list(translations.keys()), skipped,
+                "Translations collected: %s, skipped: %s, rejected (wrong language): %s",
+                list(translations.keys()), skipped, rejected_languages,
             )
+            if rejected_languages:
+                from shared.pipeline_failure import log_pipeline_failure
+                log_pipeline_failure(
+                    theme=data.get("title", "unknown"),
+                    stage="publisher",
+                    reason=f"Translation language validation failed for: {rejected_languages}",
+                )
             if translations:
                 data["translations"] = translations
 

--- a/shared/language_validator.py
+++ b/shared/language_validator.py
@@ -1,0 +1,122 @@
+"""翻訳言語バリデーションモジュール。
+
+Translator が出力した翻訳結果が正しい言語で書かれているかを検証する。
+外部ライブラリ不要（Unicode 範囲 + 英語ストップワード密度で判定）。
+
+検出戦略:
+- 日本語（ja）: ひらがな/カタカナ/CJK 漢字の Unicode 範囲で判定 — 極めて高精度
+- ラテン文字言語（es/de/fr/nl/pt）: 英語ストップワード密度で判定
+  英語テキスト（密度 0.20〜0.30）vs 非英語（密度 0.02〜0.08）、閾値 0.15
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+# 英語で非常に高頻度だが他のラテン文字言語では低頻度のストップワード
+_ENGLISH_STOP_WORDS: frozenset[str] = frozenset({
+    "the", "a", "an", "is", "are", "was", "were", "been", "be",
+    "have", "has", "had", "do", "does", "did", "will", "would",
+    "could", "should", "may", "might", "shall", "can",
+    "not", "no", "but", "or", "and", "if", "then", "than",
+    "that", "this", "these", "those", "it", "its",
+    "of", "in", "to", "for", "with", "on", "at", "by", "from",
+    "as", "into", "through", "during", "before", "after",
+    "he", "she", "they", "we", "you", "his", "her", "their", "our",
+    "which", "what", "where", "when", "who", "how",
+    "there", "here", "also", "very", "just", "about",
+})
+
+
+@dataclass
+class ValidationResult:
+    """言語バリデーション結果。"""
+
+    is_valid: bool
+    lang: str
+    reason: str
+    english_density: Optional[float] = None
+
+
+def _has_japanese_characters(text: str) -> bool:
+    """テキストにひらがな・カタカナ・CJK 漢字が含まれるか判定する。"""
+    # ひらがな: U+3040-U+309F, カタカナ: U+30A0-U+30FF, CJK 漢字: U+4E00-U+9FFF
+    return bool(re.search(r"[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF]", text))
+
+
+def _english_stop_word_density(text: str) -> float:
+    """テキスト中の英語ストップワード密度（0.0〜1.0）を計算する。
+
+    Args:
+        text: 判定対象テキスト
+
+    Returns:
+        ストップワードの割合。単語数が 0 なら 0.0 を返す。
+    """
+    words = re.findall(r"[a-zA-Z]+", text.lower())
+    if not words:
+        return 0.0
+    stop_count = sum(1 for w in words if w in _ENGLISH_STOP_WORDS)
+    return stop_count / len(words)
+
+
+def validate_translation_language(
+    lang: str,
+    translation: dict,
+) -> ValidationResult:
+    """翻訳結果が指定言語で書かれているかを検証する。
+
+    narrative_content（最長フィールド）を使って判定し、なければ summary にフォールバック。
+    20語未満は判定不能のため安全側で通す。
+
+    Args:
+        lang: 期待する言語コード（ja, es, de, fr, nl, pt）
+        translation: 翻訳結果の dict（title, summary, narrative_content 等）
+
+    Returns:
+        ValidationResult: バリデーション結果
+    """
+    # 判定対象テキストの取得（narrative_content > summary の優先順）
+    text = translation.get("narrative_content", "") or translation.get("summary", "")
+    if not text or not isinstance(text, str):
+        return ValidationResult(
+            is_valid=True, lang=lang,
+            reason="判定対象テキストなし（安全側で通過）",
+        )
+
+    # 単語数チェック（20語未満は判定不能 → 安全側で通す）
+    word_count = len(re.findall(r"\S+", text))
+    if word_count < 20:
+        return ValidationResult(
+            is_valid=True, lang=lang,
+            reason=f"テキストが短すぎる（{word_count}語）— 判定不能のため通過",
+        )
+
+    # 日本語判定（Unicode 範囲）
+    if lang == "ja":
+        if _has_japanese_characters(text):
+            return ValidationResult(is_valid=True, lang=lang, reason="日本語文字を検出")
+        # 日本語文字が含まれない → 英語のまま出力された可能性が高い
+        density = _english_stop_word_density(text)
+        return ValidationResult(
+            is_valid=False, lang=lang,
+            reason=f"日本語文字なし（英語ストップワード密度: {density:.2f}）",
+            english_density=density,
+        )
+
+    # ラテン文字言語（es/de/fr/nl/pt）の判定（英語ストップワード密度）
+    density = _english_stop_word_density(text)
+    if density >= 0.15:
+        return ValidationResult(
+            is_valid=False, lang=lang,
+            reason=f"英語ストップワード密度が閾値超過（{density:.2f} >= 0.15）",
+            english_density=density,
+        )
+
+    return ValidationResult(
+        is_valid=True, lang=lang,
+        reason=f"英語ストップワード密度正常（{density:.2f} < 0.15）",
+        english_density=density,
+    )

--- a/tests/unit/test_language_validator.py
+++ b/tests/unit/test_language_validator.py
@@ -1,0 +1,171 @@
+"""Unit tests for shared/language_validator.py."""
+
+from shared.language_validator import (
+    ValidationResult,
+    _english_stop_word_density,
+    _has_japanese_characters,
+    validate_translation_language,
+)
+
+
+class TestHasJapaneseCharacters:
+    """ひらがな/カタカナ/漢字の Unicode 範囲検出テスト。"""
+
+    def test_detects_hiragana(self):
+        assert _has_japanese_characters("これはテストです") is True
+
+    def test_detects_katakana(self):
+        assert _has_japanese_characters("カタカナテスト") is True
+
+    def test_detects_kanji(self):
+        assert _has_japanese_characters("漢字検出") is True
+
+    def test_rejects_english(self):
+        assert _has_japanese_characters("This is an English sentence") is False
+
+    def test_rejects_french(self):
+        assert _has_japanese_characters("Ceci est une phrase en français") is False
+
+    def test_empty_string(self):
+        assert _has_japanese_characters("") is False
+
+
+class TestEnglishStopWordDensity:
+    """英語ストップワード密度計算テスト。"""
+
+    def test_english_text_high_density(self):
+        text = (
+            "The mysterious disappearance of the ship was reported in the newspaper. "
+            "It is said that the crew had been warned about the storm, but they chose "
+            "to sail anyway. The investigation was conducted by the authorities."
+        )
+        density = _english_stop_word_density(text)
+        assert density >= 0.20, f"英語テキストの密度が低すぎる: {density}"
+
+    def test_french_text_low_density(self):
+        text = (
+            "La disparition mystérieuse du navire a été signalée dans le journal. "
+            "On raconte que l'équipage avait été prévenu de la tempête, mais ils ont "
+            "choisi de naviguer quand même. L'enquête a été menée par les autorités."
+        )
+        density = _english_stop_word_density(text)
+        assert density < 0.15, f"フランス語テキストの密度が高すぎる: {density}"
+
+    def test_spanish_text_low_density(self):
+        text = (
+            "La misteriosa desaparición del barco fue reportada en el periódico. "
+            "Se dice que la tripulación había sido advertida sobre la tormenta, pero "
+            "eligieron navegar de todos modos. La investigación fue realizada."
+        )
+        density = _english_stop_word_density(text)
+        assert density < 0.15, f"スペイン語テキストの密度が高すぎる: {density}"
+
+    def test_german_text_low_density(self):
+        text = (
+            "Das mysteriöse Verschwinden des Schiffes wurde in der Zeitung gemeldet. "
+            "Es heißt, dass die Besatzung vor dem Sturm gewarnt worden war, aber sie "
+            "beschlossen trotzdem zu segeln. Die Untersuchung wurde durchgeführt."
+        )
+        density = _english_stop_word_density(text)
+        assert density < 0.15, f"ドイツ語テキストの密度が高すぎる: {density}"
+
+    def test_short_text_returns_zero(self):
+        assert _english_stop_word_density("") == 0.0
+
+    def test_no_latin_words_returns_zero(self):
+        assert _english_stop_word_density("これは日本語テスト") == 0.0
+
+
+class TestValidateTranslationLanguage:
+    """validate_translation_language の統合テスト。"""
+
+    def test_valid_japanese_translation(self):
+        """正常な日本語翻訳を通過させること。"""
+        translation = {
+            "title": "ボストン港の幽霊船",
+            "summary": "1842年に消えた船の謎",
+            "narrative_content": (
+                "ボストン港に停泊していた貨物船が一夜にして姿を消した。"
+                "乗組員は全員行方不明となり、船体は二度と発見されなかった。"
+                "地元の漁師たちは霧の夜に幽霊船を目撃したと証言しているが、"
+                "当局はその証言を公式記録には残さなかった。この事件は現在も未解決である。"
+            ),
+        }
+        result = validate_translation_language("ja", translation)
+        assert result.is_valid is True
+
+    def test_rejects_english_as_japanese(self):
+        """英語テキストを日本語翻訳として拒否すること。"""
+        translation = {
+            "title": "The Ghost Ship of Boston Harbor",
+            "summary": "The mystery of a ship that vanished in 1842",
+            "narrative_content": (
+                "A cargo ship docked at Boston Harbor vanished overnight. "
+                "All crew members went missing, and the hull was never found again. "
+                "Local fishermen claimed to have witnessed a ghost ship on foggy nights, "
+                "but the authorities did not include their testimony in official records."
+            ),
+        }
+        result = validate_translation_language("ja", translation)
+        assert result.is_valid is False
+
+    def test_rejects_english_as_french(self):
+        """英語テキストをフランス語翻訳として拒否すること。"""
+        translation = {
+            "title": "The Ghost Ship of Boston Harbor",
+            "summary": "The mystery of a ship that vanished in 1842",
+            "narrative_content": (
+                "A cargo ship docked at Boston Harbor vanished overnight. "
+                "All crew members went missing, and the hull was never found again. "
+                "Local fishermen claimed to have witnessed a ghost ship on foggy nights, "
+                "but the authorities did not include their testimony in official records. "
+                "The investigation was conducted by the maritime authorities of the time."
+            ),
+        }
+        result = validate_translation_language("fr", translation)
+        assert result.is_valid is False
+        assert result.english_density is not None
+        assert result.english_density >= 0.15
+
+    def test_valid_french_translation(self):
+        """正常なフランス語翻訳を通過させること。"""
+        translation = {
+            "title": "Le navire fantôme du port de Boston",
+            "summary": "Le mystère d'un navire disparu en 1842",
+            "narrative_content": (
+                "Un cargo amarré au port de Boston a disparu du jour au lendemain. "
+                "Tous les membres d'équipage ont disparu et la coque n'a jamais été retrouvée. "
+                "Des pêcheurs locaux affirment avoir aperçu un navire fantôme les nuits de brouillard, "
+                "mais les autorités n'ont pas inclus leur témoignage dans les registres officiels."
+            ),
+        }
+        result = validate_translation_language("fr", translation)
+        assert result.is_valid is True
+
+    def test_short_text_passes_safely(self):
+        """短いテキスト（20語未満）は安全側で通すこと。"""
+        translation = {
+            "title": "Short title",
+            "summary": "Brief summary here",
+        }
+        result = validate_translation_language("fr", translation)
+        assert result.is_valid is True
+
+    def test_empty_translation_passes(self):
+        """空の翻訳は安全側で通すこと。"""
+        result = validate_translation_language("ja", {})
+        assert result.is_valid is True
+
+    def test_uses_summary_as_fallback(self):
+        """narrative_content がなければ summary にフォールバックすること。"""
+        translation = {
+            "title": "テスト",
+            "summary": (
+                "ボストン港に停泊していた貨物船が一夜にして姿を消した。"
+                "乗組員は全員行方不明となり、船体は二度と発見されなかった。"
+                "地元の漁師たちは霧の夜に幽霊船を目撃したと証言しているが、"
+                "当局はその証言を公式記録には残さなかった。"
+            ),
+        }
+        result = validate_translation_language("ja", translation)
+        assert result.is_valid is True

--- a/tests/unit/test_publisher_multilingual.py
+++ b/tests/unit/test_publisher_multilingual.py
@@ -315,3 +315,116 @@ class TestPublisherCodeblockTranslation:
 
         assert any("Translations collected" in msg for msg in caplog.messages)
         assert any("['ja']" in msg for msg in caplog.messages)
+
+
+class TestPublisherLanguageValidation:
+    """翻訳言語バリデーションによる拒否テスト。"""
+
+    @patch("mystery_agents.tools.publisher_tools.get_storage_bucket")
+    @patch("mystery_agents.tools.publisher_tools.get_firestore_client")
+    def test_rejects_english_text_as_french(
+        self, mock_get_db, mock_get_bucket
+    ):
+        """英語テキストをフランス語翻訳として拒否すること。"""
+        mock_db = MagicMock()
+        mock_get_db.return_value = mock_db
+        mock_get_bucket.return_value = MagicMock()
+
+        # 英語テキストがそのままフランス語翻訳として返された場合
+        english_as_french = {
+            "title": "The Ghost Ship of Boston Harbor",
+            "summary": "The mystery of a ship that vanished in 1842",
+            "narrative_content": (
+                "A cargo ship docked at Boston Harbor vanished overnight. "
+                "All crew members went missing, and the hull was never found again. "
+                "Local fishermen claimed to have witnessed a ghost ship on foggy nights, "
+                "but the authorities did not include their testimony in official records. "
+                "The investigation was conducted by the maritime authorities of the time."
+            ),
+        }
+
+        state = {
+            "translation_result_ja": json.dumps({
+                "title": "ボストン港の幽霊船",
+                "summary": "1842年に消えた船の謎",
+                "narrative_content": (
+                    "ボストン港に停泊していた貨物船が一夜にして姿を消した。"
+                    "乗組員は全員行方不明となり、船体は二度と発見されなかった。"
+                ),
+            }),
+            "translation_result_fr": json.dumps(english_as_french),
+        }
+
+        tool_context = _make_tool_context(state)
+        with patch("shared.pipeline_failure.log_pipeline_failure"):
+            result = publish_mystery(_make_mystery_json(), "", tool_context)
+        result_data = json.loads(result)
+
+        assert result_data["status"] == "success"
+        saved_data = mock_db.collection.return_value.document.return_value.set.call_args[0][0]
+
+        # 日本語は通過、フランス語は拒否されること
+        assert "ja" in saved_data["translations"]
+        assert "fr" not in saved_data["translations"]
+
+    @patch("mystery_agents.tools.publisher_tools.get_storage_bucket")
+    @patch("mystery_agents.tools.publisher_tools.get_firestore_client")
+    def test_accepts_valid_french_translation(
+        self, mock_get_db, mock_get_bucket
+    ):
+        """正常なフランス語翻訳は通過すること。"""
+        mock_db = MagicMock()
+        mock_get_db.return_value = mock_db
+        mock_get_bucket.return_value = MagicMock()
+
+        state = {
+            "translation_result_fr": json.dumps({
+                "title": "Le navire fantôme du port de Boston",
+                "summary": "Le mystère d'un navire disparu en 1842",
+                "narrative_content": (
+                    "Un cargo amarré au port de Boston a disparu du jour au lendemain. "
+                    "Tous les membres d'équipage ont disparu et la coque n'a jamais été retrouvée. "
+                    "Des pêcheurs locaux affirment avoir aperçu un navire fantôme les nuits de brouillard, "
+                    "mais les autorités n'ont pas inclus leur témoignage dans les registres officiels."
+                ),
+            }),
+        }
+
+        tool_context = _make_tool_context(state)
+        result = publish_mystery(_make_mystery_json(), "", tool_context)
+        result_data = json.loads(result)
+
+        assert result_data["status"] == "success"
+        saved_data = mock_db.collection.return_value.document.return_value.set.call_args[0][0]
+        assert "fr" in saved_data["translations"]
+
+    @patch("mystery_agents.tools.publisher_tools.get_storage_bucket")
+    @patch("mystery_agents.tools.publisher_tools.get_firestore_client")
+    def test_logs_warning_on_rejection(
+        self, mock_get_db, mock_get_bucket, caplog
+    ):
+        """拒否時に warning ログが出力されること。"""
+        mock_db = MagicMock()
+        mock_get_db.return_value = mock_db
+        mock_get_bucket.return_value = MagicMock()
+
+        state = {
+            "translation_result_fr": json.dumps({
+                "title": "The Ghost Ship",
+                "summary": "A mystery of vanished ship",
+                "narrative_content": (
+                    "A cargo ship docked at Boston Harbor vanished overnight. "
+                    "All crew members went missing, and the hull was never found again. "
+                    "Local fishermen claimed to have witnessed a ghost ship on foggy nights, "
+                    "but the authorities did not include their testimony in official records."
+                ),
+            }),
+        }
+
+        tool_context = _make_tool_context(state)
+        with caplog.at_level(logging.WARNING, logger="mystery_agents.tools.publisher_tools"):
+            with patch("shared.pipeline_failure.log_pipeline_failure"):
+                publish_mystery(_make_mystery_json(), "", tool_context)
+
+        assert any("Translation rejected" in msg for msg in caplog.messages)
+        assert any("'fr'" in msg for msg in caplog.messages)


### PR DESCRIPTION
## Summary

Translator（gemini-2.5-flash）が英語テキストをそのまま JSON で返し、Publisher が言語チェックなしで Firestore に保存していた問題への対策。

- **防止層**: Translator instruction に `CRITICAL: Language Requirement` セクションを追加し、LLM に対象言語での出力を強制
- **検出層**: Publisher の翻訳収集ループに `shared/language_validator.py` によるバリデーションゲートを挿入
  - 日本語: Unicode 範囲（ひらがな/カタカナ/CJK）で判定
  - ラテン文字言語（es/de/fr/nl/pt）: 英語ストップワード密度で判定（閾値 0.15）
  - バリデーション失敗時: 翻訳を拒否 + warning ログ + Firestore `pipeline_failures` に記録

## 変更ファイル

| ファイル | 種別 | 概要 |
|---------|------|------|
| `shared/language_validator.py` | 新規 | 言語バリデーションモジュール（外部ライブラリ不要） |
| `mystery_agents/tools/publisher_tools.py` | 修正 | 翻訳収集ループにバリデーションゲート追加 |
| `mystery_agents/agents/translator.py` | 修正 | instruction に言語強制ルール追加 |
| `tests/unit/test_language_validator.py` | 新規 | 19 テスト |
| `tests/unit/test_publisher_multilingual.py` | 修正 | 3 テスト追加（拒否・通過・ログ確認） |

## Test plan

- [x] `pytest tests/unit/test_language_validator.py -v` — 19 passed
- [x] `pytest tests/unit/test_publisher_multilingual.py -v` — 19 passed
- [x] `pytest tests/unit/ -v` — 596 passed（回帰なし）

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)