### PR TITLE
feat: Europeana Search API 統合（欧州文化遺産資料検索）

### DIFF
--- a/mystery_agents/agents/language_librarians.py
+++ b/mystery_agents/agents/language_librarians.py
@@ -119,10 +119,11 @@ LANGUAGE_CONFIGS = {
             "Focus on German-language sources relevant to American history:\n"
             "- German immigrant communities (Pennsylvania Dutch, Texas Germans)\n"
             "- Deutsche Digitale Bibliothek (DDB) for German institutional records\n"
+            "- Europeana for pan-European cultural heritage materials in German\n"
             "- Internet Archive for digitized German-language books and periodicals\n"
             "- Protestant church records, immigration documents, German-language American newspapers"
         ),
-        "sources_hint": "ddb, internet_archive",
+        "sources_hint": "ddb, europeana, internet_archive",
         "newspaper_instruction": "Do NOT call search_newspapers (it only searches English/Spanish newspapers).",
         "tools": "archives_only",  # search_archives のみ
     },
@@ -147,10 +148,11 @@ LANGUAGE_CONFIGS = {
             "Focus on French-language sources relevant to American history:\n"
             "- French colonial records (Louisiana, Quebec, Nouvelle-France)\n"
             "- Acadian/Cajun history and culture\n"
+            "- Europeana for pan-European cultural heritage materials in French\n"
             "- Internet Archive for digitized French-language materials\n"
             "- Huguenot immigration, fur trade, French-Indian alliances"
         ),
-        "sources_hint": "internet_archive",
+        "sources_hint": "europeana, internet_archive",
         "newspaper_instruction": "Do NOT call search_newspapers (it only searches English/Spanish newspapers).",
         "tools": "archives_only",
     },
@@ -160,10 +162,11 @@ LANGUAGE_CONFIGS = {
         "cultural_context": (
             "Focus on Dutch-language sources relevant to American history:\n"
             "- Dutch colonial records (New Amsterdam/New York, Dutch West India Company)\n"
+            "- Europeana for pan-European cultural heritage materials in Dutch\n"
             "- Internet Archive for digitized Dutch-language materials\n"
             "- VOC/WIC trade records, colonial administration, patroon system"
         ),
-        "sources_hint": "internet_archive",
+        "sources_hint": "europeana, internet_archive",
         "newspaper_instruction": "Do NOT call search_newspapers (it only searches English/Spanish newspapers).",
         "tools": "archives_only",
     },
@@ -173,10 +176,11 @@ LANGUAGE_CONFIGS = {
         "cultural_context": (
             "Focus on Portuguese-language sources relevant to American/Atlantic history:\n"
             "- Atlantic trade networks, Brazil-Africa-Americas triangle\n"
+            "- Europeana for pan-European cultural heritage materials in Portuguese\n"
             "- Internet Archive for digitized Portuguese-language materials\n"
             "- Maritime exploration, slave trade documentation, colonial correspondence"
         ),
-        "sources_hint": "internet_archive",
+        "sources_hint": "europeana, internet_archive",
         "newspaper_instruction": "Do NOT call search_newspapers (it only searches English/Spanish newspapers).",
         "tools": "archives_only",
     },

--- a/mystery_agents/schemas/document.py
+++ b/mystery_agents/schemas/document.py
@@ -28,6 +28,7 @@ class SourceType(str, Enum):
     PARES = "pares"
     INTERNET_ARCHIVE = "internet_archive"
     DDB = "ddb"
+    EUROPEANA = "europeana"
 
 
 class ArchiveDocument(BaseModel):

--- a/mystery_agents/tools/__init__.py
+++ b/mystery_agents/tools/__init__.py
@@ -10,6 +10,7 @@ from .internet_archive import search_internet_archive
 from .loc_digital import search_loc_digital
 from .nypl_digital import search_nypl
 from .ddb import search_ddb
+from .europeana import search_europeana
 
 # Librarian Agent LLM-facing tools
 from .librarian_tools import (
@@ -49,6 +50,7 @@ __all__ = [
     "search_nypl",
     "search_internet_archive",
     "search_ddb",
+    "search_europeana",
     # Librarian LLM tools
     "search_newspapers",
     "search_archives",

--- a/mystery_agents/tools/europeana.py
+++ b/mystery_agents/tools/europeana.py
@@ -1,0 +1,215 @@
+"""Europeana Search API tool.
+
+Searches the Europeana aggregated collections from 6,000+ European cultural
+heritage institutions (museums, libraries, archives). Uses wskey query
+parameter authentication.
+"""
+
+import json
+import os
+import re
+import time
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from shared.http_retry import create_retry_session
+
+from ..schemas.document import ArchiveDocument, SourceLanguage, SourceType
+from .search_utils import build_search_query
+
+BASE_URL = "https://api.europeana.eu/record/v2/search.json"
+_session = create_retry_session()
+MIN_REQUEST_DELAY = 1.0
+_last_request_time = 0.0
+
+# Europeana の language フィールドから SourceLanguage へのマッピング
+_LANG_MAP: dict[str, SourceLanguage] = {
+    "en": SourceLanguage.EN,
+    "es": SourceLanguage.ES,
+    "de": SourceLanguage.DE,
+    "fr": SourceLanguage.FR,
+    "nl": SourceLanguage.NL,
+    "pt": SourceLanguage.PT,
+}
+
+
+def _rate_limit() -> None:
+    global _last_request_time
+    now = time.time()
+    elapsed = now - _last_request_time
+    if elapsed < MIN_REQUEST_DELAY:
+        time.sleep(MIN_REQUEST_DELAY - elapsed)
+    _last_request_time = time.time()
+
+
+def _detect_language(item: dict) -> SourceLanguage:
+    """アイテムの language フィールドから SourceLanguage を検出する。"""
+    languages = item.get("language", [])
+    if isinstance(languages, list):
+        for lang in languages:
+            if lang and lang.lower() in _LANG_MAP:
+                return _LANG_MAP[lang.lower()]
+    elif isinstance(languages, str) and languages.lower() in _LANG_MAP:
+        return _LANG_MAP[languages.lower()]
+    # デフォルトは英語
+    return SourceLanguage.EN
+
+
+def _extract_location(item: dict) -> str:
+    """アイテムから場所情報を抽出する。"""
+    # edmPlaceLabelLangAware を優先
+    place_labels = item.get("edmPlaceLabelLangAware", {})
+    if isinstance(place_labels, dict):
+        # 英語ラベルを優先、なければ最初の値を使用
+        for key in ("en", "def"):
+            if key in place_labels and place_labels[key]:
+                labels = place_labels[key]
+                if isinstance(labels, list) and labels:
+                    return str(labels[0])[:200]
+
+    # country フィールドにフォールバック
+    country = item.get("country", [])
+    if isinstance(country, list) and country:
+        return str(country[0])[:200]
+    elif isinstance(country, str) and country:
+        return country[:200]
+
+    return "Europe"
+
+
+def _parse_year(date_str: str) -> Optional[str]:
+    """年文字列を ISO 日付形式に変換する。"""
+    if not date_str:
+        return None
+    year_match = re.search(r"\b(1[3-9]\d{2}|20\d{2})\b", date_str)
+    if year_match:
+        return f"{year_match.group(1)}-01-01"
+    return date_str[:10] if len(date_str) > 10 else date_str
+
+
+def search_europeana(
+    keywords: List[str],
+    date_start: str = "1800",
+    date_end: str = "1899",
+    max_results: int = 20,
+    language: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Search Europeana for European cultural heritage materials.
+
+    Args:
+        keywords: List of search keywords
+        date_start: Start year
+        date_end: End year
+        max_results: Maximum results to return
+        language: Optional ISO 639-1 language code for filtering
+
+    Returns:
+        Dict with documents, total_hits, error keys.
+    """
+    api_key = os.environ.get("EUROPEANA_API_KEY", "")
+    if not api_key:
+        return {"documents": [], "total_hits": 0, "error": "EUROPEANA_API_KEY not set"}
+
+    search_text = build_search_query(keywords)
+    if not search_text:
+        return {"documents": [], "total_hits": 0, "error": "No keywords provided"}
+
+    params: dict[str, Any] = {
+        "wskey": api_key,
+        "query": search_text,
+        "rows": min(max_results, 100),
+        "start": 1,
+        "profile": "standard",
+    }
+
+    # 日付フィルタ
+    qf_list: list[str] = [f"YEAR:[{date_start} TO {date_end}]"]
+
+    # 言語フィルタ
+    if language:
+        qf_list.append(f"LANGUAGE:{language}")
+
+    params["qf"] = qf_list
+
+    headers = {
+        "Accept": "application/json",
+        "User-Agent": "GhostInTheArchive/1.0",
+    }
+
+    _rate_limit()
+
+    try:
+        response = _session.get(
+            BASE_URL,
+            params=params,
+            headers=headers,
+            timeout=30,
+        )
+        response.raise_for_status()
+        data = response.json()
+
+        documents = []
+        items = data.get("items", [])
+
+        for item in items:
+            # タイトル抽出
+            title = item.get("title", ["Unknown Title"])
+            if isinstance(title, list):
+                title = title[0] if title else "Unknown Title"
+
+            # 説明文抽出
+            description = ""
+            dc_description = item.get("dcDescription", [])
+            if isinstance(dc_description, list) and dc_description:
+                description = str(dc_description[0])
+            elif isinstance(dc_description, str):
+                description = dc_description
+
+            # URL 抽出（guid を優先、edmIsShownAt にフォールバック）
+            url = item.get("guid", "")
+            if not url:
+                shown_at = item.get("edmIsShownAt", [])
+                if isinstance(shown_at, list) and shown_at:
+                    url = str(shown_at[0])
+                elif isinstance(shown_at, str):
+                    url = shown_at
+            if not url:
+                continue
+
+            # 日付抽出
+            date_str = ""
+            year = item.get("year", [])
+            if isinstance(year, list) and year:
+                date_str = str(year[0])
+            elif isinstance(year, str):
+                date_str = year
+
+            # 言語検出
+            lang = _detect_language(item)
+
+            # 場所抽出
+            location = _extract_location(item)
+
+            # キーワードマッチ
+            combined = f"{title} {description}".lower()
+            matched = [kw for kw in keywords if kw.lower() in combined]
+
+            doc = ArchiveDocument(
+                title=str(title)[:500],
+                date=_parse_year(str(date_str)),
+                source_url=url,
+                summary=str(description)[:500] if description else str(title)[:500],
+                language=lang,
+                location=str(location)[:200],
+                source_type=SourceType.EUROPEANA,
+                raw_text=str(description)[:5000] if description else None,
+                keywords_matched=matched,
+            )
+            documents.append(doc)
+
+        total_hits = data.get("totalResults", len(documents))
+        return {"documents": documents, "total_hits": total_hits, "error": None}
+
+    except (requests.RequestException, json.JSONDecodeError) as e:
+        return {"documents": [], "total_hits": 0, "error": f"Europeana API error: {e}"}

--- a/mystery_agents/tools/librarian_tools.py
+++ b/mystery_agents/tools/librarian_tools.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 from .bilingual_search import KEYWORD_PAIRS, expand_keywords_bilingual
 from .chronicling_america import search_chronicling_america
 from .ddb import search_ddb
+from .europeana import search_europeana
 from .dpla import search_dpla
 from .internet_archive import search_internet_archive
 from .link_validator import ValidationSummary, validate_documents
@@ -256,7 +257,7 @@ def save_search_results(
 
 
 # 言語フィルタをサポートするソース
-_LANGUAGE_FILTER_SOURCES = {"dpla", "internet_archive"}
+_LANGUAGE_FILTER_SOURCES = {"dpla", "internet_archive", "europeana"}
 
 _ARCHIVE_SOURCES = {
     "loc": ("LOC Digital Collections", search_loc_digital),
@@ -264,6 +265,7 @@ _ARCHIVE_SOURCES = {
     "nypl": ("NYPL Digital Collections", search_nypl),
     "internet_archive": ("Internet Archive", search_internet_archive),
     "ddb": ("Deutsche Digitale Bibliothek", search_ddb),
+    "europeana": ("Europeana", search_europeana),
 }
 
 
@@ -292,7 +294,7 @@ def search_archives(
         date_start: Start year (default: 1800)
         date_end: End year (default: 1899)
         sources: Comma-separated source names to search (default: all US sources).
-                 Options: loc, dpla, nypl, internet_archive, ddb
+                 Options: loc, dpla, nypl, internet_archive, ddb, europeana
         max_results: Max results per source (default: 10)
         language: Optional ISO 639-1 language code (en, de, fr, es, nl, pt).
                   When specified, applies language filter to supported APIs

--- a/mystery_agents/tools/link_validator.py
+++ b/mystery_agents/tools/link_validator.py
@@ -33,6 +33,7 @@ EXPECTED_DOMAINS: dict[SourceType, list[str]] = {
     SourceType.NYPL: ["digitalcollections.nypl.org", "nypl.org"],
     SourceType.INTERNET_ARCHIVE: ["archive.org"],
     SourceType.DDB: ["deutsche-digitale-bibliothek.de"],
+    SourceType.EUROPEANA: ["europeana.eu"],
 }
 
 

--- a/tests/unit/test_europeana.py
+++ b/tests/unit/test_europeana.py
@@ -1,0 +1,193 @@
+"""Unit tests for Europeana API tool."""
+
+from unittest.mock import patch
+
+import responses
+
+from mystery_agents.tools.europeana import (
+    BASE_URL,
+    _detect_language,
+    _extract_location,
+    _parse_year,
+    search_europeana,
+)
+from mystery_agents.schemas.document import SourceLanguage, SourceType
+
+
+class TestSearchEuropeana:
+    """Tests for search_europeana function."""
+
+    def test_missing_api_key(self):
+        """API Key 未設定時はエラーを返す。"""
+        with patch.dict("os.environ", {}, clear=True):
+            result = search_europeana(keywords=["test"])
+        assert result["error"] == "EUROPEANA_API_KEY not set"
+        assert result["documents"] == []
+
+    def test_empty_keywords(self):
+        """空のキーワードリストでエラーを返す。"""
+        with patch.dict("os.environ", {"EUROPEANA_API_KEY": "test_key"}):
+            result = search_europeana(keywords=[])
+        assert result["error"] == "No keywords provided"
+
+    @responses.activate
+    def test_successful_search(self):
+        """正常なレスポンスでドキュメントを返す。"""
+        mock_response = {
+            "success": True,
+            "totalResults": 1,
+            "items": [
+                {
+                    "title": ["Medieval Manuscript from Paris"],
+                    "year": ["1450"],
+                    "guid": "https://www.europeana.eu/item/123/abc",
+                    "dcDescription": ["A rare medieval manuscript found in Paris archives"],
+                    "language": ["fr"],
+                    "country": ["France"],
+                }
+            ],
+        }
+        responses.add(responses.GET, BASE_URL, json=mock_response, status=200)
+
+        with patch.dict("os.environ", {"EUROPEANA_API_KEY": "test_key"}):
+            result = search_europeana(keywords=["medieval", "manuscript"])
+
+        assert result["total_hits"] == 1
+        assert len(result["documents"]) == 1
+        doc = result["documents"][0]
+        assert doc.title == "Medieval Manuscript from Paris"
+        assert doc.language == SourceLanguage.FR
+        assert doc.source_type == SourceType.EUROPEANA
+        assert "europeana.eu" in doc.source_url
+
+    @responses.activate
+    def test_language_filter(self):
+        """language パラメータで qf=LANGUAGE:xx が送信される。"""
+        mock_response = {"success": True, "totalResults": 0, "items": []}
+        responses.add(responses.GET, BASE_URL, json=mock_response, status=200)
+
+        with patch.dict("os.environ", {"EUROPEANA_API_KEY": "test_key"}):
+            search_europeana(keywords=["test"], language="de")
+
+        request = responses.calls[0].request
+        assert "LANGUAGE%3Ade" in request.url or "LANGUAGE:de" in request.url
+
+    @responses.activate
+    def test_date_filter(self):
+        """日付フィルタが qf パラメータで送信される。"""
+        mock_response = {"success": True, "totalResults": 0, "items": []}
+        responses.add(responses.GET, BASE_URL, json=mock_response, status=200)
+
+        with patch.dict("os.environ", {"EUROPEANA_API_KEY": "test_key"}):
+            search_europeana(keywords=["test"], date_start="1800", date_end="1899")
+
+        request = responses.calls[0].request
+        # URL エンコードされた形式でもチェック
+        assert "1800" in request.url
+        assert "1899" in request.url
+
+    @responses.activate
+    def test_api_error_handling(self):
+        """API エラー時はエラーメッセージを返す。"""
+        responses.add(responses.GET, BASE_URL, json={"error": "forbidden"}, status=403)
+
+        with patch.dict("os.environ", {"EUROPEANA_API_KEY": "bad_key"}):
+            result = search_europeana(keywords=["test"])
+
+        assert result["error"] is not None
+        assert "Europeana API error" in result["error"]
+        assert result["documents"] == []
+
+    @responses.activate
+    def test_empty_results(self):
+        """結果が0件の場合。"""
+        mock_response = {"success": True, "totalResults": 0, "items": []}
+        responses.add(responses.GET, BASE_URL, json=mock_response, status=200)
+
+        with patch.dict("os.environ", {"EUROPEANA_API_KEY": "test_key"}):
+            result = search_europeana(keywords=["nonexistent"])
+
+        assert result["total_hits"] == 0
+        assert result["documents"] == []
+        assert result["error"] is None
+
+    @responses.activate
+    def test_wskey_parameter(self):
+        """wskey パラメータがリクエストに含まれることを確認。"""
+        mock_response = {"success": True, "totalResults": 0, "items": []}
+        responses.add(responses.GET, BASE_URL, json=mock_response, status=200)
+
+        with patch.dict("os.environ", {"EUROPEANA_API_KEY": "my_secret_key"}):
+            search_europeana(keywords=["test"])
+
+        request = responses.calls[0].request
+        assert "wskey=my_secret_key" in request.url
+
+    @responses.activate
+    def test_edmIsShownAt_fallback(self):
+        """guid がない場合は edmIsShownAt にフォールバックする。"""
+        mock_response = {
+            "success": True,
+            "totalResults": 1,
+            "items": [
+                {
+                    "title": ["Test Document"],
+                    "edmIsShownAt": ["https://example.europeana.eu/item/456"],
+                    "language": ["en"],
+                    "country": ["United Kingdom"],
+                }
+            ],
+        }
+        responses.add(responses.GET, BASE_URL, json=mock_response, status=200)
+
+        with patch.dict("os.environ", {"EUROPEANA_API_KEY": "test_key"}):
+            result = search_europeana(keywords=["test"])
+
+        assert len(result["documents"]) == 1
+        assert result["documents"][0].source_url == "https://example.europeana.eu/item/456"
+
+
+class TestDetectLanguage:
+    """Tests for _detect_language helper."""
+
+    def test_detect_french(self):
+        assert _detect_language({"language": ["fr"]}) == SourceLanguage.FR
+
+    def test_detect_german(self):
+        assert _detect_language({"language": ["de"]}) == SourceLanguage.DE
+
+    def test_default_to_english(self):
+        assert _detect_language({"language": []}) == SourceLanguage.EN
+
+    def test_unknown_language(self):
+        assert _detect_language({"language": ["zz"]}) == SourceLanguage.EN
+
+    def test_string_language(self):
+        assert _detect_language({"language": "nl"}) == SourceLanguage.NL
+
+
+class TestExtractLocation:
+    """Tests for _extract_location helper."""
+
+    def test_from_country(self):
+        assert _extract_location({"country": ["France"]}) == "France"
+
+    def test_from_place_label(self):
+        result = _extract_location({"edmPlaceLabelLangAware": {"en": ["Paris"]}})
+        assert result == "Paris"
+
+    def test_default_europe(self):
+        assert _extract_location({}) == "Europe"
+
+
+class TestParseYear:
+    """Tests for _parse_year helper."""
+
+    def test_parse_year(self):
+        assert _parse_year("1850") == "1850-01-01"
+
+    def test_parse_empty(self):
+        assert _parse_year("") is None
+
+    def test_parse_full_date(self):
+        assert _parse_year("1850-03-15") == "1850-01-01"


### PR DESCRIPTION
## Summary

Librarian ツールに Europeana Search API を統合し、欧州 27カ国・6,000万件以上の文化遺産資料（絵画、写本、地図、写真、書籍等）を検索可能にする。

- `mystery_agents/tools/europeana.py` 新規作成 — Europeana Search API v2 ツール（wskey 認証、レート制限、言語フィルタ、日付フィルタ対応）
- `SourceType.EUROPEANA` 追加、`EXPECTED_DOMAINS` / `_ARCHIVE_SOURCES` / `_LANGUAGE_FILTER_SOURCES` にレジストリ登録
- 欧州言語 Librarian (de/fr/nl/pt) の `sources_hint` と `cultural_context` に Europeana を追加
- ユニットテスト 20 件追加（全 594 テスト PASSED、回帰なし）

Closes #177

## Test plan

- [x] `pytest tests/unit/test_europeana.py -v` — 新規 20 テスト全 PASSED
- [x] `pytest tests/unit/ -v` — 全 594 テスト PASSED（回帰なし）
- [ ] API Key 取得後に手動統合テスト実行

🤖 Generated with [Claude Code](https://claude.com/claude-code)