### PR TITLE
feat: 記事本文のアーカイブ引用と考察の視覚的分離

### DIFF
--- a/mystery_agents/agents/storyteller.py
+++ b/mystery_agents/agents/storyteller.py
@@ -43,6 +43,17 @@ load_dotenv(Path(__file__).parent.parent / ".env")
 # 3. 深層 — 民俗学的文脈との交差
 # 4. 結び — 解明されない余韻
 #
+# ## フォーマット：アーカイブ証拠と考察の分離
+# Markdown の引用記法（`>`）を以下に使用する：
+# - アーカイブ資料からの直接引用（新聞、公式記録、乗客名簿、航海日誌）
+# - 一次資料から抽出した事実の記述
+# - 民俗的な口承伝統、地方伝説、目撃証言
+#
+# 通常の段落（`>` なし）を以下に使用する：
+# - あなたの分析、解釈、推測
+# - 証拠をつなぐナラティブの橋渡し
+# - 証拠から生じる疑問
+#
 # ## クリエイティブガイドライン
 # - トーン: 学術的信頼性を維持しつつ、怪異的な情緒を醸し出す
 # - 言語: 英語
@@ -119,6 +130,27 @@ Bring to light the process by which facts became legends, or the historical trut
 ### 4. Conclusion — Lingering Without Resolution
 End without fully resolving the mystery, suggesting that "something still sleeps in the archive."
 Leave readers with a lingering chill.
+
+## Formatting: Separating Archive Evidence from Analysis
+
+Use Markdown blockquotes (`>`) for:
+- Direct quotes from archive sources (newspapers, official records, manifests, logs)
+- Factual descriptions extracted from primary sources
+- Folkloric oral traditions, local legends, and eyewitness accounts
+
+Use regular paragraphs (no `>`) for:
+- Your analysis, interpretation, and speculation
+- Narrative bridges connecting pieces of evidence
+- Questions raised by the evidence
+
+Example:
+> The Boston Daily Advertiser reported on March 15, 1842: "The vessel was last seen departing Boston Light at approximately 3:00 PM."
+
+> The ship's manifest, preserved in the National Archives, lists 23 crew members and 4 passengers — yet the harbor master's log records only 19 souls aboard.
+
+This four-person discrepancy raises uncomfortable questions. If the manifest was filed before departure, who were these phantom passengers?
+
+> Local fishermen in Gloucester have long spoken of "the crying ship" — a vessel heard but never seen on foggy March nights.
 
 ## Output Format
 

--- a/web-public/src/app/[lang]/mystery/[id]/page.tsx
+++ b/web-public/src/app/[lang]/mystery/[id]/page.tsx
@@ -132,7 +132,7 @@ export default async function MysteryDetailPage({
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 lg:gap-12">
             {/* Main content */}
             <div className="lg:col-span-2 space-y-12">
-              <NarrativeSection narrativeContent={narrativeContent} summary={summary} />
+              <NarrativeSection narrativeContent={narrativeContent} summary={summary} lang={lang} />
 
               {/* Divider between narrative and archival data */}
               <div className="flex items-center gap-4">

--- a/web-public/src/components/mystery/narrative-section.tsx
+++ b/web-public/src/components/mystery/narrative-section.tsx
@@ -1,17 +1,50 @@
-import Markdown from "react-markdown"
+import Markdown, { type Components } from "react-markdown"
 import remarkGfm from "remark-gfm"
+import { FileText } from "lucide-react"
 import { stripLeadingH1 } from "@ghost/shared/src/lib/utils"
+
+// 7言語のアーカイブ引用ラベル
+const ARCHIVE_LABEL: Record<string, string> = {
+  en: "From the Archive",
+  ja: "アーカイブ記録",
+  es: "Del Archivo",
+  de: "Aus dem Archiv",
+  fr: "Extrait d'archive",
+  nl: "Uit het Archief",
+  pt: "Do Arquivo",
+}
+
+function ArchiveBlockquote({ children, lang }: { children?: React.ReactNode; lang: string }) {
+  return (
+    <blockquote className="not-prose relative my-8 border-l-2 border-gold/40 bg-paper-light/50 px-6 py-5 rounded-sm">
+      <div className="flex items-center gap-2 mb-3 text-xs font-mono uppercase tracking-wider text-gold/70">
+        <FileText className="w-3.5 h-3.5" />
+        <span>{ARCHIVE_LABEL[lang] || ARCHIVE_LABEL.en}</span>
+      </div>
+      <div className="font-serif text-foreground/80 italic leading-relaxed">
+        {children}
+      </div>
+    </blockquote>
+  )
+}
 
 interface NarrativeSectionProps {
   narrativeContent?: string
   summary: string
+  lang?: string
 }
 
-export function NarrativeSection({ narrativeContent, summary }: NarrativeSectionProps) {
+export function NarrativeSection({ narrativeContent, summary, lang = "en" }: NarrativeSectionProps) {
   if (narrativeContent) {
+    const markdownComponents: Components = {
+      blockquote: ({ children }) => (
+        <ArchiveBlockquote lang={lang}>{children}</ArchiveBlockquote>
+      ),
+    }
+
     return (
-      <section className="prose prose-lg prose-invert max-w-none prose-headings:font-serif prose-headings:text-parchment prose-headings:mt-12 prose-headings:mb-4 prose-p:text-foreground/90 prose-p:leading-loose prose-p:mb-6 prose-a:text-gold prose-blockquote:border-gold/30 prose-blockquote:bg-card prose-blockquote:px-6 prose-blockquote:py-4 prose-blockquote:rounded-sm prose-blockquote:text-foreground/70 prose-blockquote:italic prose-blockquote:font-serif prose-strong:text-parchment prose-hr:border-border">
-        <Markdown remarkPlugins={[remarkGfm]}>
+      <section className="prose prose-lg prose-invert max-w-none prose-headings:font-serif prose-headings:text-parchment prose-headings:mt-12 prose-headings:mb-4 prose-p:text-foreground/90 prose-p:leading-loose prose-p:mb-6 prose-a:text-gold prose-strong:text-parchment prose-hr:border-border">
+        <Markdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
           {stripLeadingH1(narrativeContent).replace(/\*\*(.+?)\*\*/g, ' **$1** ')}
         </Markdown>
       </section>


### PR DESCRIPTION
## Summary

- Storyteller プロンプトに blockquote フォーマットルール追加（アーカイブ引用は `>`、考察は通常段落）
- NarrativeSection にカスタム blockquote レンダラー（ArchiveBlockquote）追加 — 「From the Archive」ラベル + FileText アイコンで視覚的分離
- 7言語対応のラベル（en/ja/es/de/fr/nl/pt）

## 変更ファイル

| ファイル | 変更内容 |
|---------|----------|
| `mystery_agents/agents/storyteller.py` | blockquote 使用ルール追加（英語 instruction + 日本語コメント） |
| `web-public/src/components/mystery/narrative-section.tsx` | ArchiveBlockquote カスタムレンダラー + lang prop |
| `web-public/src/app/[lang]/mystery/[id]/page.tsx` | NarrativeSection に lang prop 追加 |

## Test plan

- [x] `python -m pytest tests/unit/ -v` — 779 テスト全パス
- [x] `npx next typegen && npx tsc --noEmit` — 型エラーなし
- [ ] 既存記事での blockquote 表示を視覚確認（`npm run dev`）
- [x] Translator の blockquote 保持指示は既存（`Preserve blockquotes (>)`）

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)