### PR TITLE
refactor: バイリンガル展開削除 + 年代デフォルト修正 + 新聞ディスパッチャ化

### DIFF
--- a/mystery_agents/agents/language_librarians.py
+++ b/mystery_agents/agents/language_librarians.py
@@ -47,7 +47,12 @@ def _resolve_sources_hint(lang_code: str) -> str:
 #    - `sources` パラメータで関連アーカイブを指定: {sources_hint}
 #    - `language` パラメータを "{lang_code}" に設定して言語フィルタリングを行う
 #    - 例: keywords="Bell Witch, Adams Tennessee, poltergeist, haunting"
-# 3. {newspaper_instruction}
+#    - テーマが特定の時代を示唆する場合、`date_start` / `date_end` で年パラメータを設定する
+#      （例: date_start="1700", date_end="1800"）
+#    - デフォルト範囲は 1500-1899。テーマの歴史的文脈に応じて調整する
+# 3. 歴史的な新聞記事を検索するには **search_newspapers** を呼び出す
+#    - ツールは対象言語で利用可能な新聞ソースに自動ルーティングする
+#    - 対象言語の新聞ソースが存在しない場合、空の結果を返す（エラーではない）
 # 4. 各ツールは1回ずつ呼び出す。リトライ不要
 # 5. 資料が見つからなかった場合は NO_DOCUMENTS_FOUND を出力
 # === End 日本語訳 ===
@@ -77,6 +82,9 @@ Search digital archives for {language_name}-language primary sources related to 
    - Use the `sources` parameter to target relevant archives: {sources_hint}
    - Use the `language` parameter set to "{lang_code}" for language filtering
    - Example: keywords="Bell Witch, Adams Tennessee, poltergeist, haunting"
+   - If the theme suggests a specific time period, set `date_start` and `date_end` year parameters
+     (e.g., date_start="1700", date_end="1800")
+   - Default range is 1500-1899; adjust based on the historical context of the theme
 3. {newspaper_instruction}
 
 ## Output Format
@@ -102,6 +110,13 @@ Search theme: [theme]
 ```
 """
 
+# 全言語共通の新聞検索指示
+_NEWSPAPER_INSTRUCTION = (
+    "Call **search_newspapers** for historical newspaper articles.\n"
+    "   - The tool automatically routes to newspaper sources available for your language.\n"
+    "   - If no newspaper sources exist for your language, it returns an empty result (not an error)."
+)
+
 # 言語別設定
 LANGUAGE_CONFIGS = {
     "en": {
@@ -115,11 +130,7 @@ LANGUAGE_CONFIGS = {
             "- Europeana for English-language materials in European collections\n"
             "- English-speaking regions globally: British Isles, North America, Australia, India, etc."
         ),
-        "newspaper_instruction": (
-            "Also call **search_newspapers** for Chronicling America newspaper articles.\n"
-            "   - The tool handles bilingual expansion (English/Spanish) automatically"
-        ),
-        "has_newspaper_tool": True,
+        "newspaper_instruction": _NEWSPAPER_INSTRUCTION,
     },
     "de": {
         "language_name": "German",
@@ -132,8 +143,7 @@ LANGUAGE_CONFIGS = {
             "- German, Austrian, and Swiss historical records and archives\n"
             "- Church records, university archives, Germanic folklore collections"
         ),
-        "newspaper_instruction": "Do NOT call search_newspapers (it only searches English/Spanish newspapers).",
-        "has_newspaper_tool": False,
+        "newspaper_instruction": _NEWSPAPER_INSTRUCTION,
     },
     "es": {
         "language_name": "Spanish",
@@ -147,8 +157,7 @@ LANGUAGE_CONFIGS = {
             "- Europeana for Iberian cultural heritage materials\n"
             "- Mission records, colonial correspondence, Inquisition records"
         ),
-        "newspaper_instruction": "Do NOT call search_newspapers (the EN Librarian already handles bilingual newspaper search).",
-        "has_newspaper_tool": False,
+        "newspaper_instruction": _NEWSPAPER_INSTRUCTION,
     },
     "fr": {
         "language_name": "French",
@@ -162,8 +171,7 @@ LANGUAGE_CONFIGS = {
             "- Belgian and Swiss French-language archives\n"
             "- Revolutionary and Napoleonic era documents, Enlightenment texts"
         ),
-        "newspaper_instruction": "Do NOT call search_newspapers (it only searches English/Spanish newspapers).",
-        "has_newspaper_tool": False,
+        "newspaper_instruction": _NEWSPAPER_INSTRUCTION,
     },
     "nl": {
         "language_name": "Dutch",
@@ -177,8 +185,7 @@ LANGUAGE_CONFIGS = {
             "- Colonial records (Indonesia, Suriname, Caribbean, South Africa)\n"
             "- Maritime trade networks, cartography, Dutch Reformed Church records"
         ),
-        "newspaper_instruction": "Do NOT call search_newspapers (it only searches English/Spanish newspapers).",
-        "has_newspaper_tool": False,
+        "newspaper_instruction": _NEWSPAPER_INSTRUCTION,
     },
     "pt": {
         "language_name": "Portuguese",
@@ -192,8 +199,7 @@ LANGUAGE_CONFIGS = {
             "- Atlantic trade networks, colonial records (Brazil, Africa, Asia)\n"
             "- Lusophone Africa and Macau historical records"
         ),
-        "newspaper_instruction": "Do NOT call search_newspapers (it only searches English/Spanish newspapers).",
-        "has_newspaper_tool": False,
+        "newspaper_instruction": _NEWSPAPER_INSTRUCTION,
     },
 }
 
@@ -206,10 +212,7 @@ def create_librarian(lang_code: str) -> LlmAgent:
     sources_hint = _resolve_sources_hint(lang_code)
     instruction = _BASE_INSTRUCTION.format(sources_hint=sources_hint, **config)
 
-    if config.get("has_newspaper_tool"):
-        tools = [search_newspapers, search_archives, get_available_keywords]
-    else:
-        tools = [search_archives]
+    tools = [search_newspapers, search_archives, get_available_keywords]
 
     return LlmAgent(
         name=f"librarian_{lang_code}",

--- a/mystery_agents/tools/archive_source_base.py
+++ b/mystery_agents/tools/archive_source_base.py
@@ -71,7 +71,7 @@ class ArchiveSource(ABC):
     def search(
         self,
         keywords: list[str],
-        date_start: str = "1800",
+        date_start: str = "1500",
         date_end: str = "1899",
         max_results: int = 20,
         language: str | None = None,

--- a/mystery_agents/tools/dpla.py
+++ b/mystery_agents/tools/dpla.py
@@ -54,16 +54,18 @@ class DPLASource(ArchiveSource):
         if not search_text:
             return ArchiveSearchResult(error="No keywords provided")
 
-        start_year = date_start[:4] if len(date_start) >= 4 else date_start
-        end_year = date_end[:4] if len(date_end) >= 4 else date_end
-
         params = {
             "q": search_text,
             "api_key": api_key,
             "page_size": min(max_results, 100),
-            "sourceResource.date.after": start_year,
-            "sourceResource.date.before": end_year,
         }
+
+        # 空文字日付対応: 日付フィルタを条件付きに
+        if date_start and date_end:
+            start_year = date_start[:4] if len(date_start) >= 4 else date_start
+            end_year = date_end[:4] if len(date_end) >= 4 else date_end
+            params["sourceResource.date.after"] = start_year
+            params["sourceResource.date.before"] = end_year
 
         # 言語フィルタ
         if language and language in _DPLA_LANG_NAMES:

--- a/mystery_agents/tools/europeana.py
+++ b/mystery_agents/tools/europeana.py
@@ -63,14 +63,14 @@ class EuropeanaSource(ArchiveSource):
             "profile": "standard",
         }
 
-        # 日付フィルタ
-        qf_list: list[str] = [f"YEAR:[{date_start} TO {date_end}]"]
-
-        # 言語フィルタ
+        # 空文字日付対応: フィルタを条件付きに
+        qf_list: list[str] = []
+        if date_start and date_end:
+            qf_list.append(f"YEAR:[{date_start} TO {date_end}]")
         if language:
             qf_list.append(f"LANGUAGE:{language}")
-
-        params["qf"] = qf_list
+        if qf_list:
+            params["qf"] = qf_list
 
         headers = {
             "Accept": "application/json",

--- a/mystery_agents/tools/internet_archive.py
+++ b/mystery_agents/tools/internet_archive.py
@@ -50,10 +50,12 @@ class InternetArchiveSource(ArchiveSource):
         if not search_text:
             return ArchiveSearchResult(error="No keywords provided")
 
-        start_year = date_start[:4] if len(date_start) >= 4 else date_start
-        end_year = date_end[:4] if len(date_end) >= 4 else date_end
-
-        query = f"({search_text}) AND date:[{start_year}-01-01 TO {end_year}-12-31]"
+        # 空文字日付対応: 日付フィルタを条件付きに
+        query = f"({search_text})"
+        if date_start and date_end:
+            start_year = date_start[:4] if len(date_start) >= 4 else date_start
+            end_year = date_end[:4] if len(date_end) >= 4 else date_end
+            query += f" AND date:[{start_year}-01-01 TO {end_year}-12-31]"
 
         # 言語フィルタ
         if language and language in _LANG_CODE_MAP:

--- a/mystery_agents/tools/librarian_tools.py
+++ b/mystery_agents/tools/librarian_tools.py
@@ -19,7 +19,7 @@ from ..schemas.document import ArchiveDocument
 from .bilingual_search import KEYWORD_PAIRS, expand_keywords_bilingual
 from .chronicling_america import search_chronicling_america
 from .link_validator import ValidationSummary, validate_documents
-from .source_registry import get_all_sources, get_source
+from .source_registry import get_all_sources, get_source, resolve_newspaper_sources
 
 # 並列実行の最大ワーカー数
 _MAX_WORKERS = 6
@@ -30,34 +30,66 @@ _TOTAL_DOCS_CAP = 30
 
 def search_newspapers(
     keywords: str,
-    date_start: str = "1800",
+    date_start: str = "1500",
     date_end: str = "1899",
     states: Optional[str] = None,
     max_results: int = 20,
     min_results: int = 3,
+    language: Optional[str] = None,
     tool_context: Optional[ToolContext] = None,
 ) -> str:
-    """Search historical newspapers in Chronicling America with automatic fallback.
+    """Search historical newspapers with automatic routing to available sources.
 
-    Searches the Library of Congress Chronicling America database for
-    18th-19th century newspaper articles. Automatically expands keywords
-    to include both English and Spanish variants.
+    Routes to newspaper sources registered in the Source Registry based on
+    language. Currently supports Chronicling America (English). For unsupported
+    languages, returns an empty result (not an error).
 
-    If fewer than min_results documents are found, automatically applies
-    progressive fallback strategies: individual keyword search, geographic
-    expansion (all US states), and date range expansion (+/-10 years).
+    When a newspaper source is found, applies progressive fallback strategies:
+    individual keyword search, geographic expansion, and date range expansion.
 
     Args:
         keywords: Comma-separated list of search keywords related to historical mysteries
-        date_start: Start year (default: 1800)
+        date_start: Start year (default: 1500)
         date_end: End year (default: 1899)
         states: Comma-separated US states to search (default: East Coast states)
         max_results: Maximum number of results to return (default: 20)
         min_results: Minimum documents before stopping fallback (default: 3)
+        language: ISO 639-1 language code (default: "en")
 
     Returns:
         JSON string containing search results with documents matching the query
     """
+    # 言語のデフォルト
+    lang = language or "en"
+
+    # Registry から新聞ソースを解決
+    newspaper_sources = resolve_newspaper_sources(lang)
+    if not newspaper_sources:
+        # 該当言語の新聞ソースなし → 空結果を返す（エラーではない）
+        empty_result = {
+            "source": "none",
+            "keywords_used": [kw.strip() for kw in keywords.split(",") if kw.strip()],
+            "total_hits": 0,
+            "documents_returned": 0,
+            "documents": [],
+            "error": None,
+            "search_levels_used": [],
+            "link_validation": {
+                "total_checked": 0,
+                "reachable": 0,
+                "unreachable": 0,
+                "removed_count": 0,
+                "removed_urls": [],
+                "duration_ms": 0,
+            },
+        }
+        if tool_context is not None:
+            existing = tool_context.state.get("raw_search_results", [])
+            existing.append(empty_result)
+            tool_context.state["raw_search_results"] = existing
+        return json.dumps(empty_result, ensure_ascii=False, indent=2)
+
+    # --- Chronicling America フォールバックロジック ---
     # キーワードパース
     keyword_list = [kw.strip() for kw in keywords.split(",") if kw.strip()]
 
@@ -138,7 +170,7 @@ def search_newspapers(
 
     # Level 4: 日付範囲拡大（±10年）
     if len(all_docs) < min_results:
-        expanded_start = str(max(1700, int(date_start) - 10))
+        expanded_start = str(max(1400, int(date_start) - 10))
         expanded_end = str(min(1920, int(date_end) + 10))
         if expanded_start != date_start or expanded_end != date_end:
             logger.info(
@@ -342,7 +374,7 @@ def _rank_documents(
 
 def search_archives(
     keywords: str,
-    date_start: str = "1800",
+    date_start: str = "1500",
     date_end: str = "1899",
     sources: Optional[str] = None,
     max_results: int = 10,
@@ -355,33 +387,22 @@ def search_archives(
     Deutsche Digitale Bibliothek, and Europeana using ThreadPoolExecutor.
     Results are ranked by keyword match count and capped at a total limit.
 
-    When no language filter is specified, automatically expands keywords to
-    include both English and Spanish variants. When a language is specified,
-    keywords are passed as-is and the language filter is applied to APIs that
-    support it.
-
     Args:
         keywords: Comma-separated search keywords
-        date_start: Start year (default: 1800)
+        date_start: Start year (default: 1500)
         date_end: End year (default: 1899)
         sources: Comma-separated source names to search (default: all US sources).
                  Options: loc, dpla, nypl, internet_archive, ddb, europeana
         max_results: Max results per source (default: 10)
         language: Optional ISO 639-1 language code (en, de, fr, es, nl, pt).
-                  When specified, applies language filter to supported APIs
-                  and skips bilingual expansion.
+                  When specified, applies language filter to supported APIs.
 
     Returns:
         JSON string with merged results from all sources.
     """
     keyword_list = [kw.strip() for kw in keywords.split(",") if kw.strip()]
 
-    # 言語指定がある場合はバイリンガル展開をスキップ
-    if language:
-        keyword_groups = [keyword_list]
-    else:
-        expanded = expand_keywords_bilingual(keyword_list)
-        keyword_groups = [expanded["en"], expanded["es"]]
+    keyword_groups = [keyword_list]
 
     all_sources_map = get_all_sources()
 
@@ -536,8 +557,10 @@ def search_archives(
 def get_available_keywords() -> str:
     """Get the list of available bilingual keyword pairs.
 
-    Returns the predefined English-Spanish keyword pairs that can be
-    used for searching historical mysteries.
+    .. deprecated::
+        Bilingual keyword pairs are no longer used in the pipeline.
+        Each language Librarian generates keywords natively.
+        Retained for backward compatibility.
 
     Returns:
         JSON string containing keyword pairs

--- a/mystery_agents/tools/loc_digital.py
+++ b/mystery_agents/tools/loc_digital.py
@@ -42,17 +42,19 @@ class LOCDigitalSource(ArchiveSource):
         if not search_text:
             return ArchiveSearchResult(error="No keywords provided")
 
-        start_year = date_start[:4] if len(date_start) >= 4 else date_start
-        end_year = date_end[:4] if len(date_end) >= 4 else date_end
-
         params = {
             "q": search_text,
             "fa": "not:partof:chronicling america",
             "fo": "json",
             "c": min(max_results, 50),
             "sp": 1,
-            "dates": f"{start_year}/{end_year}",
         }
+
+        # 空文字日付対応: 日付フィルタを条件付きに
+        if date_start and date_end:
+            start_year = date_start[:4] if len(date_start) >= 4 else date_start
+            end_year = date_end[:4] if len(date_end) >= 4 else date_end
+            params["dates"] = f"{start_year}/{end_year}"
 
         response = self._session.get(
             BASE_URL,

--- a/mystery_agents/tools/nypl_digital.py
+++ b/mystery_agents/tools/nypl_digital.py
@@ -44,10 +44,13 @@ class NYPLSource(ArchiveSource):
         if not search_text:
             return ArchiveSearchResult(error="No keywords provided")
 
-        # 日付範囲をクエリに含める
-        start_year = date_start[:4] if len(date_start) >= 4 else date_start
-        end_year = date_end[:4] if len(date_end) >= 4 else date_end
-        search_text_with_date = f"{search_text} {start_year}-{end_year}"
+        # 空文字日付対応: 日付範囲をクエリに含めるのを条件付きに
+        if date_start and date_end:
+            start_year = date_start[:4] if len(date_start) >= 4 else date_start
+            end_year = date_end[:4] if len(date_end) >= 4 else date_end
+            search_text_with_date = f"{search_text} {start_year}-{end_year}"
+        else:
+            search_text_with_date = search_text
 
         params = {
             "q": search_text_with_date,

--- a/tests/unit/test_dpla.py
+++ b/tests/unit/test_dpla.py
@@ -1,0 +1,33 @@
+"""Unit tests for DPLA API tool."""
+
+from unittest.mock import patch
+
+import responses
+
+from mystery_agents.tools.dpla import (
+    BASE_URL,
+    DPLASource,
+)
+
+
+class TestEmptyDates:
+    """空文字日付のテスト。"""
+
+    @responses.activate
+    def test_empty_dates_omits_date_filter(self):
+        """date_start/date_end が空文字の場合、date パラメータが省略される。"""
+        mock_response = {
+            "count": 0,
+            "docs": [],
+        }
+        responses.add(responses.GET, BASE_URL, json=mock_response, status=200)
+
+        source = DPLASource()
+        with patch.dict("os.environ", {"DPLA_API_KEY": "test_key"}):
+            result = source.search(keywords=["test"], date_start="", date_end="")
+
+        request = responses.calls[0].request
+        # date.after / date.before パラメータが URL に含まれないことを確認
+        assert "date.after" not in request.url
+        assert "date.before" not in request.url
+        assert result.error is None

--- a/tests/unit/test_europeana.py
+++ b/tests/unit/test_europeana.py
@@ -188,6 +188,24 @@ class TestExtractLocation:
         assert _extract_location({}) == "Europe"
 
 
+class TestEmptyDates:
+    """空文字日付のテスト。"""
+
+    @responses.activate
+    def test_empty_dates_omits_date_filter(self):
+        """date_start/date_end が空文字の場合、YEAR フィルタが省略される。"""
+        mock_response = {"success": True, "totalResults": 0, "items": []}
+        responses.add(responses.GET, BASE_URL, json=mock_response, status=200)
+
+        source = EuropeanaSource()
+        with patch.dict("os.environ", {"EUROPEANA_API_KEY": "test_key"}):
+            source.search(keywords=["test"], date_start="", date_end="")
+
+        request = responses.calls[0].request
+        # YEAR フィルタが URL に含まれないことを確認
+        assert "YEAR" not in request.url
+
+
 class TestParseYear:
     """Tests for ArchiveSource.parse_year() (旧 _parse_year)。"""
 

--- a/tests/unit/test_internet_archive.py
+++ b/tests/unit/test_internet_archive.py
@@ -1,0 +1,31 @@
+"""Unit tests for Internet Archive API tool."""
+
+import responses
+
+from mystery_agents.tools.internet_archive import (
+    BASE_URL,
+    InternetArchiveSource,
+)
+
+
+class TestEmptyDates:
+    """空文字日付のテスト。"""
+
+    @responses.activate
+    def test_empty_dates_omits_date_filter(self):
+        """date_start/date_end が空文字の場合、date:[] 句がクエリに含まれない。"""
+        mock_response = {
+            "response": {
+                "numFound": 0,
+                "docs": [],
+            },
+        }
+        responses.add(responses.GET, BASE_URL, json=mock_response, status=200)
+
+        source = InternetArchiveSource()
+        result = source.search(keywords=["ghost"], date_start="", date_end="")
+
+        request = responses.calls[0].request
+        # date:[ フィルタが含まれないことを確認
+        assert "date%3A%5B" not in request.url and "date:[" not in request.url
+        assert result.error is None

--- a/tests/unit/test_librarian_tools.py
+++ b/tests/unit/test_librarian_tools.py
@@ -480,3 +480,142 @@ class TestSearchSingleSource:
         )
 
         assert len(docs) == 1
+
+
+# === PR 3: バイリンガル展開除去・デフォルト日付・新聞ディスパッチャのテスト ===
+
+
+class TestNoBilingualExpansion:
+    """search_archives がバイリンガル展開を行わないことを確認"""
+
+    @patch("mystery_agents.tools.librarian_tools.validate_documents")
+    @patch("mystery_agents.tools.librarian_tools.get_all_sources")
+    @patch("mystery_agents.tools.librarian_tools.expand_keywords_bilingual")
+    def test_search_archives_no_bilingual_expansion(
+        self, mock_expand, mock_get_all, mock_validate
+    ):
+        """search_archives は expand_keywords_bilingual を呼ばない。"""
+        mock_get_all.return_value = {
+            "loc": _make_mock_source(source_key="loc", docs=[], total_hits=0),
+        }
+        mock_validate.return_value = type("Summary", (), {
+            "total_checked": 0, "reachable": 0, "unreachable": 0,
+            "removed_urls": [], "duration_ms": 0, "verified_documents": [],
+        })()
+
+        search_archives(keywords="ghost, ship", sources="loc", language="en")
+
+        mock_expand.assert_not_called()
+
+
+class TestDefaultDates:
+    """デフォルト日付が 1500-1899 であることを確認"""
+
+    @patch("mystery_agents.tools.librarian_tools.validate_documents")
+    @patch("mystery_agents.tools.librarian_tools.get_all_sources")
+    def test_search_archives_default_dates_1500_1899(
+        self, mock_get_all, mock_validate
+    ):
+        """search_archives のデフォルト日付が 1500-1899 でソースに渡される。"""
+        call_log = []
+
+        class LogSource:
+            source_key = "loc"
+            source_name = "LOC"
+            supports_language_filter = False
+
+            def search(self, **kwargs):
+                call_log.append(kwargs)
+                return ArchiveSearchResult(documents=[], total_hits=0)
+
+        mock_get_all.return_value = {"loc": LogSource()}
+        mock_validate.return_value = type("Summary", (), {
+            "total_checked": 0, "reachable": 0, "unreachable": 0,
+            "removed_urls": [], "duration_ms": 0, "verified_documents": [],
+        })()
+
+        # date_start / date_end を明示しない → デフォルト値が使われる
+        search_archives(keywords="test", sources="loc", language="en")
+
+        assert len(call_log) == 1
+        assert call_log[0]["date_start"] == "1500"
+        assert call_log[0]["date_end"] == "1899"
+
+
+class TestNewspaperDispatcher:
+    """search_newspapers のディスパッチャ動作テスト"""
+
+    @patch("mystery_agents.tools.librarian_tools.validate_documents")
+    @patch("mystery_agents.tools.librarian_tools.search_chronicling_america")
+    @patch("mystery_agents.tools.librarian_tools.resolve_newspaper_sources")
+    def test_newspaper_dispatcher_en_uses_chronicling_america(
+        self, mock_resolve, mock_search_ca, mock_validate
+    ):
+        """EN → Chronicling America にルーティングされる。"""
+        mock_ca = type("CA", (), {
+            "source_key": "chronicling_america",
+            "is_newspaper_source": True,
+        })()
+        mock_resolve.return_value = [mock_ca]
+
+        doc = _make_doc()
+        mock_search_ca.return_value = {
+            "total_hits": 1,
+            "documents": [doc],
+            "error": None,
+        }
+        mock_validate.return_value = type("Summary", (), {
+            "total_checked": 1, "reachable": 1, "unreachable": 0,
+            "removed_urls": [], "duration_ms": 50,
+            "verified_documents": [doc],
+        })()
+
+        result_json = search_newspapers(keywords="ghost", language="en")
+        result = json.loads(result_json)
+
+        assert result["source"] == "chronicling_america"
+        assert result["documents_returned"] == 1
+        mock_search_ca.assert_called()
+
+    @patch("mystery_agents.tools.librarian_tools.resolve_newspaper_sources")
+    def test_newspaper_dispatcher_unsupported_lang_returns_empty(
+        self, mock_resolve
+    ):
+        """新聞ソースが存在しない言語 → 空結果を返す（エラーではない）。"""
+        mock_resolve.return_value = []
+
+        result_json = search_newspapers(keywords="Geist", language="de")
+        result = json.loads(result_json)
+
+        assert result["source"] == "none"
+        assert result["documents_returned"] == 0
+        assert result["error"] is None
+        assert result["total_hits"] == 0
+
+    @patch("mystery_agents.tools.librarian_tools.validate_documents")
+    @patch("mystery_agents.tools.librarian_tools.search_chronicling_america")
+    @patch("mystery_agents.tools.librarian_tools.resolve_newspaper_sources")
+    def test_newspaper_dispatcher_default_language_is_en(
+        self, mock_resolve, mock_search_ca, mock_validate
+    ):
+        """language 未指定 → "en" として処理される。"""
+        mock_ca = type("CA", (), {
+            "source_key": "chronicling_america",
+            "is_newspaper_source": True,
+        })()
+        mock_resolve.return_value = [mock_ca]
+
+        mock_search_ca.return_value = {
+            "total_hits": 0,
+            "documents": [],
+            "error": None,
+        }
+        mock_validate.return_value = type("Summary", (), {
+            "total_checked": 0, "reachable": 0, "unreachable": 0,
+            "removed_urls": [], "duration_ms": 0, "verified_documents": [],
+        })()
+
+        search_newspapers(keywords="test")
+
+        # language 未指定でも resolve_newspaper_sources("en") が呼ばれる
+        mock_resolve.assert_called_once_with("en")

--- a/tests/unit/test_loc_digital.py
+++ b/tests/unit/test_loc_digital.py
@@ -1,0 +1,31 @@
+"""Unit tests for LOC Digital Collections API tool."""
+
+from unittest.mock import patch
+
+import responses
+
+from mystery_agents.tools.loc_digital import (
+    BASE_URL,
+    LOCDigitalSource,
+)
+
+
+class TestEmptyDates:
+    """空文字日付のテスト。"""
+
+    @responses.activate
+    def test_empty_dates_omits_date_filter(self):
+        """date_start/date_end が空文字の場合、dates パラメータが省略される。"""
+        mock_response = {
+            "results": [],
+            "pagination": {"total": 0},
+        }
+        responses.add(responses.GET, BASE_URL, json=mock_response, status=200)
+
+        source = LOCDigitalSource()
+        result = source.search(keywords=["test"], date_start="", date_end="")
+
+        request = responses.calls[0].request
+        # dates パラメータが URL に含まれないことを確認
+        assert "dates=" not in request.url
+        assert result.error is None

--- a/tests/unit/test_nypl_digital.py
+++ b/tests/unit/test_nypl_digital.py
@@ -1,0 +1,38 @@
+"""Unit tests for NYPL Digital Collections API tool."""
+
+from unittest.mock import patch
+
+import responses
+
+from mystery_agents.tools.nypl_digital import (
+    BASE_URL,
+    NYPLSource,
+)
+
+
+class TestEmptyDates:
+    """空文字日付のテスト。"""
+
+    @responses.activate
+    def test_empty_dates_omits_date_filter(self):
+        """date_start/date_end が空文字の場合、日付範囲がクエリに付加されない。"""
+        mock_response = {
+            "nyplAPI": {
+                "response": {
+                    "numResults": "0",
+                    "result": [],
+                },
+            },
+        }
+        responses.add(responses.GET, BASE_URL, json=mock_response, status=200)
+
+        source = NYPLSource()
+        with patch.dict("os.environ", {"NYPL_API_TOKEN": "test_token"}):
+            result = source.search(keywords=["ghost"], date_start="", date_end="")
+
+        request = responses.calls[0].request
+        # クエリに年範囲が付加されず、キーワードのみ
+        # "ghost" は含まれるが "1500-1899" のような日付範囲は含まれない
+        assert "ghost" in request.url
+        assert "1500" not in request.url
+        assert result.error is None


### PR DESCRIPTION
## Summary

Issue #186（Librarian ツール層アーキテクチャ改修）の最終 PR（PR 3/3）。

- `search_archives` から EN/ES バイリンガル展開を除去（各言語 Librarian が母語でキーワード生成するため不要に）
- デフォルト年代範囲を 1800-1899 → 1500-1899 に変更（大航海時代以降をカバー）
- `search_newspapers` を汎用ディスパッチャ化（Source Registry で新聞ソースを動的ルーティング、未対応言語は空結果）
- 5 つの API ツールに空文字日付ガードを追加（LOC, DPLA, NYPL, Internet Archive, Europeana）
- 全言語 Librarian に `search_newspapers` を提供 + instruction 統一

Closes #186

## 変更ファイル

| ファイル | 変更内容 |
|----------|----------|
| `mystery_agents/tools/librarian_tools.py` | バイリンガル展開除去 + デフォルト 1500 + 新聞ディスパッチャ |
| `mystery_agents/tools/archive_source_base.py` | `search()` デフォルト `date_start="1500"` |
| `mystery_agents/tools/loc_digital.py` | 空文字日付チェック追加 |
| `mystery_agents/tools/dpla.py` | 同上 |
| `mystery_agents/tools/nypl_digital.py` | 同上 |
| `mystery_agents/tools/internet_archive.py` | 同上 |
| `mystery_agents/tools/europeana.py` | 同上 |
| `mystery_agents/agents/language_librarians.py` | 全 Librarian に search_newspapers + instruction 更新 |
| `tests/unit/test_librarian_tools.py` | 新テスト 5 件追加 |
| `tests/unit/test_loc_digital.py` | 新規: 空文字日付テスト |
| `tests/unit/test_dpla.py` | 新規: 空文字日付テスト |
| `tests/unit/test_nypl_digital.py` | 新規: 空文字日付テスト |
| `tests/unit/test_internet_archive.py` | 新規: 空文字日付テスト |
| `tests/unit/test_europeana.py` | 空文字日付テスト追加 |

## 関連 Issue

- #199: API 年代範囲ガード（フォローアップ Issue として作成済み）

## Test plan

- [x] 全 689 ユニットテスト通過
- [x] 新規テスト 10 件追加（バイリンガル除去、デフォルト日付、ディスパッチャ、空文字日付 ×5）
- [ ] 既存テストへの影響なし（デフォルト値変更は明示指定テストに影響しない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)