### PR TITLE
feat: 記事カードに分類バッジ・メタデータ表示を追加

### DIFF
--- a/web-public/src/app/[lang]/page.tsx
+++ b/web-public/src/app/[lang]/page.tsx
@@ -50,6 +50,7 @@ async function MysteryList({ lang, dict }: { lang: SupportedLang; dict: Dictiona
           mystery={featured}
           lang={lang}
           label={dict.home.featuredStory}
+          classificationLabels={dict.classification}
         />
       </div>
 
@@ -68,7 +69,7 @@ async function MysteryList({ lang, dict }: { lang: SupportedLang; dict: Dictiona
 
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {rest.map((mystery) => (
-              <MysteryCard key={mystery.mystery_id} mystery={mystery} lang={lang} />
+              <MysteryCard key={mystery.mystery_id} mystery={mystery} lang={lang} classificationLabels={dict.classification} />
             ))}
           </div>
         </>

--- a/web-public/src/components/classification-badge.tsx
+++ b/web-public/src/components/classification-badge.tsx
@@ -1,0 +1,44 @@
+import { cn } from "@ghost/shared/src/lib/utils"
+import type { Dictionary } from "@/lib/i18n/dictionaries"
+
+type ClassificationCode = "HIS" | "FLK" | "ANT" | "OCC" | "URB" | "CRM" | "REL" | "LOC"
+
+interface ClassificationBadgeProps {
+  mysteryId: string
+  labels: Dictionary["classification"]
+  className?: string
+}
+
+const colorMap: Record<ClassificationCode, string> = {
+  HIS: "bg-amber-900/30 text-amber-400",
+  FLK: "bg-teal-900/30 text-teal-400",
+  ANT: "bg-orange-900/30 text-orange-400",
+  OCC: "bg-purple-900/30 text-purple-400",
+  URB: "bg-slate-700/30 text-slate-400",
+  CRM: "bg-red-900/30 text-red-400",
+  REL: "bg-indigo-900/30 text-indigo-400",
+  LOC: "bg-emerald-900/30 text-emerald-400",
+}
+
+function extractClassification(mysteryId: string): ClassificationCode | null {
+  const code = mysteryId.slice(0, 3).toUpperCase()
+  if (code in colorMap) return code as ClassificationCode
+  return null
+}
+
+export function ClassificationBadge({ mysteryId, labels, className }: ClassificationBadgeProps) {
+  const code = extractClassification(mysteryId)
+  if (!code) return null
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center px-2 py-0.5 rounded text-[10px] font-mono uppercase tracking-wider",
+        colorMap[code],
+        className
+      )}
+    >
+      {labels[code]}
+    </span>
+  )
+}

--- a/web-public/src/components/featured-mystery-card.tsx
+++ b/web-public/src/components/featured-mystery-card.tsx
@@ -4,18 +4,21 @@ import { ResponsiveHeroImage } from "@/components/responsive-hero-image"
 import type { FirestoreMystery } from "@ghost/shared/src/types/mystery"
 import { localizeMystery } from "@ghost/shared/src/lib/localize"
 import { cn } from "@ghost/shared/src/lib/utils"
+import { ClassificationBadge } from "@/components/classification-badge"
 import type { SupportedLang } from "@/lib/i18n/config"
+import type { Dictionary } from "@/lib/i18n/dictionaries"
 
 interface FeaturedMysteryCardProps {
   mystery: FirestoreMystery
   lang: SupportedLang
   label: string
+  classificationLabels: Dictionary["classification"]
 }
 
-export function FeaturedMysteryCard({ mystery, lang, label }: FeaturedMysteryCardProps) {
+export function FeaturedMysteryCard({ mystery, lang, label, classificationLabels }: FeaturedMysteryCardProps) {
   const { title, summary } = localizeMystery(mystery, lang)
 
-  const location = mystery.historical_context?.geographic_scope?.[0] || ""
+  const locations = mystery.historical_context?.geographic_scope || []
   const timePeriod = mystery.historical_context?.time_period || ""
   const hasImage = !!mystery.images?.hero
 
@@ -46,12 +49,15 @@ export function FeaturedMysteryCard({ mystery, lang, label }: FeaturedMysteryCar
           "p-6 md:p-8",
           hasImage && "lg:flex lg:flex-col lg:justify-center lg:py-10 lg:px-10"
         )}>
-          {/* フィーチャーバッジ */}
-          <div className="flex items-center gap-2 mb-4">
-            <Star className="w-4 h-4 text-gold" />
-            <span className="text-xs font-mono uppercase tracking-widest text-gold">
-              {label}
-            </span>
+          {/* フィーチャーバッジ + 分類バッジ */}
+          <div className="flex items-center gap-3 mb-4">
+            <div className="flex items-center gap-2">
+              <Star className="w-4 h-4 text-gold" />
+              <span className="text-xs font-mono uppercase tracking-widest text-gold">
+                {label}
+              </span>
+            </div>
+            <ClassificationBadge mysteryId={mystery.mystery_id} labels={classificationLabels} />
           </div>
 
           {/* メタデータ */}
@@ -79,10 +85,15 @@ export function FeaturedMysteryCard({ mystery, lang, label }: FeaturedMysteryCar
 
           {/* フッターメタデータ */}
           <div className="flex items-center gap-3 pt-4 border-t border-border/50 text-xs text-muted-foreground">
-            {location && (
+            {locations.length > 0 && (
               <span className="flex items-center gap-1">
                 <MapPin className="w-3 h-3" />
-                {location}
+                {locations[0]}
+                {locations.length > 1 && (
+                  <span className="text-muted-foreground/70">
+                    {classificationLabels.moreLocations.replace("{count}", String(locations.length - 1))}
+                  </span>
+                )}
               </span>
             )}
             {timePeriod && (

--- a/web-public/src/components/mystery-card.tsx
+++ b/web-public/src/components/mystery-card.tsx
@@ -4,18 +4,21 @@ import { FileText, MapPin, Calendar } from "lucide-react"
 import type { FirestoreMystery } from "@ghost/shared/src/types/mystery"
 import { cn } from "@ghost/shared/src/lib/utils"
 import { localizeMystery } from "@ghost/shared/src/lib/localize"
+import { ClassificationBadge } from "@/components/classification-badge"
 import type { SupportedLang } from "@/lib/i18n/config"
+import type { Dictionary } from "@/lib/i18n/dictionaries"
 
 interface MysteryCardProps {
   mystery: FirestoreMystery
   lang?: SupportedLang
+  classificationLabels: Dictionary["classification"]
   className?: string
 }
 
-export function MysteryCard({ mystery, lang = "en", className }: MysteryCardProps) {
+export function MysteryCard({ mystery, lang = "en", classificationLabels, className }: MysteryCardProps) {
   const { title, summary } = localizeMystery(mystery, lang)
 
-  const location = mystery.historical_context?.geographic_scope?.[0] || ""
+  const locations = mystery.historical_context?.geographic_scope || []
   const timePeriod = mystery.historical_context?.time_period || ""
   const thumbnailUrl = mystery.images?.thumbnail
 
@@ -38,16 +41,21 @@ export function MysteryCard({ mystery, lang = "en", className }: MysteryCardProp
 
           <div className="min-w-0">
             {/* File tab decoration */}
-            <div className="flex items-start justify-between gap-3 mb-4">
+            <div className="flex items-start justify-between gap-3 mb-2">
               <div className="flex items-center gap-2 text-xs text-muted-foreground font-mono uppercase tracking-wider">
                 <FileText className="w-3.5 h-3.5 text-gold" />
                 <span>{mystery.mystery_id}</span>
               </div>
-              <time className="text-xs text-muted-foreground font-mono">
+              <time className="text-xs text-muted-foreground font-mono shrink-0">
                 {mystery.publishedAt
                   ? mystery.publishedAt.toLocaleDateString()
                   : mystery.createdAt.toLocaleDateString()}
               </time>
+            </div>
+
+            {/* 分類バッジ */}
+            <div className="mb-3">
+              <ClassificationBadge mysteryId={mystery.mystery_id} labels={classificationLabels} />
             </div>
 
             {/* Title */}
@@ -62,10 +70,15 @@ export function MysteryCard({ mystery, lang = "en", className }: MysteryCardProp
 
             {/* Footer metadata */}
             <div className="flex items-center gap-3 pt-3 border-t border-border/50 text-xs text-muted-foreground">
-              {location && (
+              {locations.length > 0 && (
                 <span className="flex items-center gap-1">
                   <MapPin className="w-3 h-3" />
-                  {location}
+                  {locations[0]}
+                  {locations.length > 1 && (
+                    <span className="text-muted-foreground/70">
+                      {classificationLabels.moreLocations.replace("{count}", String(locations.length - 1))}
+                    </span>
+                  )}
                 </span>
               )}
               {timePeriod && (

--- a/web-public/src/lib/i18n/dictionaries/de.ts
+++ b/web-public/src/lib/i18n/dictionaries/de.ts
@@ -87,6 +87,17 @@ const dict: Dictionary = {
     view: "Ansehen",
     originalText: "Originaltext",
   },
+  classification: {
+    HIS: "Geschichte",
+    FLK: "Volkskunde",
+    ANT: "Anthropologie",
+    OCC: "Okkultismus",
+    URB: "Urbane Legende",
+    CRM: "Kriminalfall",
+    REL: "Religion",
+    LOC: "Genius Loci",
+    moreLocations: "+{count} weitere",
+  },
   footer: {
     description:
       "Mehrsprachige Kreuzanalyse der öffentlichen digitalen Archive der Welt — die Geister aufspüren, die sich in den Lücken zwischen Aufzeichnungen, Sprachen und Disziplinen verbergen.",

--- a/web-public/src/lib/i18n/dictionaries/en.ts
+++ b/web-public/src/lib/i18n/dictionaries/en.ts
@@ -86,6 +86,17 @@ const dict: Dictionary = {
     view: "View",
     originalText: "Original text",
   },
+  classification: {
+    HIS: "History",
+    FLK: "Folklore",
+    ANT: "Anthropology",
+    OCC: "Occult",
+    URB: "Urban Legend",
+    CRM: "Crime",
+    REL: "Religion",
+    LOC: "Locus",
+    moreLocations: "+{count} more",
+  },
   footer: {
     description:
       "Multi-lingual cross-analysis of the world's public digital archives — unearthing the Ghosts hiding in the gaps between records, languages, and disciplines.",

--- a/web-public/src/lib/i18n/dictionaries/es.ts
+++ b/web-public/src/lib/i18n/dictionaries/es.ts
@@ -87,6 +87,17 @@ const dict: Dictionary = {
     view: "Ver",
     originalText: "Texto original",
   },
+  classification: {
+    HIS: "Historia",
+    FLK: "Folclore",
+    ANT: "Antropología",
+    OCC: "Ocultismo",
+    URB: "Leyenda urbana",
+    CRM: "Crimen",
+    REL: "Religión",
+    LOC: "Locus",
+    moreLocations: "+{count} más",
+  },
   footer: {
     description:
       "Análisis multilingüe cruzado de los archivos digitales públicos del mundo — desenterrando los Fantasmas ocultos en las brechas entre registros, idiomas y disciplinas.",

--- a/web-public/src/lib/i18n/dictionaries/fr.ts
+++ b/web-public/src/lib/i18n/dictionaries/fr.ts
@@ -87,6 +87,17 @@ const dict: Dictionary = {
     view: "Voir",
     originalText: "Texte original",
   },
+  classification: {
+    HIS: "Histoire",
+    FLK: "Folklore",
+    ANT: "Anthropologie",
+    OCC: "Occultisme",
+    URB: "Légende urbaine",
+    CRM: "Crime",
+    REL: "Religion",
+    LOC: "Genius Loci",
+    moreLocations: "+{count} autres",
+  },
   footer: {
     description:
       "Analyse croisée multilingue des archives numériques publiques du monde — exhumant les Fantômes cachés dans les interstices entre documents, langues et disciplines.",

--- a/web-public/src/lib/i18n/dictionaries/ja.ts
+++ b/web-public/src/lib/i18n/dictionaries/ja.ts
@@ -86,6 +86,17 @@ const dict: Dictionary = {
     view: "閲覧",
     originalText: "原文",
   },
+  classification: {
+    HIS: "歴史",
+    FLK: "民俗",
+    ANT: "人類学",
+    OCC: "怪奇",
+    URB: "都市伝説",
+    CRM: "未解決事件",
+    REL: "信仰・禁忌",
+    LOC: "地霊・場所",
+    moreLocations: "他{count}件",
+  },
   footer: {
     description:
       "世界の公開デジタルアーカイブの多言語横断分析——記録と言語と学問の隙間に潜むGhostを発掘する。",

--- a/web-public/src/lib/i18n/dictionaries/nl.ts
+++ b/web-public/src/lib/i18n/dictionaries/nl.ts
@@ -87,6 +87,17 @@ const dict: Dictionary = {
     view: "Bekijken",
     originalText: "Originele tekst",
   },
+  classification: {
+    HIS: "Geschiedenis",
+    FLK: "Volkskunde",
+    ANT: "Antropologie",
+    OCC: "Occultisme",
+    URB: "Stadlegende",
+    CRM: "Misdaad",
+    REL: "Religie",
+    LOC: "Genius Loci",
+    moreLocations: "+{count} meer",
+  },
   footer: {
     description:
       "Meertalige kruisanalyse van de openbare digitale archieven van de wereld — de Geesten opgraven die zich verschuilen in de hiaten tussen documenten, talen en disciplines.",

--- a/web-public/src/lib/i18n/dictionaries/pt.ts
+++ b/web-public/src/lib/i18n/dictionaries/pt.ts
@@ -87,6 +87,17 @@ const dict: Dictionary = {
     view: "Ver",
     originalText: "Texto original",
   },
+  classification: {
+    HIS: "História",
+    FLK: "Folclore",
+    ANT: "Antropologia",
+    OCC: "Ocultismo",
+    URB: "Lenda urbana",
+    CRM: "Crime",
+    REL: "Religião",
+    LOC: "Genius Loci",
+    moreLocations: "+{count} mais",
+  },
   footer: {
     description:
       "Análise cruzada multilíngue dos arquivos digitais públicos do mundo — desenterrando os Fantasmas escondidos nas lacunas entre registros, idiomas e disciplinas.",

--- a/web-public/src/lib/i18n/dictionaries/types.ts
+++ b/web-public/src/lib/i18n/dictionaries/types.ts
@@ -70,6 +70,17 @@ export interface Dictionary {
     view: string;
     originalText: string;
   };
+  classification: {
+    HIS: string;
+    FLK: string;
+    ANT: string;
+    OCC: string;
+    URB: string;
+    CRM: string;
+    REL: string;
+    LOC: string;
+    moreLocations: string;
+  };
   footer: {
     description: string;
     primarySources: string;


### PR DESCRIPTION
## Summary

- `ClassificationBadge` コンポーネントを新規作成（Mystery ID の先頭3文字から分類コードを抽出し、8分類に対応する色付きバッジを表示）
- `MysteryCard` / `FeaturedMysteryCard` に分類バッジを配置
- i18n 辞書（`Dictionary` 型）に `classification` セクションを追加し、7言語（en/ja/es/de/fr/nl/pt）の分類ラベルを定義
- `geographic_scope` の表示改善: 2件以上ある場合「+N more」（各言語ローカライズ済み）表示

## 配色マッピング

| コード | 分類 | テーマ色 |
|--------|------|---------|
| HIS | 歴史 | 琥珀 |
| FLK | 民俗 | 青緑 |
| ANT | 人類学 | 橙 |
| OCC | 怪奇 | 紫 |
| URB | 都市伝説 | 灰 |
| CRM | 未解決事件 | 赤 |
| REL | 信仰・禁忌 | 藍 |
| LOC | 地霊・場所 | 緑 |

## Test plan

- [ ] `npm run dev` で web-public を起動し、トップページのカード表示を確認
- [ ] 各分類コード（HIS, FLK, OCC 等）の記事で正しいバッジ色・ラベルが表示されること
- [ ] 7言語を切り替えて分類ラベルがローカライズされていること
- [ ] モバイルビューでバッジが適切に表示されること
- [ ] Featured Card にもバッジが表示されること
- [ ] `geographic_scope` が2件以上の記事で「+N」表示になること

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)