### PR TITLE
feat: Illustrator 地域アートスタイル + サムネイル + 学術領域ビジュアル

### DIFF
--- a/mystery_agents/agents/illustrator.py
+++ b/mystery_agents/agents/illustrator.py
@@ -3,9 +3,9 @@
 Reads the blog article created by the Storyteller and generates
 a single hero image using Imagen 3 that captures the essence of the article.
 
-Fact × Folklore style differentiation:
-- Fact-based content → Black & white archival photograph style
-- Folklore-based content → 19th century woodcut/engraving illustration style
+地域アートスタイル:
+- 11リージョン × 2タイプ（fact/folklore）= 22種のスタイルを style_registry から適用
+- structured_report の country_code から自動的にリージョンを決定
 
 画像品質保証:
 - Pre-generation: LLM ベースのプロンプト安全書き換え（generate_image 内部）
@@ -69,15 +69,41 @@ def _limit_tool_calls(
 # Storyteller Agent が作成したブログ記事を読み、記事の核心を表現するトップ画像1枚を生成します。
 #
 # ## 入力
-# セッション状態の {creative_content} に Storyteller が作成したブログ原稿があります。
+# - {creative_content}: Storyteller が作成したブログ原稿
+# - {structured_report}: Armchair Polymath の構造化分析（country_code を含む）
 #
 # ## 利用可能なツール
 # - **generate_image**: Imagen 3 を使用して画像を生成しローカルに保存
 # - **validate_image**: 生成画像と記事内容の整合性を Gemini Flash で検証
 #
-# ## Fact × Folklore のスタイル使い分け（最重要）
-# - Fact ベース → style="fact"（白黒アーカイブ写真風）
-# - Folklore ベース → style="folklore"（19世紀の木版画・銅版画風）
+# ## 地域アートスタイル選択（最重要）
+# {structured_report} の country_code を読み取り、region パラメータとして generate_image に渡す。
+# country_code が不明な場合は記事内容から推論する。
+#
+# 対応リージョン:
+# - US: Fact=B&W銀塩写真 / Folklore=アメリカ木版画
+# - JP: Fact=明治アルビュメンプリント / Folklore=浮世絵
+# - GB: Fact=ヴィクトリア湿板写真 / Folklore=ゴシック・ペン画
+# - NL: Fact=オランダ黄金時代油彩 / Folklore=フランドル写本装飾
+# - AU: Fact=植民地リトグラフ / Folklore=ブッシュ風景エッチング
+# - NZ: Fact=植民地測量写真 / Folklore=在来植物風景エッチング
+# - DE: Fact=ダゲレオタイプ / Folklore=ドイツ表現主義木版画
+# - FR: Fact=アジェ風ドキュメンタリー写真 / Folklore=アール・ヌーヴォー
+# - ES: Fact=宮廷肖像エッチング / Folklore=ゴヤ・カプリチョス風
+# - PT: Fact=大航海時代海図 / Folklore=海洋エングレービング
+# 不明 → EU（フォールバック: Fact=カルト・ド・ヴィジット / Folklore=ルネサンス銅版画）
+#
+# ## Fact × Folklore のスタイル使い分け
+# - Fact ベース → style="fact"
+# - Folklore ベース → style="folklore"
+#
+# ## 学術領域に基づくビジュアル要素ガイダンス
+# 記事の主要な学術領域に応じて、プロンプトに含めるビジュアル要素を選択する:
+# - 歴史学 → 文書、建築、時代考証（公文書、建物ファサード、時代に正確なオブジェクト）
+# - 民俗学 → 風景、自然、伝統的オブジェクト（神社、祠、民具、祭具）
+# - 文化人類学 → 物質文化、儀礼空間（手工芸品、集会所、交易品）
+# - 言語学 → 写本、碑文、多言語テキスト（古文書、石碑、異なる文字体系）
+# - 文書館学 → 保管空間、劣化した文書（書庫、目録、損傷した記録）
 #
 # ## 生成する画像
 # トップ画像1枚のみ（16:9、filename_hint: "header"）
@@ -93,7 +119,7 @@ def _limit_tool_calls(
 # ## 画像検証（生成成功後）
 # generate_image が "status": "success" を返した後、検証を必ず実行する:
 # 1. {creative_content} から2-5文のテーマ要約を作成
-# 2. validate_image を呼び出す
+# 2. validate_image を呼び出す（region パラメータも渡す）
 # 3. verdict が "pass" → 結果を出力
 # 4. verdict が "fail" → feedback と suggested_focus を使って新プロンプトを作成し、
 #    generate_image をもう1回だけ呼ぶ。再検証はしない。
@@ -113,7 +139,8 @@ Read the blog article created by the Storyteller Agent and generate a single her
 that captures the essence of the article.
 
 ## Input
-The session state {creative_content} contains the blog article created by the Storyteller.
+- The session state {creative_content} contains the blog article created by the Storyteller.
+- The session state {structured_report} contains the Armchair Polymath's structured analysis (includes country_code).
 Analyze the content (theme, historical background, folkloric elements, atmosphere)
 and devise the optimal visual concept.
 
@@ -121,22 +148,51 @@ and devise the optimal visual concept.
 - **generate_image**: Generate an image using Imagen 3 and save it locally
 - **validate_image**: Validate the generated image against the article content using Gemini Flash
 
-## Fact × Folklore Style Differentiation (Critical)
+## Regional Art Style Selection (Critical)
+
+Read the `country_code` from {structured_report} and pass it as the `region` parameter to generate_image.
+If country_code is unavailable, infer the region from the article content. Each region has a distinct
+art style for both fact and folklore content:
+
+| Region | Fact Style | Folklore Style |
+|--------|-----------|---------------|
+| US | B&W silver gelatin photograph | American woodcut engraving |
+| JP | Meiji-era albumen print | Ukiyo-e woodblock print |
+| GB | Victorian wet plate collodion | Gothic pen and ink illustration |
+| NL | Dutch Golden Age oil painting | Flemish manuscript illumination |
+| AU | Colonial-era lithograph | Bush landscape etching |
+| NZ | Colonial survey photograph | Native flora landscape etching |
+| DE | Daguerreotype | German Expressionist woodcut |
+| FR | Atget-style documentary photograph | Art Nouveau illustration |
+| ES | Spanish court portrait etching | Goya Caprichos-inspired aquatint |
+| PT | Age of Exploration nautical chart | Maritime engraving |
+
+For unknown regions, use `region="EU"` (fallback: carte de visite / Renaissance copperplate).
+
+## Fact × Folklore Style Differentiation
 
 Choose a style based on the article content:
 
 ### Fact-based (content centered on historical facts)
 - Specify **style="fact"**
-- Black & white archival photograph style (monochrome, silver gelatin print texture)
-- Examples: ship's logs, harbor scenes, old buildings, document close-ups
+- The art style will be automatically selected based on the region
 
 ### Folklore-based (content centered on legends/the uncanny)
 - Specify **style="folklore"**
-- 19th century woodcut/engraving illustration style (cross-hatching, sepia tones)
-- Examples: ghost ships, lighthouses in fog, eerie landscapes, legendary scenes
+- The art style will be automatically selected based on the region
 
 ### When both elements are present
 - Choose either fact or folklore based on the article's overall theme
+
+## Academic Discipline Visual Elements
+
+Choose visual elements based on the article's primary academic discipline:
+
+- **History** → Documents, architecture, period-accurate objects (official records, building facades, era-specific artifacts)
+- **Folklore** → Landscapes, nature, traditional objects (shrines, folk implements, ritual tools)
+- **Cultural Anthropology** → Material culture, ritual spaces (handicrafts, meeting halls, trade goods)
+- **Linguistics** → Manuscripts, inscriptions, multilingual texts (old documents, stone tablets, different writing systems)
+- **Archival Science** → Storage spaces, deteriorated documents (repositories, catalogs, damaged records)
 
 ## Image to Generate
 
@@ -145,6 +201,7 @@ Generate **only one hero image**:
 - aspect_ratio: "16:9"
 - A single image that captures the essence of the article
 - filename_hint: "header"
+- region: The country_code from {structured_report} (e.g., "JP", "GB", "NL")
 
 ## Prompt Creation Guidelines
 
@@ -155,9 +212,11 @@ Generate **only one hero image**:
 4. **Composition**: close-up, wide shot, overhead view, etc.
 
 ### Prompt Examples
-Fact: "Close-up of a weathered 19th century ship's log book lying open on dark wood, ink entries fading, candlelight casting dramatic shadows, dust particles visible, overhead shot at 45 degrees, shallow depth of field"
+Japan Fact: "A sepia-toned interior of a Meiji-era wooden library, bamboo shelves lined with bound volumes, a single oil lamp casting warm pools of light on tatami flooring, calligraphy brushes resting on a low desk"
 
-Folklore: "A ghostly sailing ship emerging from thick fog near a rocky New England coastline, moonlight piercing through storm clouds, enormous waves crashing against cliffs, dramatic cross-hatching linework"
+Britain Folklore: "A Gothic pen and ink illustration of a mist-shrouded moor at twilight, ancient standing stones casting long shadows, twisted hawthorn trees, intricate crosshatching, Victorian book illustration style"
+
+Netherlands Fact: "A Dutch Golden Age still life of navigation instruments on a dark wooden table, brass astrolabe, old maps, warm amber candlelight, Vermeer-inspired lighting, rich chiaroscuro"
 
 ### Elements to Avoid
 - Modern elements (electronics, modern clothing)
@@ -187,6 +246,7 @@ If the generate_image tool returns `"status": "fallback"`, retry **exactly once*
    - If the original prompt was about a specific incident → Focus on **period symbolic objects** (old keys, letters, maps, lanterns, etc.)
    - If the original prompt included supernatural elements → Focus on **natural landscapes or architecture**
 2. The retry prompt must contain **absolutely no direct depictions of people, creatures, or supernatural phenomena**
+3. Keep the same `region` parameter for the retry
 3. If the second generate_image call also returns `"status": "fallback"`, **use the fallback image as-is** (do not retry a third time to prevent infinite loops)
 
 ## Image Validation (After Successful Generation)
@@ -194,7 +254,7 @@ If the generate_image tool returns `"status": "fallback"`, retry **exactly once*
 After generate_image returns `"status": "success"`, you MUST validate:
 
 1. Write a 2-5 sentence summary of {creative_content} covering theme, setting, key elements
-2. Call validate_image with the filepath, your summary, and the style you used
+2. Call validate_image with the filepath, your summary, the style, and the region you used
 3. If verdict is "pass" → output the generate_image result
 4. If verdict is "fail" → create a NEW prompt using the feedback and suggested_focus,
    call generate_image ONE MORE TIME. Do NOT validate again after this retry.
@@ -213,6 +273,7 @@ Do NOT include any text other than the JSON (no explanations, comments, etc.).
 - **You MUST call the generate_image tool to actually generate an image**
 - Do not just create a prompt and stop
 - Balance historical accuracy with visual appeal
+- Always pass the `region` parameter to both generate_image and validate_image
 - If {creative_content} contains "NO_CONTENT", do not generate an image and report accordingly
 """
 
@@ -221,8 +282,7 @@ illustrator_agent = LlmAgent(
     model=create_pro_model(),
     description=(
         "Reads the Storyteller's blog article and generates a single hero image using Imagen 3. "
-        "Uses black & white photograph style for Fact-based articles and "
-        "woodcut illustration style for Folklore-based articles. "
+        "Uses region-specific art styles (11 regions × 2 types = 22 styles) based on the article's country. "
         "Validates generated images against article content for consistency."
     ),
     instruction=ILLUSTRATOR_INSTRUCTION,

--- a/mystery_agents/tools/illustrator_tools.py
+++ b/mystery_agents/tools/illustrator_tools.py
@@ -206,7 +206,7 @@ def _sanitize_prompt(prompt: str) -> str:
     return result
 
 
-def _build_safe_fallback_prompt(style: str) -> str:
+def _build_safe_fallback_prompt(style: str, region: str = "EU") -> str:
     """Build an ultra-safe fallback prompt with no thematic content.
 
     Used as the last resort (attempt 2) when both the original and
@@ -216,28 +216,31 @@ def _build_safe_fallback_prompt(style: str) -> str:
 
     Args:
         style: Image style - "fact", "folklore", or "auto".
+        region: ISO 3166-1 alpha-2 国コード。
 
     Returns:
         A safe prompt string guaranteed to pass safety filters.
     """
-    if style == "fact":
-        return (
-            "Black and white archival photograph style, monochrome, "
-            "high contrast, vintage silver gelatin print texture. "
-            "An old weathered leather-bound book lying open on a dark oak desk, "
-            "candlelight casting long shadows, dust motes in the air, "
-            "antique brass inkwell nearby, aged parchment pages, "
-            "dramatic chiaroscuro lighting, overhead shot at 45 degrees"
-        )
-    elif style == "folklore":
-        return (
-            "19th century woodcut engraving illustration style, "
-            "cross-hatching technique, sepia toned, aged paper texture. "
-            "A misty coastal landscape at twilight, rocky cliffs overlooking "
-            "a calm sea, a lone ancient lighthouse in the distance, "
-            "gnarled oak trees silhouetted against a cloudy sky, "
-            "dramatic linework, vintage newspaper illustration aesthetic"
-        )
+    if style in ("fact", "folklore"):
+        from .style_registry import get_art_style
+
+        art_style = get_art_style(region, style)
+        # レジストリのスタイルプレフィックス + 汎用の安全な情景
+        if style == "fact":
+            scene = (
+                "An old weathered leather-bound book lying open on a dark oak desk, "
+                "candlelight casting long shadows, dust motes in the air, "
+                "antique brass inkwell nearby, aged parchment pages, "
+                "dramatic chiaroscuro lighting, overhead shot at 45 degrees"
+            )
+        else:
+            scene = (
+                "A misty coastal landscape at twilight, rocky cliffs overlooking "
+                "a calm sea, a lone ancient lighthouse in the distance, "
+                "gnarled oak trees silhouetted against a cloudy sky, "
+                "dramatic linework"
+            )
+        return f"{art_style.style_prefix}{scene}"
     else:
         return (
             "A dimly lit archival room with tall wooden shelves filled "
@@ -248,16 +251,16 @@ def _build_safe_fallback_prompt(style: str) -> str:
         )
 
 
-def _get_style_description(style: str) -> str:
+def _get_style_description(style: str, region: str = "EU") -> str:
     """スタイルの説明文を返す。"""
-    if style == "fact":
-        return "Black and white archival photograph, monochrome, silver gelatin print"
-    elif style == "folklore":
-        return "19th century woodcut engraving, cross-hatching, sepia toned"
+    if style in ("fact", "folklore"):
+        from .style_registry import get_style_description as _registry_desc
+
+        return _registry_desc(region, style)
     return "Atmospheric, cinematic composition"
 
 
-def _rewrite_safe_prompt(prompt: str, style: str) -> str:
+def _rewrite_safe_prompt(prompt: str, style: str, region: str = "EU") -> str:
     """Gemini Flash で元プロンプトを安全に書き換える。
 
     単語置換ではなく、LLM が文脈を理解して:
@@ -307,7 +310,7 @@ Original prompt: {prompt}"""
 
 
 def _build_contextual_safe_prompt(
-    style: str, tool_context: Optional[ToolContext],
+    style: str, region: str, tool_context: Optional[ToolContext],
 ) -> str:
     """記事内容から安全な新コンセプトを生成。
 
@@ -322,9 +325,9 @@ def _build_contextual_safe_prompt(
         creative_content = tool_context.state.get("creative_content")
 
     if not creative_content or "NO_CONTENT" in str(creative_content):
-        return _build_safe_fallback_prompt(style)
+        return _build_safe_fallback_prompt(style, region)
 
-    style_desc = _get_style_description(style)
+    style_desc = _get_style_description(style, region)
     contextual_instruction = f"""Create a safe image generation prompt for an AI image generator based on this article.
 
 The prompt must be COMPLETELY SAFE:
@@ -360,7 +363,7 @@ Safe image prompt:"""
         )
 
     # フォールバック: 既存の汎用プロンプト
-    return _build_safe_fallback_prompt(style)
+    return _build_safe_fallback_prompt(style, region)
 
 
 def _get_client() -> genai.Client:
@@ -391,9 +394,54 @@ def _get_variants(filepath: str) -> tuple[list, str | None]:
     return [], error_msg
 
 
+def _generate_thumbnail(source_path: str) -> dict | None:
+    """16:9 画像から 400×400 の中央クロップサムネイルを生成する。
+
+    Args:
+        source_path: ソース画像のパス。
+
+    Returns:
+        サムネイルの情報 dict、または生成失敗時は None。
+    """
+    src = Path(source_path)
+    if not src.exists():
+        logger.warning("_generate_thumbnail: ソースが見つからない: %s", source_path)
+        return None
+
+    try:
+        from PIL import Image as PILImage
+
+        with PILImage.open(src) as img:
+            w, h = img.size
+
+            # 中央正方形クロップ
+            side = min(w, h)
+            left = (w - side) // 2
+            top = (h - side) // 2
+            cropped = img.crop((left, top, left + side, top + side))
+
+            # 400×400 にリサイズ
+            thumb = cropped.resize((400, 400), PILImage.LANCZOS)
+
+            out_name = f"{src.stem}_thumb.webp"
+            out_path = src.parent / out_name
+            thumb.save(str(out_path), "WEBP", quality=WEBP_QUALITY)
+
+            return {
+                "filepath": str(out_path),
+                "filename": out_name,
+                "width": 400,
+                "height": 400,
+            }
+    except Exception as e:
+        logger.warning("_generate_thumbnail: サムネイル生成失敗: %s", e)
+        return None
+
+
 def generate_image(
     prompt: str,
     style: str = "auto",
+    region: str = "EU",
     aspect_ratio: str = "16:9",
     negative_prompt: Optional[str] = None,
     filename_hint: Optional[str] = None,
@@ -406,13 +454,17 @@ def generate_image(
     after uploading to Cloud Storage.
 
     The style parameter controls the visual approach:
-    - "fact": Monochrome archival photograph style (for Fact-based articles)
-    - "folklore": 19th century woodcut/engraving illustration style (for Folklore-based articles)
+    - "fact": Region-specific archival style (for Fact-based articles)
+    - "folklore": Region-specific artistic style (for Folklore-based articles)
     - "auto": Let the prompt determine the style
+
+    The region parameter selects a culture-specific art style from the style registry.
+    Supported regions: US, JP, GB, NL, AU, NZ, DE, FR, ES, PT. Unknown regions fall back to EU.
 
     Args:
         prompt: Detailed English prompt describing the image to generate.
-        style: Image style - "fact" (monochrome photo), "folklore" (woodcut illustration), or "auto".
+        style: Image style - "fact", "folklore", or "auto".
+        region: ISO 3166-1 alpha-2 country code for region-specific art style (default: "EU").
         aspect_ratio: Aspect ratio - "16:9" (blog header), "1:1" (square), "9:16" (vertical).
         negative_prompt: Elements to exclude from the image.
         filename_hint: Optional hint for the filename (e.g., "boston_harbor").
@@ -420,23 +472,14 @@ def generate_image(
     Returns:
         JSON string with the file path and generation details.
     """
-    # Apply style-specific prompt modifications
-    if style == "fact":
-        style_prefix = (
-            "Black and white archival photograph style, monochrome, "
-            "high contrast, vintage silver gelatin print texture, "
-            "documentary photography aesthetic. "
-        )
+    # Apply style-specific prompt modifications via style registry
+    if style in ("fact", "folklore"):
+        from .style_registry import get_art_style
+
+        art_style = get_art_style(region, style)
+        style_prefix = art_style.style_prefix
         if not negative_prompt:
-            negative_prompt = "color, modern elements, digital artifacts, cartoon, illustration"
-    elif style == "folklore":
-        style_prefix = (
-            "19th century woodcut engraving illustration style, "
-            "cross-hatching technique, sepia toned, aged paper texture, "
-            "vintage newspaper illustration aesthetic. "
-        )
-        if not negative_prompt:
-            negative_prompt = "photograph, modern elements, digital art, 3D render, color photography"
+            negative_prompt = art_style.negative_prompt
     else:
         style_prefix = ""
 
@@ -497,6 +540,9 @@ def generate_image(
                 # Generate responsive variants
                 variants, variant_error = _get_variants(str(filepath))
 
+                # Generate thumbnail (400×400 center crop)
+                thumbnail = _generate_thumbnail(str(filepath))
+
                 result = {
                     "status": "success",
                     "filepath": str(filepath),
@@ -504,11 +550,13 @@ def generate_image(
                     "prompt_used": current_prompt,
                     "original_prompt": full_prompt,
                     "style": style,
+                    "region": region,
                     "aspect_ratio": aspect_ratio,
                     "attempt": attempt + 1,
                     "prompt_sanitized": prompt_sanitized,
                     "variants": variants,
                     "variant_error": variant_error,
+                    "thumbnail": thumbnail,
                 }
 
                 # Save image metadata to session state for Publisher
@@ -529,10 +577,10 @@ def generate_image(
             # attempt 0 失敗 → LLM で知的書き換え（attempt 1 用）
             # attempt 1 失敗 → 記事から安全な新コンセプト生成（attempt 2 用）
             if attempt == 0:
-                current_prompt = _rewrite_safe_prompt(current_prompt, style)
+                current_prompt = _rewrite_safe_prompt(current_prompt, style, region)
                 prompt_sanitized = True
             elif attempt == 1:
-                current_prompt = _build_contextual_safe_prompt(style, tool_context)
+                current_prompt = _build_contextual_safe_prompt(style, region, tool_context)
                 prompt_sanitized = True
             continue
 
@@ -567,11 +615,11 @@ def generate_image(
 
             # LLM ベースのプログレッシブ・リトライ（その他エラー時も同様）
             if attempt == 0:
-                current_prompt = _rewrite_safe_prompt(current_prompt, style)
+                current_prompt = _rewrite_safe_prompt(current_prompt, style, region)
                 prompt_sanitized = True
                 continue
             elif attempt == 1:
-                current_prompt = _build_contextual_safe_prompt(style, tool_context)
+                current_prompt = _build_contextual_safe_prompt(style, region, tool_context)
                 prompt_sanitized = True
                 continue
 
@@ -602,6 +650,9 @@ def generate_image(
             else:
                 logger.warning("Fallback variant not found: %s", src)
 
+        # サムネイル生成（フォールバック画像から）
+        fallback_thumbnail = _generate_thumbnail(str(fallback_copy))
+
         fallback_result = {
             "status": "fallback",
             "filepath": str(fallback_copy),
@@ -611,6 +662,7 @@ def generate_image(
             "last_error": last_error,
             "attempts": MAX_RETRIES,
             "variants": variant_copies,
+            "thumbnail": fallback_thumbnail,
             "retry_suggestion": (
                 "Try generating with a completely different visual concept. "
                 "Focus on locations, architecture, or symbolic objects instead of the original subject. "
@@ -642,6 +694,7 @@ def validate_image(
     image_filepath: str,
     expected_theme: str,
     style: str = "auto",
+    region: str = "EU",
     tool_context: Optional[ToolContext] = None,
 ) -> str:
     """生成画像と記事内容の整合性を Gemini Flash で検証する。
@@ -654,6 +707,7 @@ def validate_image(
         image_filepath: 生成画像のファイルパス。
         expected_theme: 記事テーマの要約（2-5文、Illustrator LLM が作成）。
         style: 使用したスタイル — "fact" / "folklore" / "auto"。
+        region: ISO 3166-1 alpha-2 国コード（地域スタイル検証用）。
         tool_context: ADK ToolContext（セッション状態への保存用）。
 
     Returns:
@@ -681,18 +735,20 @@ def validate_image(
             "error": f"Failed to load image: {e}",
         }, ensure_ascii=False)
 
-    style_desc = _get_style_description(style)
+    style_desc = _get_style_description(style, region)
 
     validation_prompt = f"""Evaluate whether this image is appropriate as a hero image for the following article.
 
 Article summary: {expected_theme}
 Intended style: {style_desc}
+Region: {region}
 
 Criteria:
 1. THEME MATCH: Does the image relate to the article's subject (location, era, objects, atmosphere)?
 2. ERA CONSISTENCY: No anachronisms (modern elements in historical setting)?
-3. STYLE ADHERENCE: fact=B&W archival photo / folklore=woodcut/engraving?
+3. STYLE ADHERENCE: Does the image match the intended regional art style described above?
 4. QUALITY: No obvious AI artifacts or distorted objects?
+5. CULTURAL APPROPRIATENESS: Is the image culturally appropriate for the region?
 
 Respond in JSON only: {{"verdict":"pass" or "fail", "confidence":0.0 to 1.0, "feedback":"one sentence", "suggested_focus":"if fail, what to focus on instead"}}"""
 

--- a/mystery_agents/tools/publisher_tools.py
+++ b/mystery_agents/tools/publisher_tools.py
@@ -150,8 +150,11 @@ def _upload_images_internal(mystery_id: str, image_paths: list[str]) -> dict:
 
         # Rename file to mystery_id-based name
         variant_suffix = ""
-        for label in ("_sm", "_md", "_lg", "_xl"):
+        is_thumbnail = False
+        for label in ("_thumb", "_sm", "_md", "_lg", "_xl"):
             if p.stem.endswith(label):
+                if label == "_thumb":
+                    is_thumbnail = True
                 variant_suffix = label
                 break
         new_filename = f"{mystery_id}{variant_suffix}{p.suffix}"
@@ -195,11 +198,15 @@ def _upload_images_internal(mystery_id: str, image_paths: list[str]) -> dict:
                 f"/o/{blob_name.replace('/', '%2F')}?alt=media"
             )
 
-        lbl = variant_suffix.lstrip("_") if variant_suffix else "original"
-        if lbl == "original":
-            images["hero"] = public_url
+        # サムネイルは images["thumbnail"] に、それ以外は hero/variants に格納
+        if is_thumbnail:
+            images["thumbnail"] = public_url
         else:
-            variants[lbl] = public_url
+            lbl = variant_suffix.lstrip("_") if variant_suffix else "original"
+            if lbl == "original":
+                images["hero"] = public_url
+            else:
+                variants[lbl] = public_url
 
     if variants:
         if "lg" in variants:
@@ -383,6 +390,10 @@ def publish_mystery(
                 for variant in image_source.get("variants", []):
                     if variant.get("filepath"):
                         image_paths.append(variant["filepath"])
+                # サムネイルも含める
+                thumb = image_source.get("thumbnail")
+                if thumb and isinstance(thumb, dict) and thumb.get("filepath"):
+                    image_paths.append(thumb["filepath"])
                 if image_paths:
                     images = _upload_images_internal(mystery_id, image_paths)
                     if images:
@@ -398,6 +409,10 @@ def publish_mystery(
                     for variant in visual_assets.get("variants", []):
                         if variant.get("filepath"):
                             image_paths.append(variant["filepath"])
+                    # サムネイルも含める
+                    thumb = visual_assets.get("thumbnail")
+                    if thumb and isinstance(thumb, dict) and thumb.get("filepath"):
+                        image_paths.append(thumb["filepath"])
 
                     if image_paths:
                         images = _upload_images_internal(mystery_id, image_paths)
@@ -514,8 +529,11 @@ def upload_images(mystery_id: str, image_paths: str) -> str:
 
             # Rename file to mystery_id-based name
             variant_suffix = ""
-            for label in ("_sm", "_md", "_lg", "_xl"):
+            is_thumbnail = False
+            for label in ("_thumb", "_sm", "_md", "_lg", "_xl"):
                 if p.stem.endswith(label):
+                    if label == "_thumb":
+                        is_thumbnail = True
                     variant_suffix = label
                     break
             new_filename = f"{mystery_id}{variant_suffix}{p.suffix}"
@@ -548,7 +566,7 @@ def upload_images(mystery_id: str, image_paths: str) -> str:
 
             uploaded.append({
                 "path": local_path,
-                "label": variant_suffix.lstrip("_") if variant_suffix else "original",
+                "label": "thumb" if is_thumbnail else (variant_suffix.lstrip("_") if variant_suffix else "original"),
                 "status": "success",
                 "storage_path": f"gs://{bucket.name}/{blob_name}",
                 "public_url": public_url,
@@ -561,7 +579,9 @@ def upload_images(mystery_id: str, image_paths: str) -> str:
             if entry["status"] != "success":
                 continue
             lbl = entry["label"]
-            if lbl == "original":
+            if lbl == "thumb":
+                images["thumbnail"] = entry["public_url"]
+            elif lbl == "original":
                 images["hero"] = entry["public_url"]
             else:
                 variants[lbl] = entry["public_url"]

--- a/mystery_agents/tools/style_registry.py
+++ b/mystery_agents/tools/style_registry.py
@@ -1,0 +1,322 @@
+"""地域アートスタイルレジストリ。
+
+(region, content_type) → ArtStyle のルックアップテーブル。
+Illustrator が記事の地域に応じた画像スタイルを適用するために使用する。
+"""
+
+from dataclasses import dataclass
+
+# コンテンツタイプ定数
+CONTENT_TYPE_FACT = "fact"
+CONTENT_TYPE_FOLKLORE = "folklore"
+
+# フォールバックリージョン
+FALLBACK_REGION = "EU"
+
+
+@dataclass(frozen=True)
+class ArtStyle:
+    """画像生成スタイル定義。"""
+
+    region: str  # ISO 3166-1 alpha-2
+    content_type: str  # "fact" | "folklore"
+    style_prefix: str  # Imagen プロンプトに付加
+    negative_prompt: str
+    description: str  # validate_image 用
+
+
+# 11リージョン × 2タイプ = 22種
+_STYLE_REGISTRY: dict[tuple[str, str], ArtStyle] = {
+    # --- US: アメリカ ---
+    ("US", CONTENT_TYPE_FACT): ArtStyle(
+        region="US",
+        content_type=CONTENT_TYPE_FACT,
+        style_prefix=(
+            "Black and white archival photograph style, monochrome, "
+            "high contrast, vintage silver gelatin print texture, "
+            "documentary photography aesthetic. "
+        ),
+        negative_prompt="color, modern elements, digital artifacts, cartoon, illustration",
+        description="Black and white archival photograph, monochrome, silver gelatin print",
+    ),
+    ("US", CONTENT_TYPE_FOLKLORE): ArtStyle(
+        region="US",
+        content_type=CONTENT_TYPE_FOLKLORE,
+        style_prefix=(
+            "19th century American woodcut engraving illustration style, "
+            "cross-hatching technique, sepia toned, aged paper texture, "
+            "vintage newspaper illustration aesthetic. "
+        ),
+        negative_prompt="photograph, modern elements, digital art, 3D render, color photography",
+        description="19th century American woodcut engraving, cross-hatching, sepia toned",
+    ),
+    # --- JP: 日本 ---
+    ("JP", CONTENT_TYPE_FACT): ArtStyle(
+        region="JP",
+        content_type=CONTENT_TYPE_FACT,
+        style_prefix=(
+            "Meiji-era albumen print photograph style, sepia-toned monochrome, "
+            "soft focus, faded edges, vintage Japanese documentary photography, "
+            "hand-tinted details. "
+        ),
+        negative_prompt="modern elements, digital artifacts, cartoon, anime, bright colors",
+        description="Meiji-era albumen print photograph, sepia-toned, soft focus, vintage Japanese photography",
+    ),
+    ("JP", CONTENT_TYPE_FOLKLORE): ArtStyle(
+        region="JP",
+        content_type=CONTENT_TYPE_FOLKLORE,
+        style_prefix=(
+            "Ukiyo-e woodblock print style, bold outlines, flat color areas, "
+            "traditional Japanese color palette, washi paper texture, "
+            "Edo-period artistic aesthetic. "
+        ),
+        negative_prompt="photograph, 3D render, realistic, modern elements, Western art style",
+        description="Ukiyo-e woodblock print, bold outlines, traditional Japanese color palette",
+    ),
+    # --- GB: イギリス ---
+    ("GB", CONTENT_TYPE_FACT): ArtStyle(
+        region="GB",
+        content_type=CONTENT_TYPE_FACT,
+        style_prefix=(
+            "Victorian wet plate collodion photograph style, monochrome, "
+            "long exposure softness, dark vignetting, glass plate negative aesthetic, "
+            "mid-19th century British documentary photography. "
+        ),
+        negative_prompt="color, modern elements, digital artifacts, sharp digital focus, cartoon",
+        description="Victorian wet plate collodion photograph, monochrome, dark vignetting",
+    ),
+    ("GB", CONTENT_TYPE_FOLKLORE): ArtStyle(
+        region="GB",
+        content_type=CONTENT_TYPE_FOLKLORE,
+        style_prefix=(
+            "Gothic pen and ink illustration style, fine crosshatching, "
+            "dark atmospheric shadows, Victorian book illustration aesthetic, "
+            "intricate linework on aged vellum. "
+        ),
+        negative_prompt="photograph, modern elements, bright colors, digital art, 3D render",
+        description="Gothic pen and ink illustration, fine crosshatching, Victorian book illustration",
+    ),
+    # --- NL: オランダ ---
+    ("NL", CONTENT_TYPE_FACT): ArtStyle(
+        region="NL",
+        content_type=CONTENT_TYPE_FACT,
+        style_prefix=(
+            "Dutch Golden Age oil painting style, Vermeer-inspired lighting, "
+            "rich chiaroscuro, warm amber tones, linen canvas texture, "
+            "17th century Netherlandish realism. "
+        ),
+        negative_prompt="photograph, modern elements, digital art, flat colors, cartoon",
+        description="Dutch Golden Age oil painting, Vermeer-inspired lighting, rich chiaroscuro",
+    ),
+    ("NL", CONTENT_TYPE_FOLKLORE): ArtStyle(
+        region="NL",
+        content_type=CONTENT_TYPE_FOLKLORE,
+        style_prefix=(
+            "Flemish manuscript illumination style, gold leaf accents, "
+            "rich jewel-toned pigments, intricate border decorations, "
+            "medieval Netherlandish book art aesthetic. "
+        ),
+        negative_prompt="photograph, modern elements, digital art, 3D render, monochrome",
+        description="Flemish manuscript illumination, gold leaf accents, medieval Netherlandish book art",
+    ),
+    # --- AU: オーストラリア ---
+    ("AU", CONTENT_TYPE_FACT): ArtStyle(
+        region="AU",
+        content_type=CONTENT_TYPE_FACT,
+        style_prefix=(
+            "Colonial-era lithograph style, hand-tinted stone print, "
+            "muted earth tones, fine detail engraving, "
+            "19th century Australian survey illustration aesthetic. "
+        ),
+        negative_prompt="photograph, modern elements, digital art, bright neon colors, cartoon",
+        description="Colonial-era lithograph, hand-tinted stone print, Australian survey illustration",
+    ),
+    ("AU", CONTENT_TYPE_FOLKLORE): ArtStyle(
+        region="AU",
+        content_type=CONTENT_TYPE_FOLKLORE,
+        style_prefix=(
+            "Australian bush landscape etching style, fine line engraving, "
+            "dramatic light and shadow, eucalyptus and outback scenery, "
+            "colonial-era naturalist illustration aesthetic. "
+        ),
+        negative_prompt="photograph, modern elements, digital art, 3D render, urban setting",
+        description="Australian bush landscape etching, fine line engraving, naturalist illustration",
+    ),
+    # --- NZ: ニュージーランド ---
+    ("NZ", CONTENT_TYPE_FACT): ArtStyle(
+        region="NZ",
+        content_type=CONTENT_TYPE_FACT,
+        style_prefix=(
+            "Colonial survey photograph style, sepia-toned monochrome, "
+            "frontier documentation aesthetic, early gelatin silver print, "
+            "New Zealand landscape survey photography. "
+        ),
+        negative_prompt="color, modern elements, digital artifacts, cartoon, illustration",
+        description="Colonial survey photograph, sepia-toned, New Zealand frontier documentation",
+    ),
+    ("NZ", CONTENT_TYPE_FOLKLORE): ArtStyle(
+        region="NZ",
+        content_type=CONTENT_TYPE_FOLKLORE,
+        style_prefix=(
+            "Native flora landscape etching style, botanical illustration technique, "
+            "fine line engraving of fern forests and volcanic terrain, "
+            "19th century New Zealand naturalist aesthetic. "
+        ),
+        negative_prompt="photograph, modern elements, digital art, 3D render, urban setting",
+        description="Native flora landscape etching, botanical illustration, New Zealand naturalist",
+    ),
+    # --- DE: ドイツ ---
+    ("DE", CONTENT_TYPE_FACT): ArtStyle(
+        region="DE",
+        content_type=CONTENT_TYPE_FACT,
+        style_prefix=(
+            "Daguerreotype photograph style, mirror-like silver surface, "
+            "sharp central focus with soft edges, copper plate aesthetic, "
+            "early 19th century German portrait photography. "
+        ),
+        negative_prompt="color, modern elements, digital artifacts, cartoon, illustration, paper texture",
+        description="Daguerreotype photograph, mirror-like silver surface, early German photography",
+    ),
+    ("DE", CONTENT_TYPE_FOLKLORE): ArtStyle(
+        region="DE",
+        content_type=CONTENT_TYPE_FOLKLORE,
+        style_prefix=(
+            "German Expressionist woodcut print style, bold angular forms, "
+            "stark black and white contrast, emotional intensity, "
+            "Die Brücke movement aesthetic, rough-hewn linework. "
+        ),
+        negative_prompt="photograph, soft colors, realistic, digital art, smooth gradients",
+        description="German Expressionist woodcut, bold angular forms, stark black and white contrast",
+    ),
+    # --- FR: フランス ---
+    ("FR", CONTENT_TYPE_FACT): ArtStyle(
+        region="FR",
+        content_type=CONTENT_TYPE_FACT,
+        style_prefix=(
+            "Eugène Atget-style documentary photograph, matte albumen print, "
+            "soft morning light, empty Parisian streets aesthetic, "
+            "early 20th century French architectural photography. "
+        ),
+        negative_prompt="color, modern elements, digital artifacts, cartoon, illustration, people",
+        description="Atget-style documentary photograph, matte albumen print, early French photography",
+    ),
+    ("FR", CONTENT_TYPE_FOLKLORE): ArtStyle(
+        region="FR",
+        content_type=CONTENT_TYPE_FOLKLORE,
+        style_prefix=(
+            "Art Nouveau illustration style, flowing organic lines, "
+            "Mucha-inspired decorative borders, muted jewel tones, "
+            "Belle Époque poster aesthetic, sinuous botanical motifs. "
+        ),
+        negative_prompt="photograph, modern elements, geometric shapes, 3D render, monochrome",
+        description="Art Nouveau illustration, flowing organic lines, Belle Époque poster aesthetic",
+    ),
+    # --- ES: スペイン ---
+    ("ES", CONTENT_TYPE_FACT): ArtStyle(
+        region="ES",
+        content_type=CONTENT_TYPE_FACT,
+        style_prefix=(
+            "Spanish court portrait etching style, fine intaglio engraving, "
+            "formal composition, rich dark tones, copperplate line quality, "
+            "Habsburg-era Iberian printmaking aesthetic. "
+        ),
+        negative_prompt="color photography, modern elements, digital art, cartoon, bright colors",
+        description="Spanish court portrait etching, fine intaglio engraving, Habsburg-era printmaking",
+    ),
+    ("ES", CONTENT_TYPE_FOLKLORE): ArtStyle(
+        region="ES",
+        content_type=CONTENT_TYPE_FOLKLORE,
+        style_prefix=(
+            "Goya Los Caprichos-inspired aquatint style, dramatic tonal gradations, "
+            "grotesque and fantastical elements, dark satirical atmosphere, "
+            "Spanish Romantic printmaking aesthetic. "
+        ),
+        negative_prompt="photograph, modern elements, digital art, bright cheerful colors, 3D render",
+        description="Goya Caprichos-inspired aquatint, dramatic tonal gradations, Spanish Romantic printmaking",
+    ),
+    # --- PT: ポルトガル ---
+    ("PT", CONTENT_TYPE_FACT): ArtStyle(
+        region="PT",
+        content_type=CONTENT_TYPE_FACT,
+        style_prefix=(
+            "Age of Exploration nautical chart style, hand-drawn cartography, "
+            "compass roses, sea monsters at margins, parchment background, "
+            "Portuguese maritime illustration aesthetic. "
+        ),
+        negative_prompt="photograph, modern elements, digital art, 3D render, monochrome photograph",
+        description="Age of Exploration nautical chart, hand-drawn cartography, Portuguese maritime illustration",
+    ),
+    ("PT", CONTENT_TYPE_FOLKLORE): ArtStyle(
+        region="PT",
+        content_type=CONTENT_TYPE_FOLKLORE,
+        style_prefix=(
+            "Maritime engraving illustration style, copper-line ship details, "
+            "wave patterns in fine crosshatching, aged nautical document aesthetic, "
+            "Portuguese Age of Discovery printmaking. "
+        ),
+        negative_prompt="photograph, modern elements, digital art, 3D render, bright colors",
+        description="Maritime engraving, copper-line details, Portuguese Age of Discovery printmaking",
+    ),
+    # --- EU: ヨーロッパ（フォールバック） ---
+    ("EU", CONTENT_TYPE_FACT): ArtStyle(
+        region="EU",
+        content_type=CONTENT_TYPE_FACT,
+        style_prefix=(
+            "Carte de visite photograph style, small-format albumen print, "
+            "oval vignette framing, studio backdrop, "
+            "19th century European portrait photography aesthetic. "
+        ),
+        negative_prompt="color, modern elements, digital artifacts, cartoon, illustration",
+        description="Carte de visite photograph, small-format albumen print, 19th century European photography",
+    ),
+    ("EU", CONTENT_TYPE_FOLKLORE): ArtStyle(
+        region="EU",
+        content_type=CONTENT_TYPE_FOLKLORE,
+        style_prefix=(
+            "Renaissance copperplate engraving style, fine burin linework, "
+            "classical composition, detailed hatching technique, "
+            "Albrecht Dürer-inspired European printmaking aesthetic. "
+        ),
+        negative_prompt="photograph, modern elements, digital art, bright colors, 3D render",
+        description="Renaissance copperplate engraving, fine burin linework, Dürer-inspired printmaking",
+    ),
+}
+
+
+def get_art_style(region: str, content_type: str) -> ArtStyle:
+    """リージョンとコンテンツタイプに応じたアートスタイルを返す。
+
+    不明なリージョンは EU にフォールバック。
+    不正な content_type は fact にフォールバック。
+
+    Args:
+        region: ISO 3166-1 alpha-2 国コード（例: "US", "JP", "GB"）
+        content_type: "fact" または "folklore"
+
+    Returns:
+        対応する ArtStyle
+    """
+    # content_type の正規化
+    if content_type not in (CONTENT_TYPE_FACT, CONTENT_TYPE_FOLKLORE):
+        content_type = CONTENT_TYPE_FACT
+
+    region = region.upper()
+
+    # 完全一致
+    key = (region, content_type)
+    if key in _STYLE_REGISTRY:
+        return _STYLE_REGISTRY[key]
+
+    # リージョン不明 → EU フォールバック
+    fallback_key = (FALLBACK_REGION, content_type)
+    return _STYLE_REGISTRY[fallback_key]
+
+
+def get_all_regions() -> list[str]:
+    """登録済みの全リージョンコードを返す。"""
+    return sorted({style.region for style in _STYLE_REGISTRY.values()})
+
+
+def get_style_description(region: str, content_type: str) -> str:
+    """リージョンとコンテンツタイプに応じたスタイル説明文を返す。"""
+    return get_art_style(region, content_type).description

--- a/tests/unit/test_illustrator_tools.py
+++ b/tests/unit/test_illustrator_tools.py
@@ -264,7 +264,7 @@ class TestGenerateImageStyles:
 
     @patch("mystery_agents.tools.illustrator_tools._get_client")
     def test_fact_style_prefix(self, mock_get_client):
-        """Should add monochrome prefix for fact style."""
+        """Should add style prefix from registry for fact style."""
         mock_client = MagicMock()
         mock_get_client.return_value = mock_client
 
@@ -273,15 +273,16 @@ class TestGenerateImageStyles:
         mock_response.generated_images = [MagicMock(image=mock_image)]
         mock_client.models.generate_images.return_value = mock_response
 
+        # EU(デフォルト) の fact スタイル → carte de visite
         result = generate_image("A ship's log", style="fact")
         result_data = json.loads(result)
 
-        assert "Black and white" in result_data["prompt_used"]
+        assert "Carte de visite" in result_data["prompt_used"]
         assert result_data["style"] == "fact"
 
     @patch("mystery_agents.tools.illustrator_tools._get_client")
     def test_folklore_style_prefix(self, mock_get_client):
-        """Should add woodcut prefix for folklore style."""
+        """Should add style prefix from registry for folklore style."""
         mock_client = MagicMock()
         mock_get_client.return_value = mock_client
 
@@ -290,10 +291,11 @@ class TestGenerateImageStyles:
         mock_response.generated_images = [MagicMock(image=mock_image)]
         mock_client.models.generate_images.return_value = mock_response
 
+        # EU(デフォルト) の folklore スタイル → Renaissance copperplate
         result = generate_image("A mysterious ship", style="folklore")
         result_data = json.loads(result)
 
-        assert "woodcut" in result_data["prompt_used"]
+        assert "Renaissance" in result_data["prompt_used"] or "copperplate" in result_data["prompt_used"]
         assert result_data["style"] == "folklore"
 
     @patch("mystery_agents.tools.illustrator_tools._get_client")
@@ -582,14 +584,22 @@ class TestBuildSafeFallbackPrompt:
     """Tests for _build_safe_fallback_prompt function."""
 
     def test_fact_style_returns_archival_prompt(self):
-        """Should return a monochrome archival-style prompt for fact style."""
-        result = _build_safe_fallback_prompt("fact")
-        assert "black and white" in result.lower() or "monochrome" in result.lower()
+        """Should return a region-appropriate archival-style prompt for fact style."""
+        # US の fact → B&W 銀塩写真
+        result = _build_safe_fallback_prompt("fact", "US")
+        assert "silver gelatin" in result.lower() or "monochrome" in result.lower()
+        # EU（デフォルト）の fact → Carte de visite
+        result_eu = _build_safe_fallback_prompt("fact")
+        assert "carte de visite" in result_eu.lower() or "albumen" in result_eu.lower()
 
     def test_folklore_style_returns_woodcut_prompt(self):
-        """Should return a woodcut/engraving-style prompt for folklore style."""
-        result = _build_safe_fallback_prompt("folklore")
-        assert "woodcut" in result.lower() or "engraving" in result.lower()
+        """Should return a region-appropriate art-style prompt for folklore style."""
+        # US の folklore → woodcut
+        result = _build_safe_fallback_prompt("folklore", "US")
+        assert "woodcut" in result.lower()
+        # EU（デフォルト）の folklore → Renaissance copperplate
+        result_eu = _build_safe_fallback_prompt("folklore")
+        assert "renaissance" in result_eu.lower() or "copperplate" in result_eu.lower()
 
     def test_auto_style_returns_prompt(self):
         """Should return a valid prompt for auto style."""
@@ -914,7 +924,7 @@ class TestBuildContextualSafePrompt:
         mock_ctx = MagicMock()
         mock_ctx.state = {"creative_content": "The Bell Witch legend of Tennessee..."}
 
-        result = _build_contextual_safe_prompt("folklore", mock_ctx)
+        result = _build_contextual_safe_prompt("folklore", "US", mock_ctx)
 
         assert result == "A weathered farmhouse in 1817 Tennessee at twilight"
         mock_client.models.generate_content.assert_called_once()
@@ -929,24 +939,24 @@ class TestBuildContextualSafePrompt:
         mock_ctx = MagicMock()
         mock_ctx.state = {"creative_content": "Some article content..."}
 
-        result = _build_contextual_safe_prompt("fact", mock_ctx)
+        result = _build_contextual_safe_prompt("fact", "US", mock_ctx)
 
-        # _build_safe_fallback_prompt("fact") の結果が返る
-        assert "black and white" in result.lower() or "monochrome" in result.lower()
+        # _build_safe_fallback_prompt("fact", "US") の結果が返る
+        assert "silver gelatin" in result.lower() or "monochrome" in result.lower()
 
     def test_contextual_no_creative_content(self):
         """creative_content なしで汎用フォールバック。"""
         mock_ctx = MagicMock()
         mock_ctx.state = {}
 
-        result = _build_contextual_safe_prompt("folklore", mock_ctx)
+        result = _build_contextual_safe_prompt("folklore", "US", mock_ctx)
 
-        # _build_safe_fallback_prompt("folklore") の結果が返る
-        assert "woodcut" in result.lower() or "engraving" in result.lower()
+        # _build_safe_fallback_prompt("folklore", "US") の結果が返る
+        assert "woodcut" in result.lower()
 
     def test_contextual_no_tool_context(self):
         """tool_context が None で汎用フォールバック。"""
-        result = _build_contextual_safe_prompt("auto", None)
+        result = _build_contextual_safe_prompt("auto", "EU", None)
 
         # _build_safe_fallback_prompt("auto") の結果が返る
         assert len(result) > 20
@@ -956,9 +966,9 @@ class TestBuildContextualSafePrompt:
         mock_ctx = MagicMock()
         mock_ctx.state = {"creative_content": "NO_CONTENT"}
 
-        result = _build_contextual_safe_prompt("fact", mock_ctx)
+        result = _build_contextual_safe_prompt("fact", "US", mock_ctx)
 
-        assert "black and white" in result.lower() or "monochrome" in result.lower()
+        assert "silver gelatin" in result.lower() or "monochrome" in result.lower()
 
 
 class TestValidateImage:
@@ -1147,3 +1157,122 @@ class TestValidateImage:
 
         assert result["status"] == "error"
         assert "load" in result["error"].lower() or "image" in result["error"].lower()
+
+    @patch("mystery_agents.tools.illustrator_tools._get_client")
+    def test_validate_with_region_param(self, mock_get_client, tmp_path):
+        """region パラメータがバリデーションプロンプトに反映される。"""
+        from PIL import Image as PILImage
+
+        img_path = tmp_path / "test.png"
+        PILImage.new("RGB", (100, 100), "red").save(str(img_path))
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.text = json.dumps({
+            "verdict": "pass", "confidence": 0.9,
+            "feedback": "Good", "suggested_focus": "",
+        })
+        mock_client.models.generate_content.return_value = mock_response
+
+        result = json.loads(validate_image(str(img_path), "test theme", style="fact", region="JP"))
+
+        assert result["verdict"] == "pass"
+        # バリデーションプロンプトに Region: JP が含まれることを確認
+        call_args = mock_client.models.generate_content.call_args
+        prompt_text = call_args[1]["contents"][1]
+        assert "JP" in prompt_text
+
+
+class TestGenerateImageRegion:
+    """generate_image の region パラメータテスト。"""
+
+    @patch("mystery_agents.tools.illustrator_tools._get_client")
+    def test_jp_fact_uses_meiji_style(self, mock_get_client):
+        """JP + fact → 明治スタイルプレフィックスが使われる。"""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_image = MagicMock()
+        mock_response = MagicMock()
+        mock_response.generated_images = [MagicMock(image=mock_image)]
+        mock_client.models.generate_images.return_value = mock_response
+
+        result = generate_image("A temple scene", style="fact", region="JP")
+        result_data = json.loads(result)
+
+        assert result_data["region"] == "JP"
+        prompt = result_data["prompt_used"].lower()
+        assert "meiji" in prompt or "albumen" in prompt
+
+    @patch("mystery_agents.tools.illustrator_tools._get_client")
+    def test_jp_folklore_uses_ukiyoe_style(self, mock_get_client):
+        """JP + folklore → 浮世絵スタイルプレフィックスが使われる。"""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_image = MagicMock()
+        mock_response = MagicMock()
+        mock_response.generated_images = [MagicMock(image=mock_image)]
+        mock_client.models.generate_images.return_value = mock_response
+
+        result = generate_image("A mysterious scene", style="folklore", region="JP")
+        result_data = json.loads(result)
+
+        assert result_data["region"] == "JP"
+        assert "Ukiyo-e" in result_data["prompt_used"]
+
+    @patch("mystery_agents.tools.illustrator_tools._get_client")
+    def test_gb_fact_uses_victorian_style(self, mock_get_client):
+        """GB + fact → ヴィクトリアスタイルプレフィックスが使われる。"""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_image = MagicMock()
+        mock_response = MagicMock()
+        mock_response.generated_images = [MagicMock(image=mock_image)]
+        mock_client.models.generate_images.return_value = mock_response
+
+        result = generate_image("A London scene", style="fact", region="GB")
+        result_data = json.loads(result)
+
+        assert result_data["region"] == "GB"
+        prompt = result_data["prompt_used"].lower()
+        assert "victorian" in prompt or "wet plate" in prompt
+
+    @patch("mystery_agents.tools.illustrator_tools._get_client")
+    def test_unknown_region_falls_back_to_eu(self, mock_get_client):
+        """不明リージョンは EU にフォールバック。"""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_image = MagicMock()
+        mock_response = MagicMock()
+        mock_response.generated_images = [MagicMock(image=mock_image)]
+        mock_client.models.generate_images.return_value = mock_response
+
+        result = generate_image("A scene", style="fact", region="XX")
+        result_data = json.loads(result)
+
+        assert result_data["region"] == "XX"
+        # EU フォールバックの carte de visite スタイル
+        assert "Carte de visite" in result_data["prompt_used"]
+
+    @patch("mystery_agents.tools.illustrator_tools._get_client")
+    def test_result_includes_thumbnail(self, mock_get_client):
+        """成功時のレスポンスに thumbnail が含まれる。"""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_image = MagicMock()
+        mock_response = MagicMock()
+        mock_response.generated_images = [MagicMock(image=mock_image)]
+        mock_client.models.generate_images.return_value = mock_response
+
+        result = generate_image("A test", style="auto")
+        result_data = json.loads(result)
+
+        # thumbnail は None (PILImage.open がモック画像ファイルを開けないため)
+        # または dict (実際の画像ファイルがある場合)
+        assert "thumbnail" in result_data

--- a/tests/unit/test_publisher_tools.py
+++ b/tests/unit/test_publisher_tools.py
@@ -947,3 +947,65 @@ class TestPublishMysteryStateDirectRead:
         assert saved["narrative_content"] == "LLM provided content"
         assert saved["raw_data"] == "LLM provided raw data"
 
+
+class TestThumbnailUpload:
+    """サムネイルアップロードのテスト。"""
+
+    @patch("mystery_agents.tools.publisher_tools.get_storage_bucket")
+    def test_thumb_suffix_stored_as_thumbnail(self, mock_get_bucket, tmp_path):
+        """_thumb サフィックスが images["thumbnail"] に格納される。"""
+        mock_bucket = MagicMock()
+        mock_blob = MagicMock()
+        mock_bucket.blob.return_value = mock_blob
+        mock_bucket.name = "test-bucket"
+        mock_get_bucket.return_value = mock_bucket
+
+        thumb_file = tmp_path / "header_thumb.webp"
+        thumb_file.write_bytes(b"fake thumb data")
+
+        result = upload_images("TEST-001", json.dumps([str(thumb_file)]))
+        result_data = json.loads(result)
+
+        assert result_data["status"] == "success"
+        assert "thumbnail" in result_data["images"]
+        assert result_data["images"]["thumbnail"].endswith("alt=media")
+
+    @patch("mystery_agents.tools.publisher_tools.get_storage_bucket")
+    def test_thumb_and_variants_together(self, mock_get_bucket, tmp_path):
+        """サムネイルとバリアントが同時にアップロードされる。"""
+        mock_bucket = MagicMock()
+        mock_blob = MagicMock()
+        mock_bucket.blob.return_value = mock_blob
+        mock_bucket.name = "test-bucket"
+        mock_get_bucket.return_value = mock_bucket
+
+        # メイン画像 + サムネイル + sm バリアント
+        for name in ("header.png", "header_thumb.webp", "header_sm.webp"):
+            f = tmp_path / name
+            f.write_bytes(b"fake data")
+
+        paths = [str(tmp_path / n) for n in ("header.png", "header_thumb.webp", "header_sm.webp")]
+        result = upload_images("TEST-001", json.dumps(paths))
+        result_data = json.loads(result)
+
+        assert result_data["status"] == "success"
+        assert "thumbnail" in result_data["images"]
+        assert "hero" in result_data["images"]
+
+    @patch("mystery_agents.tools.publisher_tools.get_storage_bucket")
+    def test_internal_upload_thumb_suffix(self, mock_get_bucket, tmp_path):
+        """_upload_images_internal が _thumb を images["thumbnail"] に格納する。"""
+        mock_bucket = MagicMock()
+        mock_blob = MagicMock()
+        mock_bucket.blob.return_value = mock_blob
+        mock_bucket.name = "test-bucket"
+        mock_get_bucket.return_value = mock_bucket
+
+        thumb_file = tmp_path / "header_thumb.webp"
+        thumb_file.write_bytes(b"fake thumb data")
+
+        images = _upload_images_internal("TEST-001", [str(thumb_file)])
+
+        assert "thumbnail" in images
+        assert "hero" not in images  # サムネイルだけなら hero は設定されない
+

--- a/tests/unit/test_style_registry.py
+++ b/tests/unit/test_style_registry.py
@@ -1,0 +1,238 @@
+"""Unit tests for style_registry."""
+
+from mystery_agents.tools.style_registry import (
+    ArtStyle,
+    CONTENT_TYPE_FACT,
+    CONTENT_TYPE_FOLKLORE,
+    FALLBACK_REGION,
+    get_all_regions,
+    get_art_style,
+    get_style_description,
+)
+
+
+class TestGetArtStyle:
+    """get_art_style の正常系テスト。"""
+
+    def test_us_fact(self):
+        """US + fact → B&W 銀塩写真スタイル。"""
+        style = get_art_style("US", "fact")
+        assert isinstance(style, ArtStyle)
+        assert style.region == "US"
+        assert style.content_type == "fact"
+        assert "silver gelatin" in style.style_prefix.lower()
+
+    def test_us_folklore(self):
+        """US + folklore → アメリカ木版画スタイル。"""
+        style = get_art_style("US", "folklore")
+        assert style.region == "US"
+        assert style.content_type == "folklore"
+        assert "woodcut" in style.style_prefix.lower()
+
+    def test_jp_fact(self):
+        """JP + fact → 明治アルビュメンプリント。"""
+        style = get_art_style("JP", "fact")
+        assert style.region == "JP"
+        assert "meiji" in style.style_prefix.lower() or "albumen" in style.style_prefix.lower()
+
+    def test_jp_folklore(self):
+        """JP + folklore → 浮世絵スタイル。"""
+        style = get_art_style("JP", "folklore")
+        assert style.region == "JP"
+        assert "ukiyo" in style.style_prefix.lower()
+
+    def test_gb_fact(self):
+        """GB + fact → ヴィクトリア湿板写真。"""
+        style = get_art_style("GB", "fact")
+        assert style.region == "GB"
+        assert "victorian" in style.style_prefix.lower() or "wet plate" in style.style_prefix.lower()
+
+    def test_gb_folklore(self):
+        """GB + folklore → ゴシック・ペン画。"""
+        style = get_art_style("GB", "folklore")
+        assert style.region == "GB"
+        assert "gothic" in style.style_prefix.lower()
+
+    def test_nl_fact(self):
+        """NL + fact → オランダ黄金時代油彩。"""
+        style = get_art_style("NL", "fact")
+        assert style.region == "NL"
+        assert "dutch golden age" in style.style_prefix.lower() or "vermeer" in style.style_prefix.lower()
+
+    def test_nl_folklore(self):
+        """NL + folklore → フランドル写本装飾。"""
+        style = get_art_style("NL", "folklore")
+        assert style.region == "NL"
+        assert "flemish" in style.style_prefix.lower()
+
+    def test_au_fact(self):
+        """AU + fact → 植民地リトグラフ。"""
+        style = get_art_style("AU", "fact")
+        assert style.region == "AU"
+        assert "colonial" in style.style_prefix.lower() or "lithograph" in style.style_prefix.lower()
+
+    def test_au_folklore(self):
+        """AU + folklore → ブッシュ風景エッチング。"""
+        style = get_art_style("AU", "folklore")
+        assert style.region == "AU"
+        assert "bush" in style.style_prefix.lower() or "etching" in style.style_prefix.lower()
+
+    def test_nz_fact(self):
+        """NZ + fact → 植民地測量写真。"""
+        style = get_art_style("NZ", "fact")
+        assert style.region == "NZ"
+
+    def test_nz_folklore(self):
+        """NZ + folklore → 在来植物風景エッチング。"""
+        style = get_art_style("NZ", "folklore")
+        assert style.region == "NZ"
+
+    def test_de_fact(self):
+        """DE + fact → ダゲレオタイプ。"""
+        style = get_art_style("DE", "fact")
+        assert style.region == "DE"
+        assert "daguerreotype" in style.style_prefix.lower()
+
+    def test_de_folklore(self):
+        """DE + folklore → ドイツ表現主義木版画。"""
+        style = get_art_style("DE", "folklore")
+        assert style.region == "DE"
+        assert "expressionist" in style.style_prefix.lower()
+
+    def test_fr_fact(self):
+        """FR + fact → アジェ風ドキュメンタリー写真。"""
+        style = get_art_style("FR", "fact")
+        assert style.region == "FR"
+        assert "atget" in style.style_prefix.lower()
+
+    def test_fr_folklore(self):
+        """FR + folklore → アール・ヌーヴォー。"""
+        style = get_art_style("FR", "folklore")
+        assert style.region == "FR"
+        assert "art nouveau" in style.style_prefix.lower()
+
+    def test_es_fact(self):
+        """ES + fact → 宮廷肖像エッチング。"""
+        style = get_art_style("ES", "fact")
+        assert style.region == "ES"
+
+    def test_es_folklore(self):
+        """ES + folklore → ゴヤ・カプリチョス風。"""
+        style = get_art_style("ES", "folklore")
+        assert style.region == "ES"
+        assert "goya" in style.style_prefix.lower() or "caprichos" in style.style_prefix.lower()
+
+    def test_pt_fact(self):
+        """PT + fact → 大航海時代海図。"""
+        style = get_art_style("PT", "fact")
+        assert style.region == "PT"
+        assert "nautical" in style.style_prefix.lower() or "exploration" in style.style_prefix.lower()
+
+    def test_pt_folklore(self):
+        """PT + folklore → 海洋エングレービング。"""
+        style = get_art_style("PT", "folklore")
+        assert style.region == "PT"
+        assert "maritime" in style.style_prefix.lower() or "engraving" in style.style_prefix.lower()
+
+    def test_eu_fact(self):
+        """EU + fact → カルト・ド・ヴィジット。"""
+        style = get_art_style("EU", "fact")
+        assert style.region == "EU"
+        assert "carte de visite" in style.style_prefix.lower()
+
+    def test_eu_folklore(self):
+        """EU + folklore → ルネサンス銅版画。"""
+        style = get_art_style("EU", "folklore")
+        assert style.region == "EU"
+        assert "renaissance" in style.style_prefix.lower() or "copperplate" in style.style_prefix.lower()
+
+
+class TestGetArtStyleFallback:
+    """フォールバック動作のテスト。"""
+
+    def test_unknown_region_falls_back_to_eu(self):
+        """不明リージョンは EU にフォールバック。"""
+        style = get_art_style("XX", "fact")
+        assert style.region == FALLBACK_REGION
+        assert style.content_type == "fact"
+
+    def test_unknown_region_folklore_falls_back_to_eu(self):
+        """不明リージョン + folklore → EU folklore。"""
+        style = get_art_style("ZZ", "folklore")
+        assert style.region == FALLBACK_REGION
+        assert style.content_type == "folklore"
+
+    def test_invalid_content_type_falls_back_to_fact(self):
+        """不正 content_type → fact にフォールバック。"""
+        style = get_art_style("US", "invalid")
+        assert style.content_type == "fact"
+
+    def test_empty_content_type_falls_back_to_fact(self):
+        """空 content_type → fact にフォールバック。"""
+        style = get_art_style("JP", "")
+        assert style.content_type == "fact"
+
+    def test_case_insensitive_region(self):
+        """小文字リージョンも正しく解決される。"""
+        style = get_art_style("jp", "fact")
+        assert style.region == "JP"
+
+
+class TestGetAllRegions:
+    """get_all_regions のテスト。"""
+
+    def test_returns_11_regions(self):
+        """11リージョンを返す。"""
+        regions = get_all_regions()
+        assert len(regions) == 11
+
+    def test_includes_all_expected_regions(self):
+        """全リージョンコードが含まれる。"""
+        regions = get_all_regions()
+        expected = {"US", "JP", "GB", "NL", "AU", "NZ", "DE", "FR", "ES", "PT", "EU"}
+        assert set(regions) == expected
+
+    def test_sorted(self):
+        """ソート済みで返る。"""
+        regions = get_all_regions()
+        assert regions == sorted(regions)
+
+
+class TestGetStyleDescription:
+    """get_style_description のテスト。"""
+
+    def test_returns_non_empty_string(self):
+        """全リージョン×タイプで空でない説明文を返す。"""
+        for region in get_all_regions():
+            for ct in ("fact", "folklore"):
+                desc = get_style_description(region, ct)
+                assert isinstance(desc, str)
+                assert len(desc) > 10
+
+
+class TestArtStyleAttributes:
+    """ArtStyle dataclass の属性テスト。"""
+
+    def test_has_negative_prompt(self):
+        """全スタイルが negative_prompt を持つ。"""
+        for region in get_all_regions():
+            for ct in ("fact", "folklore"):
+                style = get_art_style(region, ct)
+                assert style.negative_prompt
+                assert len(style.negative_prompt) > 5
+
+    def test_style_prefix_ends_with_space(self):
+        """style_prefix はスペースで終わる（プロンプト連結時の都合）。"""
+        for region in get_all_regions():
+            for ct in ("fact", "folklore"):
+                style = get_art_style(region, ct)
+                assert style.style_prefix.endswith(" "), f"{region}/{ct}: style_prefix should end with space"
+
+    def test_frozen_dataclass(self):
+        """ArtStyle は frozen（不変）。"""
+        style = get_art_style("US", "fact")
+        try:
+            style.region = "XX"  # type: ignore[misc]
+            assert False, "Should have raised FrozenInstanceError"
+        except AttributeError:
+            pass

--- a/tests/unit/test_thumbnail_generation.py
+++ b/tests/unit/test_thumbnail_generation.py
@@ -1,0 +1,85 @@
+"""Unit tests for thumbnail generation."""
+
+import json
+from pathlib import Path
+
+from PIL import Image as PILImage
+
+from mystery_agents.tools.illustrator_tools import _generate_thumbnail
+
+
+class TestGenerateThumbnail:
+    """_generate_thumbnail のテスト。"""
+
+    def test_generates_400x400_webp(self, tmp_path):
+        """16:9 ソースから 400×400 WebP が生成される。"""
+        # 1600×900 の 16:9 テスト画像を作成
+        src = tmp_path / "header_test.png"
+        img = PILImage.new("RGB", (1600, 900), color="red")
+        img.save(str(src))
+
+        result = _generate_thumbnail(str(src))
+
+        assert result is not None
+        assert result["width"] == 400
+        assert result["height"] == 400
+        assert result["filename"] == "header_test_thumb.webp"
+        assert Path(result["filepath"]).exists()
+
+        # 生成されたファイルが実際に 400×400 であることを確認
+        thumb = PILImage.open(result["filepath"])
+        assert thumb.size == (400, 400)
+        assert thumb.format == "WEBP"
+
+    def test_center_crop_landscape(self, tmp_path):
+        """横長画像の中央クロップが正しい。"""
+        # 1600×400 の極端な横長画像
+        src = tmp_path / "wide.png"
+        img = PILImage.new("RGB", (1600, 400), color="blue")
+        img.save(str(src))
+
+        result = _generate_thumbnail(str(src))
+
+        assert result is not None
+        thumb = PILImage.open(result["filepath"])
+        assert thumb.size == (400, 400)
+
+    def test_center_crop_square(self, tmp_path):
+        """正方形画像はクロップなしでリサイズのみ。"""
+        src = tmp_path / "square.png"
+        img = PILImage.new("RGB", (800, 800), color="green")
+        img.save(str(src))
+
+        result = _generate_thumbnail(str(src))
+
+        assert result is not None
+        thumb = PILImage.open(result["filepath"])
+        assert thumb.size == (400, 400)
+
+    def test_small_source_still_works(self, tmp_path):
+        """400px 未満のソースでも動作する（アップスケール）。"""
+        src = tmp_path / "small.png"
+        img = PILImage.new("RGB", (200, 100), color="yellow")
+        img.save(str(src))
+
+        result = _generate_thumbnail(str(src))
+
+        assert result is not None
+        thumb = PILImage.open(result["filepath"])
+        assert thumb.size == (400, 400)
+
+    def test_nonexistent_source_returns_none(self):
+        """存在しないソースで None を返す。"""
+        result = _generate_thumbnail("/nonexistent/image.png")
+        assert result is None
+
+    def test_output_in_same_directory(self, tmp_path):
+        """出力ファイルがソースと同じディレクトリに作成される。"""
+        src = tmp_path / "header.png"
+        img = PILImage.new("RGB", (1920, 1080), color="white")
+        img.save(str(src))
+
+        result = _generate_thumbnail(str(src))
+
+        assert result is not None
+        assert Path(result["filepath"]).parent == tmp_path

--- a/web-public/src/components/mystery-card.tsx
+++ b/web-public/src/components/mystery-card.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image"
 import Link from "next/link"
 import { FileText, MapPin, Calendar } from "lucide-react"
 import type { FirestoreMystery } from "@ghost/shared/src/types/mystery"
@@ -16,47 +17,65 @@ export function MysteryCard({ mystery, lang = "en", className }: MysteryCardProp
 
   const location = mystery.historical_context?.geographic_scope?.[0] || ""
   const timePeriod = mystery.historical_context?.time_period || ""
+  const thumbnailUrl = mystery.images?.thumbnail
 
   return (
     <Link href={`/${lang}/mystery/${mystery.mystery_id}`} className={cn("block group no-underline", className)}>
       <article className="aged-card letterpress-border rounded-sm p-5 h-full transition-all duration-300 hover:bg-paper-light hover:border-parchment-dark/30 hover:shadow-lg hover:shadow-black/20">
-        {/* File tab decoration */}
-        <div className="flex items-start justify-between gap-3 mb-4">
-          <div className="flex items-center gap-2 text-xs text-muted-foreground font-mono uppercase tracking-wider">
-            <FileText className="w-3.5 h-3.5 text-gold" />
-            <span>{mystery.mystery_id}</span>
+        <div className={cn(thumbnailUrl && "grid grid-cols-[96px_1fr] gap-4")}>
+          {/* サムネイル（あれば表示） */}
+          {thumbnailUrl && (
+            <div className="w-24 h-24 rounded-sm overflow-hidden flex-shrink-0 border border-border/30">
+              <Image
+                src={thumbnailUrl}
+                alt=""
+                width={96}
+                height={96}
+                className="w-full h-full object-cover opacity-90 group-hover:opacity-100 transition-opacity"
+              />
+            </div>
+          )}
+
+          <div className="min-w-0">
+            {/* File tab decoration */}
+            <div className="flex items-start justify-between gap-3 mb-4">
+              <div className="flex items-center gap-2 text-xs text-muted-foreground font-mono uppercase tracking-wider">
+                <FileText className="w-3.5 h-3.5 text-gold" />
+                <span>{mystery.mystery_id}</span>
+              </div>
+              <time className="text-xs text-muted-foreground font-mono">
+                {mystery.publishedAt
+                  ? mystery.publishedAt.toLocaleDateString()
+                  : mystery.createdAt.toLocaleDateString()}
+              </time>
+            </div>
+
+            {/* Title */}
+            <h3 className="font-serif text-lg text-parchment mb-1 leading-tight group-hover:text-gold transition-colors text-balance">
+              {title}
+            </h3>
+
+            {/* Summary */}
+            <p className="text-sm text-foreground/80 leading-relaxed mb-4 line-clamp-3">
+              {summary}
+            </p>
+
+            {/* Footer metadata */}
+            <div className="flex items-center gap-3 pt-3 border-t border-border/50 text-xs text-muted-foreground">
+              {location && (
+                <span className="flex items-center gap-1">
+                  <MapPin className="w-3 h-3" />
+                  {location}
+                </span>
+              )}
+              {timePeriod && (
+                <span className="flex items-center gap-1">
+                  <Calendar className="w-3 h-3" />
+                  {timePeriod}
+                </span>
+              )}
+            </div>
           </div>
-          <time className="text-xs text-muted-foreground font-mono">
-            {mystery.publishedAt
-              ? mystery.publishedAt.toLocaleDateString()
-              : mystery.createdAt.toLocaleDateString()}
-          </time>
-        </div>
-
-        {/* Title */}
-        <h3 className="font-serif text-lg text-parchment mb-1 leading-tight group-hover:text-gold transition-colors text-balance">
-          {title}
-        </h3>
-
-        {/* Summary */}
-        <p className="text-sm text-foreground/80 leading-relaxed mb-4 line-clamp-3">
-          {summary}
-        </p>
-
-        {/* Footer metadata */}
-        <div className="flex items-center gap-3 pt-3 border-t border-border/50 text-xs text-muted-foreground">
-          {location && (
-            <span className="flex items-center gap-1">
-              <MapPin className="w-3 h-3" />
-              {location}
-            </span>
-          )}
-          {timePeriod && (
-            <span className="flex items-center gap-1">
-              <Calendar className="w-3 h-3" />
-              {timePeriod}
-            </span>
-          )}
         </div>
       </article>
     </Link>


### PR DESCRIPTION
## Summary

- **地域アートスタイルレジストリ**: 11リージョン × 2タイプ = 22種の画像スタイルを `style_registry.py` で一元管理。`generate_image` の `region` パラメータで自動適用
- **サムネイル自動生成**: 16:9 ヒーロー画像から中央クロップ 400×400 WebP サムネイルを生成。Publisher → Firestore `images.thumbnail` に保存
- **一覧カード画像表示**: `mystery-card.tsx` にサムネイル付きグリッドレイアウト（レガシー記事はテキストのみにフォールバック）
- **学術領域ビジュアルガイダンス**: Illustrator instruction に5学術領域に応じたビジュアル要素ガイダンスを追加
- **validate_image の地域対応**: 文化的適切性を評価基準に追加

### 対応リージョン

| Region | Fact | Folklore |
|--------|------|----------|
| US | B&W 銀塩写真 | アメリカ木版画 |
| JP | 明治アルビュメンプリント | 浮世絵 |
| GB | ヴィクトリア湿板写真 | ゴシック・ペン画 |
| NL | オランダ黄金時代油彩 | フランドル写本装飾 |
| AU | 植民地リトグラフ | ブッシュ風景エッチング |
| NZ | 植民地測量写真 | 在来植物風景エッチング |
| DE | ダゲレオタイプ | ドイツ表現主義木版画 |
| FR | アジェ風ドキュメンタリー写真 | アール・ヌーヴォー |
| ES | 宮廷肖像エッチング | ゴヤ・カプリチョス風 |
| PT | 大航海時代海図 | 海洋エングレービング |
| EU | カルト・ド・ヴィジット（フォールバック） | ルネサンス銅版画 |

## Test plan

- [x] `test_style_registry.py`: 全11リージョン×2タイプのルックアップ + フォールバック (34件)
- [x] `test_thumbnail_generation.py`: 中央クロップ + WebP 生成 + エッジケース (6件)
- [x] `test_illustrator_tools.py`: region パラメータ + サムネイル含む (73件)
- [x] `test_publisher_tools.py`: _thumb → images.thumbnail 格納 (39件)
- [x] 全 152 テストパス

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)