### PR TITLE
feat: KB/Delpher API 実装（オランダ国立図書館 SRU 統合）

### DIFF
--- a/mystery_agents/agents/language_librarians.py
+++ b/mystery_agents/agents/language_librarians.py
@@ -178,6 +178,7 @@ LANGUAGE_CONFIGS = {
         "lang_code": "nl",
         "cultural_context": (
             "Search Dutch-language archives for the Dutch-speaking world:\n"
+            "- **KB/Delpher** for digitized Dutch historical newspapers (1618-1879, CC0)\n"
             "- Europeana for pan-European cultural heritage materials in Dutch\n"
             "- Internet Archive for digitized Dutch-language materials\n"
             "- Dutch national archives and Flemish/Belgian collections\n"

--- a/mystery_agents/schemas/document.py
+++ b/mystery_agents/schemas/document.py
@@ -30,6 +30,7 @@ class SourceType(str, Enum):
     DDB = "ddb"
     EUROPEANA = "europeana"
     TROVE = "trove"
+    DELPHER = "delpher"
 
 
 class ArchiveDocument(BaseModel):

--- a/mystery_agents/tools/delpher.py
+++ b/mystery_agents/tools/delpher.py
@@ -1,0 +1,169 @@
+"""KB/Delpher API ソース（Koninklijke Bibliotheek / オランダ国立図書館）。
+
+SRU v1.2 プロトコルでオランダ語の歴史的新聞・書籍（1618年〜）を検索する。
+認証不要（API キー不要）。レスポンスは Dublin Core XML。
+"""
+
+import logging
+import xml.etree.ElementTree as ET
+
+from ..schemas.document import ArchiveDocument, SourceLanguage
+from .archive_source_base import ArchiveSearchResult, ArchiveSource
+from .search_utils import build_search_query
+from .source_registry import register_source
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://jsru.kb.nl/sru/sru"
+
+# SRU / Dublin Core 名前空間
+NS = {
+    "srw": "http://www.loc.gov/zing/srw/",
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "diag": "http://www.loc.gov/zing/srw/diagnostic/",
+}
+
+
+def _get_dc_text(record_data: ET.Element, tag: str) -> str:
+    """Dublin Core 要素のテキストを取得するヘルパー。
+
+    Args:
+        record_data: recordData 要素
+        tag: DC 要素名（例: "title", "date"）
+
+    Returns:
+        要素のテキスト。見つからない場合は空文字列。
+    """
+    elem = record_data.find(f"dc:{tag}", NS)
+    if elem is not None and elem.text:
+        return elem.text.strip()
+    return ""
+
+
+def _parse_sru_response(
+    xml_text: str, keywords: list[str]
+) -> ArchiveSearchResult:
+    """SRU XML レスポンスをパースして ArchiveSearchResult を返す。
+
+    Args:
+        xml_text: SRU レスポンスの XML 文字列
+        keywords: マッチ検出用のキーワードリスト
+
+    Returns:
+        パース済みの ArchiveSearchResult
+    """
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError as e:
+        logger.warning("Delpher SRU XML パースエラー: %s", e)
+        return ArchiveSearchResult(error=f"XML parse error: {e}")
+
+    # 総ヒット数
+    num_records_elem = root.find(".//srw:numberOfRecords", NS)
+    total_hits = int(num_records_elem.text) if num_records_elem is not None and num_records_elem.text else 0
+
+    documents = []
+    for record in root.findall(".//srw:record", NS):
+        data = record.find("srw:recordData", NS)
+        if data is None:
+            continue
+
+        # identifier（URL）がないレコードはスキップ
+        identifier = _get_dc_text(data, "identifier")
+        if not identifier:
+            continue
+
+        title = _get_dc_text(data, "title") or "Unknown Title"
+        date_str = _get_dc_text(data, "date")
+        description = _get_dc_text(data, "description")
+        publisher = _get_dc_text(data, "publisher")
+        source = _get_dc_text(data, "source")
+
+        # 場所のヒント: publisher or source
+        location = publisher or source or "Netherlands"
+
+        # サマリー: description があればそれを使う、なければ title
+        summary_text = description or title
+
+        # キーワードマッチ
+        combined = f"{title} {description}".lower()
+        matched = [kw for kw in keywords if kw.lower() in combined]
+
+        # 日付パース（"YYYY/MM/DD HH:MM:SS" 形式 → "YYYY-01-01"）
+        parsed_date = None
+        if date_str:
+            # "YYYY/MM/DD ..." → YYYY 部分を抽出
+            year_part = date_str.split("/")[0] if "/" in date_str else date_str
+            parsed_date = ArchiveSource.parse_year(year_part, min_century=16)
+
+        doc = ArchiveDocument(
+            title=str(title)[:500],
+            date=parsed_date,
+            source_url=identifier,
+            summary=str(summary_text)[:500],
+            language=SourceLanguage.NL,
+            location=str(location)[:200],
+            source_type="delpher",
+            raw_text=str(description)[:5000] if description else None,
+            keywords_matched=matched,
+        )
+        documents.append(doc)
+
+    return ArchiveSearchResult(documents=documents, total_hits=total_hits)
+
+
+class DelpherSource(ArchiveSource):
+    """KB/Delpher（オランダ国立図書館）ソース。"""
+
+    source_key = "delpher"
+    source_name = "KB/Delpher (Koninklijke Bibliotheek)"
+    source_type = "delpher"
+    min_request_delay = 2.0  # 公開 API への配慮
+    supported_languages = {"nl"}
+    supports_language_filter = False
+    is_newspaper_source = False
+    expected_domains = ["kb.nl", "delpher.nl", "resolver.kb.nl"]
+    env_var_key = None  # 認証不要
+
+    def _search_impl(
+        self,
+        keywords: list[str],
+        date_start: str,
+        date_end: str,
+        max_results: int,
+        language: str | None,
+    ) -> ArchiveSearchResult:
+        search_text = build_search_query(keywords)
+        if not search_text:
+            return ArchiveSearchResult(error="No keywords provided")
+
+        # CQL クエリ構築
+        query = search_text
+
+        params = {
+            "operation": "searchRetrieve",
+            "version": "1.2",
+            "query": query,
+            "maximumRecords": min(max_results, 100),
+            "recordSchema": "dc",
+        }
+
+        headers = {
+            "Accept": "application/xml",
+            "User-Agent": "GhostInTheArchive/1.0",
+        }
+
+        response = self._session.get(
+            BASE_URL,
+            params=params,
+            headers=headers,
+            timeout=30,
+        )
+        response.raise_for_status()
+
+        return _parse_sru_response(response.text, keywords)
+
+
+# レジストリに自動登録
+_instance = DelpherSource()
+register_source(_instance)

--- a/mystery_agents/tools/source_registry.py
+++ b/mystery_agents/tools/source_registry.py
@@ -32,6 +32,7 @@ _SOURCE_MODULES = [
     "mystery_agents.tools.europeana",
     "mystery_agents.tools.chronicling_america",
     "mystery_agents.tools.trove",
+    "mystery_agents.tools.delpher",
 ]
 
 

--- a/tests/unit/test_delpher.py
+++ b/tests/unit/test_delpher.py
@@ -1,0 +1,206 @@
+"""Unit tests for KB/Delpher SRU API tool."""
+
+import responses
+
+from mystery_agents.schemas.document import SourceLanguage
+from mystery_agents.tools.delpher import (
+    BASE_URL,
+    DelpherSource,
+    _parse_sru_response,
+)
+
+# モック SRU XML レスポンス
+MOCK_SRU_RESPONSE = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<srw:searchRetrieveResponse xmlns:srw="http://www.loc.gov/zing/srw/"
+    xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <srw:version>1.2</srw:version>
+  <srw:numberOfRecords>2</srw:numberOfRecords>
+  <srw:records>
+    <srw:record>
+      <srw:recordData>
+        <dc:title>Het spookhuis te Amsterdam</dc:title>
+        <dc:date>1842/03/15 00:00:00</dc:date>
+        <dc:identifier>http://resolver.kb.nl/resolve?urn=ddd:010097857:mpeg21:a0001</dc:identifier>
+        <dc:description>Een mysterieus verhaal over het spookhuis</dc:description>
+        <dc:publisher>De Tijd</dc:publisher>
+        <dc:language>dut</dc:language>
+        <dc:type>Text</dc:type>
+      </srw:recordData>
+    </srw:record>
+    <srw:record>
+      <srw:recordData>
+        <dc:title>Vliegende Hollander gezien</dc:title>
+        <dc:date>1756/08/20 00:00:00</dc:date>
+        <dc:identifier>http://resolver.kb.nl/resolve?urn=ddd:010054321:mpeg21:a0002</dc:identifier>
+        <dc:description>Bericht over de Vliegende Hollander</dc:description>
+        <dc:source>Opregte Haarlemsche Courant</dc:source>
+        <dc:language>dut</dc:language>
+        <dc:type>Text</dc:type>
+      </srw:recordData>
+    </srw:record>
+  </srw:records>
+</srw:searchRetrieveResponse>"""
+
+MOCK_EMPTY_RESPONSE = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<srw:searchRetrieveResponse xmlns:srw="http://www.loc.gov/zing/srw/">
+  <srw:version>1.2</srw:version>
+  <srw:numberOfRecords>0</srw:numberOfRecords>
+</srw:searchRetrieveResponse>"""
+
+
+class TestDelpherSource:
+    """Tests for DelpherSource."""
+
+    def test_no_api_key_required(self):
+        """env_var_key が None であることを確認（認証不要）。"""
+        source = DelpherSource()
+        assert source.env_var_key is None
+
+    def test_source_metadata(self):
+        """ソースメタデータの基本確認。"""
+        source = DelpherSource()
+        assert source.source_key == "delpher"
+        assert source.supported_languages == {"nl"}
+        assert source.is_newspaper_source is False
+        assert source.min_request_delay == 2.0
+
+    @responses.activate
+    def test_successful_search(self):
+        """正常な XML レスポンスで ArchiveDocument に変換する。"""
+        responses.add(
+            responses.GET,
+            BASE_URL,
+            body=MOCK_SRU_RESPONSE,
+            content_type="application/xml",
+            status=200,
+        )
+
+        source = DelpherSource()
+        result = source.search(keywords=["spookhuis", "Amsterdam"])
+
+        assert result.error is None
+        assert result.total_hits == 2
+        assert len(result.documents) == 2
+
+        doc = result.documents[0]
+        assert doc.title == "Het spookhuis te Amsterdam"
+        assert doc.language == SourceLanguage.NL
+        assert doc.source_type == "delpher"
+        assert "resolver.kb.nl" in doc.source_url
+        assert doc.date == "1842-01-01"
+        assert doc.location == "De Tijd"
+        assert doc.summary == "Een mysterieus verhaal over het spookhuis"
+
+        # 2件目: publisher がない場合 source フィールドを location に使用
+        doc2 = result.documents[1]
+        assert doc2.location == "Opregte Haarlemsche Courant"
+
+    @responses.activate
+    def test_empty_results(self):
+        """0件レスポンスの場合。"""
+        responses.add(
+            responses.GET,
+            BASE_URL,
+            body=MOCK_EMPTY_RESPONSE,
+            content_type="application/xml",
+            status=200,
+        )
+
+        source = DelpherSource()
+        result = source.search(keywords=["nonexistent"])
+
+        assert result.total_hits == 0
+        assert result.documents == []
+        assert result.error is None
+
+    @responses.activate
+    def test_api_error_handling(self):
+        """500 エラー時はエラーメッセージを返す。"""
+        responses.add(
+            responses.GET,
+            BASE_URL,
+            body="Internal Server Error",
+            status=500,
+        )
+
+        source = DelpherSource()
+        result = source.search(keywords=["test"])
+
+        assert result.error is not None
+        assert "API error" in result.error
+        assert result.documents == []
+
+    @responses.activate
+    def test_sru_parameters(self):
+        """SRU パラメータが正しくリクエストに含まれる。"""
+        responses.add(
+            responses.GET,
+            BASE_URL,
+            body=MOCK_EMPTY_RESPONSE,
+            content_type="application/xml",
+            status=200,
+        )
+
+        source = DelpherSource()
+        source.search(keywords=["spook"])
+
+        request = responses.calls[0].request
+        assert "operation=searchRetrieve" in request.url
+        assert "version=1.2" in request.url
+        assert "recordSchema=dc" in request.url
+        assert "spook" in request.url
+
+    def test_keyword_matching(self):
+        """keywords_matched が正しく検出される。"""
+        result = _parse_sru_response(
+            MOCK_SRU_RESPONSE, keywords=["spookhuis", "Hollander"]
+        )
+
+        # 1件目: "spookhuis" がタイトル・説明に含まれる
+        assert "spookhuis" in result.documents[0].keywords_matched
+        # 2件目: "Hollander" がタイトル・説明に含まれる
+        assert "Hollander" in result.documents[1].keywords_matched
+
+    def test_parse_invalid_xml(self):
+        """不正 XML のエラーハンドリング。"""
+        result = _parse_sru_response("<invalid>xml", keywords=["test"])
+        assert result.error is not None
+        assert "XML parse error" in result.error
+
+    def test_record_without_identifier_skipped(self):
+        """identifier（URL）がないレコードはスキップされる。"""
+        xml_no_identifier = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<srw:searchRetrieveResponse xmlns:srw="http://www.loc.gov/zing/srw/"
+    xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <srw:numberOfRecords>1</srw:numberOfRecords>
+  <srw:records>
+    <srw:record>
+      <srw:recordData>
+        <dc:title>Record without URL</dc:title>
+        <dc:date>1800/01/01 00:00:00</dc:date>
+        <dc:language>dut</dc:language>
+      </srw:recordData>
+    </srw:record>
+  </srw:records>
+</srw:searchRetrieveResponse>"""
+
+        result = _parse_sru_response(xml_no_identifier, keywords=["test"])
+        assert result.total_hits == 1  # サーバーは1件と報告
+        assert len(result.documents) == 0  # identifier なしでスキップ
+
+    def test_empty_keywords_returns_error(self):
+        """空のキーワードでエラーを返す。"""
+        source = DelpherSource()
+        result = source.search(keywords=[])
+        assert result.error == "No keywords provided"
+
+    def test_date_parsing(self):
+        """SRU の日付フォーマット（YYYY/MM/DD HH:MM:SS）が正しくパースされる。"""
+        result = _parse_sru_response(MOCK_SRU_RESPONSE, keywords=[])
+        # "1842/03/15 00:00:00" → "1842-01-01"
+        assert result.documents[0].date == "1842-01-01"
+        # "1756/08/20 00:00:00" → "1756-01-01"
+        assert result.documents[1].date == "1756-01-01"


### PR DESCRIPTION
## Summary

Closes #180

オランダ国立図書館（Koninklijke Bibliotheek）の SRU v1.2 API を Librarian エージェントに統合し、1618年以降のオランダ語歴史的新聞・書籍を検索可能にする。

- `DelpherSource(ArchiveSource)` 新規作成 — SRU XML（Dublin Core）パーサー付き
- 認証不要（API キー不要、CC0 ライセンス）
- `SourceType` enum に `DELPHER` 追加
- Source Registry にモジュール登録（`resolve_sources("nl")` で自動解決）
- NL Librarian の `cultural_context` に KB/Delpher 記述追加
- ユニットテスト 11 件追加

## 変更ファイル

| ファイル | 変更 |
|---|---|
| `mystery_agents/tools/delpher.py` | **新規** — DelpherSource + SRU XML パーサー |
| `mystery_agents/tools/source_registry.py` | `_SOURCE_MODULES` に1行追加 |
| `mystery_agents/schemas/document.py` | `SourceType` enum に `DELPHER` 追加 |
| `mystery_agents/agents/language_librarians.py` | NL `cultural_context` に Delpher 記述追加 |
| `tests/unit/test_delpher.py` | **新規** — ユニットテスト 11 件 |

## 設計判断

- **`is_newspaper_source = False`**: `search_newspapers()` は Chronicling America にハードコーディングされているため、`search_archives(sources="delpher")` 経由でアクセス
- **日付フィルタなし**: SRU サーバー側の日付範囲フィルタが不安定（実地検証で確認）。キーワード検索のみで結果を返す
- **`min_request_delay = 2.0`**: 公開 API（認証不要）への配慮

## Test plan

- [x] `pytest tests/unit/test_delpher.py -v` — 11 tests passed
- [x] `pytest tests/unit/ -v` — 708 tests passed（回帰なし）
- [x] レジストリ確認: `get_all_sources()` に `delpher` が含まれる
- [x] NL ソース解決: `resolve_sources("nl")` → `['internet_archive', 'europeana', 'delpher']`

🤖 Generated with [Claude Code](https://claude.com/claude-code)