### PR TITLE
feat: Trove API（オーストラリア国立図書館）統合

### DIFF
--- a/mystery_agents/schemas/document.py
+++ b/mystery_agents/schemas/document.py
@@ -29,6 +29,7 @@ class SourceType(str, Enum):
     INTERNET_ARCHIVE = "internet_archive"
     DDB = "ddb"
     EUROPEANA = "europeana"
+    TROVE = "trove"
 
 
 class ArchiveDocument(BaseModel):

--- a/mystery_agents/tools/source_registry.py
+++ b/mystery_agents/tools/source_registry.py
@@ -31,6 +31,7 @@ _SOURCE_MODULES = [
     "mystery_agents.tools.ddb",
     "mystery_agents.tools.europeana",
     "mystery_agents.tools.chronicling_america",
+    "mystery_agents.tools.trove",
 ]
 
 

--- a/mystery_agents/tools/trove.py
+++ b/mystery_agents/tools/trove.py
@@ -1,0 +1,134 @@
+"""Trove API ソース（National Library of Australia）。
+
+オーストラリア国立図書館の Trove API v3 を使用して
+1803年以降の新聞 OCR 全文検索を行う。
+"""
+
+import os
+from typing import Any
+
+from ..schemas.document import ArchiveDocument, SourceLanguage
+from .archive_source_base import ArchiveSearchResult, ArchiveSource
+from .search_utils import build_search_query
+from .source_registry import register_source
+
+BASE_URL = "https://api.trove.nla.gov.au/v3/result"
+
+
+class TroveSource(ArchiveSource):
+    """Trove（オーストラリア国立図書館）ソース。"""
+
+    source_key = "trove"
+    source_name = "Trove (National Library of Australia)"
+    source_type = "trove"
+    min_request_delay = 0.5  # 200req/min → 余裕を持って 0.5s
+    supported_languages = {"en"}
+    supports_language_filter = False
+    is_newspaper_source = True
+    expected_domains = ["trove.nla.gov.au", "nla.gov.au"]
+    env_var_key = "TROVE_API_KEY"
+
+    def _search_impl(
+        self,
+        keywords: list[str],
+        date_start: str,
+        date_end: str,
+        max_results: int,
+        language: str | None,
+    ) -> ArchiveSearchResult:
+        api_key = os.environ.get("TROVE_API_KEY", "")
+
+        search_text = build_search_query(keywords)
+        if not search_text:
+            return ArchiveSearchResult(error="No keywords provided")
+
+        params: dict[str, Any] = {
+            "key": api_key,
+            "category": "newspaper",
+            "q": search_text,
+            "encoding": "json",
+            "n": min(max_results, 100),
+            "s": "*",
+            "sortby": "relevance",
+            "include": "articletext",
+        }
+
+        # decade フィルタ（年代絞り込み）
+        if date_start and date_end:
+            start_decade = int(date_start[:4]) // 10
+            end_decade = int(date_end[:4]) // 10
+            if start_decade == end_decade:
+                params["l-decade"] = start_decade * 10
+            # 複数 decade にまたがる場合はフィルタなし（API は単一 decade のみ）
+
+        headers = {
+            "Accept": "application/json",
+            "User-Agent": "GhostInTheArchive/1.0",
+        }
+
+        response = self._session.get(
+            BASE_URL,
+            params=params,
+            headers=headers,
+            timeout=30,
+        )
+        response.raise_for_status()
+        data = response.json()
+
+        documents = []
+        # Trove v3 レスポンス構造: category[0].records.article
+        categories = data.get("category", [])
+        articles = []
+        if categories:
+            records = categories[0].get("records", {})
+            articles = records.get("article", [])
+
+        for article in articles:
+            title = article.get("heading", "Unknown Title")
+            date_str = article.get("date", "")
+            trove_url = article.get("troveUrl", "")
+            if not trove_url:
+                continue
+
+            # OCR 全文 or スニペット
+            article_text = article.get("articleText", "")
+            snippet = article.get("snippet", "")
+            summary_text = snippet or (article_text[:500] if article_text else title)
+
+            # 新聞タイトルから場所のヒント
+            newspaper_title = article.get("title", {})
+            if isinstance(newspaper_title, dict):
+                location = newspaper_title.get("value", "Australia")
+            elif isinstance(newspaper_title, str):
+                location = newspaper_title
+            else:
+                location = "Australia"
+
+            # キーワードマッチ
+            combined = f"{title} {summary_text}".lower()
+            matched = [kw for kw in keywords if kw.lower() in combined]
+
+            doc = ArchiveDocument(
+                title=str(title)[:500],
+                date=self.parse_year(str(date_str), min_century=18),
+                source_url=trove_url,
+                summary=str(summary_text)[:500],
+                language=SourceLanguage.EN,
+                location=str(location)[:200],
+                source_type=self.source_type,
+                raw_text=article_text[:5000] if article_text else None,
+                keywords_matched=matched,
+            )
+            documents.append(doc)
+
+        total_hits = 0
+        if categories:
+            records = categories[0].get("records", {})
+            total_hits = records.get("total", len(documents))
+
+        return ArchiveSearchResult(documents=documents, total_hits=total_hits)
+
+
+# レジストリに自動登録
+_instance = TroveSource()
+register_source(_instance)

--- a/tests/unit/test_trove.py
+++ b/tests/unit/test_trove.py
@@ -1,0 +1,147 @@
+"""Unit tests for Trove API tool."""
+
+from unittest.mock import patch
+
+import responses
+
+from mystery_agents.tools.trove import BASE_URL, TroveSource
+
+
+class TestSearchTrove:
+    """Tests for TroveSource.search()."""
+
+    def test_missing_api_key(self):
+        """TROVE_API_KEY 未設定時はエラーを返す。"""
+        source = TroveSource()
+        with patch.dict("os.environ", {}, clear=True):
+            result = source.search(keywords=["test"])
+        assert result.error == "TROVE_API_KEY not set"
+        assert result.documents == []
+
+    def test_empty_keywords(self):
+        """空のキーワードリストでエラーを返す。"""
+        source = TroveSource()
+        with patch.dict("os.environ", {"TROVE_API_KEY": "test_key"}):
+            result = source.search(keywords=[])
+        assert result.error == "No keywords provided"
+
+    @responses.activate
+    def test_successful_search(self):
+        """正常なレスポンスでドキュメントを返す。"""
+        mock_response = {
+            "category": [
+                {
+                    "code": "newspaper",
+                    "records": {
+                        "total": 1,
+                        "article": [
+                            {
+                                "heading": "Convict Ship Wrecked off Coast",
+                                "date": "1852-03-15",
+                                "troveUrl": "https://trove.nla.gov.au/newspaper/article/123",
+                                "snippet": "A convict transport ship was wrecked...",
+                                "title": {"value": "The Sydney Morning Herald"},
+                            }
+                        ],
+                    },
+                }
+            ]
+        }
+        responses.add(responses.GET, BASE_URL, json=mock_response, status=200)
+
+        source = TroveSource()
+        with patch.dict("os.environ", {"TROVE_API_KEY": "test_key"}):
+            result = source.search(keywords=["convict", "shipwreck"])
+
+        assert result.total_hits == 1
+        assert len(result.documents) == 1
+        doc = result.documents[0]
+        assert doc.title == "Convict Ship Wrecked off Coast"
+        assert doc.source_type == "trove"
+        assert "trove.nla.gov.au" in doc.source_url
+
+    @responses.activate
+    def test_newspaper_article_with_ocr(self):
+        """articleText 付きレスポンスで raw_text を抽出する。"""
+        mock_response = {
+            "category": [
+                {
+                    "code": "newspaper",
+                    "records": {
+                        "total": 1,
+                        "article": [
+                            {
+                                "heading": "Ghost Sighting in Melbourne",
+                                "date": "1880",
+                                "troveUrl": "https://trove.nla.gov.au/newspaper/article/456",
+                                "articleText": "Full OCR text of the ghost sighting article...",
+                                "title": {"value": "The Age"},
+                            }
+                        ],
+                    },
+                }
+            ]
+        }
+        responses.add(responses.GET, BASE_URL, json=mock_response, status=200)
+
+        source = TroveSource()
+        with patch.dict("os.environ", {"TROVE_API_KEY": "test_key"}):
+            result = source.search(keywords=["ghost"])
+
+        assert len(result.documents) == 1
+        doc = result.documents[0]
+        assert doc.raw_text == "Full OCR text of the ghost sighting article..."
+        assert doc.location == "The Age"
+
+    @responses.activate
+    def test_date_filter(self):
+        """同一 decade の場合、l-decade フィルタがリクエストに含まれる。"""
+        mock_response = {"category": [{"code": "newspaper", "records": {"total": 0, "article": []}}]}
+        responses.add(responses.GET, BASE_URL, json=mock_response, status=200)
+
+        source = TroveSource()
+        with patch.dict("os.environ", {"TROVE_API_KEY": "test_key"}):
+            source.search(keywords=["test"], date_start="1850", date_end="1859")
+
+        request = responses.calls[0].request
+        assert "l-decade=1850" in request.url
+
+    @responses.activate
+    def test_api_error_handling(self):
+        """API エラー時はエラーメッセージを返す。"""
+        responses.add(responses.GET, BASE_URL, json={"error": "forbidden"}, status=403)
+
+        source = TroveSource()
+        with patch.dict("os.environ", {"TROVE_API_KEY": "bad_key"}):
+            result = source.search(keywords=["test"])
+
+        assert result.error is not None
+        assert "API error" in result.error
+        assert result.documents == []
+
+    @responses.activate
+    def test_empty_results(self):
+        """結果が0件の場合。"""
+        mock_response = {"category": [{"code": "newspaper", "records": {"total": 0, "article": []}}]}
+        responses.add(responses.GET, BASE_URL, json=mock_response, status=200)
+
+        source = TroveSource()
+        with patch.dict("os.environ", {"TROVE_API_KEY": "test_key"}):
+            result = source.search(keywords=["nonexistent"])
+
+        assert result.total_hits == 0
+        assert result.documents == []
+        assert result.error is None
+
+    @responses.activate
+    def test_api_key_parameter(self):
+        """key パラメータがリクエストに含まれることを確認。"""
+        mock_response = {"category": [{"code": "newspaper", "records": {"total": 0, "article": []}}]}
+        responses.add(responses.GET, BASE_URL, json=mock_response, status=200)
+
+        source = TroveSource()
+        with patch.dict("os.environ", {"TROVE_API_KEY": "my_secret_key"}):
+            source.search(keywords=["test"])
+
+        request = responses.calls[0].request
+        assert "key=my_secret_key" in request.url


### PR DESCRIPTION
## Summary

- TroveSource 新規実装（ArchiveSource パターン準拠）
  - Trove API v3 の新聞カテゴリ OCR 全文検索（1803年以降のオーストラリア新聞）
  - decade フィルタによる年代絞り込み
  - articleText からの raw_text 抽出対応
- SourceType enum に `TROVE` 追加
- source_registry にモジュール登録（1行追加）
- ユニットテスト 8 ケース追加（全 PASSED、既存 697 テストにも影響なし）

Closes #179

## 変更ファイル

| ファイル | 操作 | 内容 |
|---|---|---|
| `mystery_agents/tools/trove.py` | 新規 | TroveSource 実装 |
| `mystery_agents/tools/source_registry.py` | 編集 | モジュール追加（1行） |
| `mystery_agents/schemas/document.py` | 編集 | SourceType に TROVE 追加（1行） |
| `tests/unit/test_trove.py` | 新規 | ユニットテスト 8 ケース |

## Test plan

- [x] `pytest tests/unit/test_trove.py -v` — 8/8 PASSED
- [x] `pytest tests/unit/ -v` — 697/697 PASSED（既存テスト影響なし）
- [ ] `TROVE_API_KEY=<key>` で実 API 手動確認（オプション）

🤖 Generated with [Claude Code](https://claude.com/claude-code)