### PR TITLE
fix: structured_report KeyError 事前初期化

### DIFF
--- a/mystery_agents/tools/theme_analyzer_tools.py
+++ b/mystery_agents/tools/theme_analyzer_tools.py
@@ -60,6 +60,11 @@ def save_language_selection(
     # 討論ホワイトボードを初期化（LoopAgent の累積書き込み用）
     tool_context.state["debate_whiteboard"] = ""
 
+    # structured_report を空 dict で初期化
+    # Illustrator / Translator の instruction が {structured_report} を参照するため、
+    # Armchair Polymath がツールを呼ばなかった場合に KeyError を防ぐ
+    tool_context.state["structured_report"] = {}
+
     # 未選択言語のセッション変数にデフォルト値を設定
     # Scholar の instruction が全言語の {scholar_analysis_*} を参照するため、
     # 未設定だと ADK の template 展開で KeyError になる

--- a/tests/unit/test_theme_analyzer.py
+++ b/tests/unit/test_theme_analyzer.py
@@ -106,6 +106,20 @@ class TestSaveLanguageSelection:
 
         assert ctx.state["debate_whiteboard"] == ""
 
+    def test_structured_report_initialized(self):
+        """structured_report が空 dict で初期化される。"""
+        ctx = self._make_tool_context()
+        save_language_selection('["en", "de"]', ctx)
+
+        assert ctx.state["structured_report"] == {}
+
+    def test_structured_report_not_initialized_on_fallback(self):
+        """フォールバック時には structured_report は初期化されない（早期リターン）。"""
+        ctx = self._make_tool_context()
+        save_language_selection("not valid json", ctx)
+
+        assert "structured_report" not in ctx.state
+
     def test_debate_whiteboard_initialized_on_fallback(self):
         """フォールバック時にも debate_whiteboard が初期化されない（フォールバックは早期リターン）。"""
         ctx = self._make_tool_context()


### PR DESCRIPTION
## Summary

- パイプライン実行時に `KeyError: 'Context variable not found: structured_report'` が Illustrator × 1 + Translator × 6 で発生していた問題を修正
- `save_language_selection()` 内で `structured_report` を空 dict で事前初期化（`debate_whiteboard` / `scholar_analysis_{lang}` と同じパターン）
- Armchair Polymath が `save_structured_report` ツールを呼ばなかった場合の安全弁

## 変更ファイル

- `mystery_agents/tools/theme_analyzer_tools.py` — `structured_report = {}` 初期化追加
- `tests/unit/test_theme_analyzer.py` — テスト2件追加（正常時初期化 + フォールバック時未初期化）

## Test plan

- [x] `pytest tests/unit/test_theme_analyzer.py -v` — 全22テスト PASSED


🤖 Generated with [Claude Code](https://claude.com/claude-code)