### PR TITLE
feat: Wellcome Collection Catalogue API 統合（医学史・民俗・迷信コレクション）

### DIFF
--- a/mystery_agents/agents/language_librarians.py
+++ b/mystery_agents/agents/language_librarians.py
@@ -128,6 +128,7 @@ LANGUAGE_CONFIGS = {
             "- English-language newspapers (Chronicling America, British Newspaper Archive)\n"
             "- Library of Congress, DPLA, NYPL, British Library, Internet Archive collections\n"
             "- Europeana for English-language materials in European collections\n"
+            "- Wellcome Collection for medical history, manuscripts, folklore, and superstition\n"
             "- English-speaking regions globally: British Isles, North America, Australia, India, etc."
         ),
         "newspaper_instruction": _NEWSPAPER_INSTRUCTION,

--- a/mystery_agents/schemas/document.py
+++ b/mystery_agents/schemas/document.py
@@ -33,6 +33,7 @@ class SourceType(str, Enum):
     TROVE = "trove"
     DELPHER = "delpher"
     NDL = "ndl"
+    WELLCOME = "wellcome"
 
 
 class ArchiveDocument(BaseModel):

--- a/mystery_agents/tools/source_registry.py
+++ b/mystery_agents/tools/source_registry.py
@@ -34,6 +34,7 @@ _SOURCE_MODULES = [
     "mystery_agents.tools.trove",
     "mystery_agents.tools.delpher",
     "mystery_agents.tools.ndl_search",
+    "mystery_agents.tools.wellcome_collection",
 ]
 
 

--- a/mystery_agents/tools/wellcome_collection.py
+++ b/mystery_agents/tools/wellcome_collection.py
@@ -1,0 +1,221 @@
+"""Wellcome Collection Catalogue API ソース。
+
+Wellcome Collection（ロンドン）の Catalogue API v2 を使用して
+医学史・写本・民俗・迷信コレクション（数百万点）を検索する。
+認証不要。レスポンスは JSON。
+"""
+
+import logging
+import re
+
+from ..schemas.document import ArchiveDocument, SourceLanguage
+from .archive_source_base import ArchiveSearchResult, ArchiveSource
+from .search_utils import build_search_query
+from .source_registry import register_source
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://api.wellcomecollection.org/catalogue/v2/works"
+
+# ISO 639-3 → SourceLanguage マッピング
+_LANG_MAP: dict[str, SourceLanguage] = {
+    "eng": SourceLanguage.EN,
+    "fre": SourceLanguage.FR,
+    "fra": SourceLanguage.FR,
+    "deu": SourceLanguage.DE,
+    "ger": SourceLanguage.DE,
+    "spa": SourceLanguage.ES,
+    "nld": SourceLanguage.NL,
+    "dut": SourceLanguage.NL,
+    "por": SourceLanguage.PT,
+    "jpn": SourceLanguage.JA,
+}
+
+# ISO 639-1 → 639-3 マッピング（言語フィルタ用）
+_LANG_1_TO_3: dict[str, str] = {
+    "en": "eng",
+    "fr": "fre",
+    "de": "ger",
+    "es": "spa",
+    "nl": "dut",
+    "pt": "por",
+    "ja": "jpn",
+}
+
+
+def _strip_html(text: str | None) -> str:
+    """HTML タグを除去する。
+
+    Args:
+        text: HTML を含む可能性のあるテキスト
+
+    Returns:
+        タグ除去済みのプレーンテキスト。None の場合は空文字列。
+    """
+    if not text:
+        return ""
+    return re.sub(r"<[^>]+>", "", text).strip()
+
+
+def _extract_date_label(work: dict) -> str:
+    """production.dates からラベルを抽出する。
+
+    Args:
+        work: Wellcome API の work オブジェクト
+
+    Returns:
+        日付ラベル文字列。見つからない場合は空文字列。
+    """
+    for prod in work.get("production", []):
+        for date in prod.get("dates", []):
+            label = date.get("label", "")
+            if label:
+                return label
+    return ""
+
+
+def _extract_location(work: dict) -> str:
+    """production.places から場所を抽出する。
+
+    Args:
+        work: Wellcome API の work オブジェクト
+
+    Returns:
+        場所ラベル。見つからない場合は "United Kingdom"。
+    """
+    for prod in work.get("production", []):
+        for place in prod.get("places", []):
+            label = place.get("label", "")
+            if label:
+                return label
+    return "United Kingdom"
+
+
+def _detect_language(work: dict) -> SourceLanguage:
+    """languages フィールドから SourceLanguage を検出する。
+
+    Args:
+        work: Wellcome API の work オブジェクト
+
+    Returns:
+        検出された SourceLanguage。不明な場合は EN をデフォルトにする。
+    """
+    languages = work.get("languages", [])
+    if languages:
+        lang_id = languages[0].get("id", "")
+        if lang_id in _LANG_MAP:
+            return _LANG_MAP[lang_id]
+    return SourceLanguage.EN
+
+
+def _parse_wellcome_response(
+    data: dict, keywords: list[str]
+) -> ArchiveSearchResult:
+    """Wellcome API JSON レスポンスを ArchiveSearchResult に変換する。
+
+    Args:
+        data: API レスポンスの JSON 辞書
+        keywords: マッチ検出用のキーワードリスト
+
+    Returns:
+        パース済みの ArchiveSearchResult
+    """
+    total_hits = data.get("totalResults", 0)
+    documents = []
+
+    for work in data.get("results", []):
+        work_id = work.get("id")
+        if not work_id:
+            continue
+
+        title = work.get("title", "Unknown Title")
+        description = _strip_html(work.get("description"))
+        summary_text = description or title
+
+        date_label = _extract_date_label(work)
+        parsed_date = ArchiveSource.parse_year(date_label) if date_label else None
+
+        source_url = f"https://wellcomecollection.org/works/{work_id}"
+        location = _extract_location(work)
+        language = _detect_language(work)
+
+        # キーワードマッチ
+        combined = f"{title} {summary_text}".lower()
+        matched = [kw for kw in keywords if kw.lower() in combined]
+
+        doc = ArchiveDocument(
+            title=str(title)[:500],
+            date=parsed_date,
+            source_url=source_url,
+            summary=str(summary_text)[:500],
+            language=language,
+            location=str(location)[:200],
+            source_type="wellcome",
+            raw_text=None,  # Catalogue API は全文テキスト非提供
+            keywords_matched=matched,
+        )
+        documents.append(doc)
+
+    return ArchiveSearchResult(documents=documents, total_hits=total_hits)
+
+
+class WellcomeSource(ArchiveSource):
+    """Wellcome Collection（ロンドン）ソース。"""
+
+    source_key = "wellcome"
+    source_name = "Wellcome Collection"
+    source_type = "wellcome"
+    min_request_delay = 1.0
+    supported_languages = {"en"}
+    supports_language_filter = True
+    is_newspaper_source = False
+    expected_domains = ["wellcomecollection.org"]
+    env_var_key = None  # 認証不要
+
+    def _search_impl(
+        self,
+        keywords: list[str],
+        date_start: str,
+        date_end: str,
+        max_results: int,
+        language: str | None,
+    ) -> ArchiveSearchResult:
+        search_text = build_search_query(keywords)
+        if not search_text:
+            return ArchiveSearchResult(error="No keywords provided")
+
+        params: dict[str, str | int] = {
+            "query": search_text,
+            "pageSize": min(max_results, 100),
+            "include": "subjects,genres,contributors,production,languages",
+        }
+
+        # 日付フィルタ（YYYY-MM-DD 形式）
+        if date_start:
+            params["production.dates.from"] = f"{date_start[:4]}-01-01"
+        if date_end:
+            params["production.dates.to"] = f"{date_end[:4]}-12-31"
+
+        # 言語フィルタ（ISO 639-1 → 639-3 変換）
+        if language and language in _LANG_1_TO_3:
+            params["languages"] = _LANG_1_TO_3[language]
+
+        headers = {
+            "Accept": "application/json",
+            "User-Agent": "GhostInTheArchive/1.0",
+        }
+
+        response = self._session.get(
+            BASE_URL,
+            params=params,
+            headers=headers,
+            timeout=30,
+        )
+        response.raise_for_status()
+
+        return _parse_wellcome_response(response.json(), keywords)
+
+
+# レジストリに自動登録
+_instance = WellcomeSource()
+register_source(_instance)

--- a/tests/unit/test_source_registry.py
+++ b/tests/unit/test_source_registry.py
@@ -165,10 +165,11 @@ class TestEnsureAllLoaded:
         """実際のモジュールがロードされ、ソースが登録される。"""
         all_sources = get_all_sources()
 
-        # 9 つの API ツールがすべて登録されていること
+        # 全 API ツールが登録されていること
         expected_keys = {
             "loc", "dpla", "nypl", "internet_archive",
-            "ddb", "europeana", "chronicling_america", "delpher", "ndl",
+            "ddb", "europeana", "chronicling_america", "trove", "delpher",
+            "ndl", "wellcome",
         }
         assert expected_keys.issubset(set(all_sources.keys()))
 

--- a/tests/unit/test_wellcome_collection.py
+++ b/tests/unit/test_wellcome_collection.py
@@ -1,0 +1,333 @@
+"""Unit tests for Wellcome Collection Catalogue API tool."""
+
+import responses
+
+from mystery_agents.schemas.document import SourceLanguage
+from mystery_agents.tools.wellcome_collection import (
+    BASE_URL,
+    WellcomeSource,
+    _detect_language,
+    _extract_date_label,
+    _extract_location,
+    _parse_wellcome_response,
+    _strip_html,
+)
+
+# モック JSON レスポンス
+MOCK_RESPONSE = {
+    "totalResults": 2,
+    "results": [
+        {
+            "id": "abc123",
+            "title": "A Treatise on Witchcraft and Superstition",
+            "description": "<p>An early modern text on <strong>witchcraft</strong> beliefs.</p>",
+            "production": [
+                {
+                    "dates": [{"label": "1684"}],
+                    "places": [{"label": "London"}],
+                }
+            ],
+            "languages": [{"id": "eng", "label": "English"}],
+        },
+        {
+            "id": "def456",
+            "title": "Folk Medicine in Rural England",
+            "description": None,
+            "production": [
+                {
+                    "dates": [{"label": "circa 1750"}],
+                    "places": [],
+                }
+            ],
+            "languages": [{"id": "eng", "label": "English"}],
+        },
+    ],
+}
+
+MOCK_EMPTY_RESPONSE = {
+    "totalResults": 0,
+    "results": [],
+}
+
+
+class TestWellcomeSource:
+    """Tests for WellcomeSource."""
+
+    def test_source_metadata(self):
+        """ソースメタデータの基本確認。"""
+        source = WellcomeSource()
+        assert source.source_key == "wellcome"
+        assert source.source_name == "Wellcome Collection"
+        assert source.supported_languages == {"en"}
+        assert source.supports_language_filter is True
+        assert source.is_newspaper_source is False
+        assert source.min_request_delay == 1.0
+        assert source.env_var_key is None
+
+    @responses.activate
+    def test_successful_search(self):
+        """正常な JSON レスポンスで ArchiveDocument に変換する。"""
+        responses.add(
+            responses.GET,
+            BASE_URL,
+            json=MOCK_RESPONSE,
+            status=200,
+        )
+
+        source = WellcomeSource()
+        result = source.search(keywords=["witchcraft", "superstition"])
+
+        assert result.error is None
+        assert result.total_hits == 2
+        assert len(result.documents) == 2
+
+        doc = result.documents[0]
+        assert doc.title == "A Treatise on Witchcraft and Superstition"
+        assert doc.language == SourceLanguage.EN
+        assert doc.source_type == "wellcome"
+        assert doc.source_url == "https://wellcomecollection.org/works/abc123"
+        assert doc.date == "1684-01-01"
+        assert doc.location == "London"
+        # HTML が除去されたサマリー
+        assert doc.summary == "An early modern text on witchcraft beliefs."
+        assert doc.raw_text is None
+
+    @responses.activate
+    def test_html_stripped_from_description(self):
+        """description の HTML タグが除去される。"""
+        responses.add(
+            responses.GET,
+            BASE_URL,
+            json=MOCK_RESPONSE,
+            status=200,
+        )
+
+        source = WellcomeSource()
+        result = source.search(keywords=["witchcraft"])
+
+        doc = result.documents[0]
+        assert "<p>" not in doc.summary
+        assert "<strong>" not in doc.summary
+
+    @responses.activate
+    def test_none_description_uses_title(self):
+        """description が None の場合、title をサマリーに代替する。"""
+        responses.add(
+            responses.GET,
+            BASE_URL,
+            json=MOCK_RESPONSE,
+            status=200,
+        )
+
+        source = WellcomeSource()
+        result = source.search(keywords=["folk"])
+
+        doc = result.documents[1]
+        assert doc.summary == "Folk Medicine in Rural England"
+
+    @responses.activate
+    def test_empty_results(self):
+        """0件レスポンスの場合。"""
+        responses.add(
+            responses.GET,
+            BASE_URL,
+            json=MOCK_EMPTY_RESPONSE,
+            status=200,
+        )
+
+        source = WellcomeSource()
+        result = source.search(keywords=["nonexistent"])
+
+        assert result.total_hits == 0
+        assert result.documents == []
+        assert result.error is None
+
+    @responses.activate
+    def test_api_error_handling(self):
+        """500 エラー時はエラーメッセージを返す。"""
+        responses.add(
+            responses.GET,
+            BASE_URL,
+            body="Internal Server Error",
+            status=500,
+        )
+
+        source = WellcomeSource()
+        result = source.search(keywords=["test"])
+
+        assert result.error is not None
+        assert "API error" in result.error
+        assert result.documents == []
+
+    def test_empty_keywords_returns_error(self):
+        """空のキーワードでエラーを返す。"""
+        source = WellcomeSource()
+        result = source.search(keywords=[])
+        assert result.error == "No keywords provided"
+
+    @responses.activate
+    def test_date_parameters(self):
+        """日付パラメータが YYYY-MM-DD 形式でリクエストに含まれる。"""
+        responses.add(
+            responses.GET,
+            BASE_URL,
+            json=MOCK_EMPTY_RESPONSE,
+            status=200,
+        )
+
+        source = WellcomeSource()
+        source.search(
+            keywords=["plague"],
+            date_start="1600",
+            date_end="1700",
+        )
+
+        request = responses.calls[0].request
+        assert "production.dates.from=1600-01-01" in request.url
+        assert "production.dates.to=1700-12-31" in request.url
+
+    @responses.activate
+    def test_language_parameter(self):
+        """言語パラメータが ISO 639-3 に変換されてリクエストに含まれる。"""
+        responses.add(
+            responses.GET,
+            BASE_URL,
+            json=MOCK_EMPTY_RESPONSE,
+            status=200,
+        )
+
+        source = WellcomeSource()
+        source.search(keywords=["test"], language="en")
+
+        request = responses.calls[0].request
+        assert "languages=eng" in request.url
+
+    @responses.activate
+    def test_default_location(self):
+        """places が空の場合、デフォルト "United Kingdom" を使用する。"""
+        responses.add(
+            responses.GET,
+            BASE_URL,
+            json=MOCK_RESPONSE,
+            status=200,
+        )
+
+        source = WellcomeSource()
+        result = source.search(keywords=["folk"])
+
+        # 2件目は places が空
+        doc = result.documents[1]
+        assert doc.location == "United Kingdom"
+
+    @responses.activate
+    def test_work_without_id_skipped(self):
+        """id が未設定のワークはスキップされる。"""
+        data = {
+            "totalResults": 1,
+            "results": [
+                {
+                    "title": "No ID Work",
+                    "description": "Some description",
+                    "production": [],
+                    "languages": [{"id": "eng"}],
+                }
+            ],
+        }
+        responses.add(
+            responses.GET,
+            BASE_URL,
+            json=data,
+            status=200,
+        )
+
+        source = WellcomeSource()
+        result = source.search(keywords=["test"])
+
+        assert result.total_hits == 1  # サーバーは1件と報告
+        assert len(result.documents) == 0  # id なしでスキップ
+
+    def test_keyword_matching(self):
+        """keywords_matched が正しく検出される。"""
+        result = _parse_wellcome_response(
+            MOCK_RESPONSE, keywords=["witchcraft", "Folk"]
+        )
+
+        # 1件目: "witchcraft" がタイトル・説明に含まれる
+        assert "witchcraft" in result.documents[0].keywords_matched
+        # 2件目: "Folk" がタイトルに含まれる（大文字小文字非区別）
+        assert "Folk" in result.documents[1].keywords_matched
+
+
+class TestHelperFunctions:
+    """ヘルパー関数の個別テスト。"""
+
+    def test_strip_html_removes_tags(self):
+        """HTML タグが除去される。"""
+        assert _strip_html("<p>Hello <b>world</b></p>") == "Hello world"
+
+    def test_strip_html_none(self):
+        """None の場合は空文字列を返す。"""
+        assert _strip_html(None) == ""
+
+    def test_strip_html_empty(self):
+        """空文字列の場合はそのまま返す。"""
+        assert _strip_html("") == ""
+
+    def test_strip_html_no_tags(self):
+        """タグなしテキストはそのまま返す。"""
+        assert _strip_html("plain text") == "plain text"
+
+    def test_detect_language_english(self):
+        """英語の検出。"""
+        work = {"languages": [{"id": "eng", "label": "English"}]}
+        assert _detect_language(work) == SourceLanguage.EN
+
+    def test_detect_language_french(self):
+        """フランス語の検出（fre / fra 両方）。"""
+        assert _detect_language({"languages": [{"id": "fre"}]}) == SourceLanguage.FR
+        assert _detect_language({"languages": [{"id": "fra"}]}) == SourceLanguage.FR
+
+    def test_detect_language_german(self):
+        """ドイツ語の検出（ger / deu 両方）。"""
+        assert _detect_language({"languages": [{"id": "ger"}]}) == SourceLanguage.DE
+        assert _detect_language({"languages": [{"id": "deu"}]}) == SourceLanguage.DE
+
+    def test_detect_language_unknown_defaults_to_en(self):
+        """不明な言語コードは EN をデフォルトにする。"""
+        assert _detect_language({"languages": [{"id": "zho"}]}) == SourceLanguage.EN
+
+    def test_detect_language_empty_languages(self):
+        """languages が空の場合は EN。"""
+        assert _detect_language({"languages": []}) == SourceLanguage.EN
+
+    def test_detect_language_no_languages_key(self):
+        """languages キーがない場合は EN。"""
+        assert _detect_language({}) == SourceLanguage.EN
+
+    def test_extract_date_label(self):
+        """production.dates からラベルを抽出する。"""
+        work = {"production": [{"dates": [{"label": "1750"}]}]}
+        assert _extract_date_label(work) == "1750"
+
+    def test_extract_date_label_empty(self):
+        """production が空の場合は空文字列。"""
+        assert _extract_date_label({"production": []}) == ""
+        assert _extract_date_label({}) == ""
+
+    def test_extract_date_label_no_dates(self):
+        """dates が空の場合は空文字列。"""
+        assert _extract_date_label({"production": [{"dates": []}]}) == ""
+
+    def test_extract_location(self):
+        """production.places からラベルを抽出する。"""
+        work = {"production": [{"places": [{"label": "Edinburgh"}]}]}
+        assert _extract_location(work) == "Edinburgh"
+
+    def test_extract_location_default(self):
+        """places が空の場合はデフォルト "United Kingdom"。"""
+        assert _extract_location({"production": []}) == "United Kingdom"
+        assert _extract_location({}) == "United Kingdom"
+
+    def test_extract_location_empty_places(self):
+        """places が空リストの場合はデフォルト。"""
+        assert _extract_location({"production": [{"places": []}]}) == "United Kingdom"


### PR DESCRIPTION
## Summary

- British Library IIIF API（#182）がランサムウェア攻撃で停止中（復旧時期未定）のため、代替としてイギリスの **Wellcome Collection Catalogue API v2** を統合
- 医学史・写本・民俗・迷信コレクション（数百万点）を検索可能に
- 認証不要・REST JSON API で、日付フィルタ・言語フィルタに対応

## 変更内容

| ファイル | 変更 |
|----------|------|
| `mystery_agents/tools/wellcome_collection.py` | **新規** — `WellcomeSource` (ArchiveSource サブクラス) |
| `mystery_agents/schemas/document.py` | SourceType enum に `WELLCOME` 追加 |
| `mystery_agents/tools/source_registry.py` | モジュール登録追加 |
| `mystery_agents/agents/language_librarians.py` | English cultural_context に Wellcome Collection 追記 |
| `tests/unit/test_wellcome_collection.py` | **新規** — ユニットテスト 28 件 |
| `tests/unit/test_source_registry.py` | expected_keys に `wellcome`, `trove` 追加 |

## Test plan

- [x] `test_wellcome_collection.py` — 28 テスト全パス
- [x] `test_source_registry.py` — 10 テスト全パス
- [x] 全ユニットテスト（751 件）— リグレッションなし

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)