### PR TITLE
feat: アーカイブ検索の年代フィルタ戦略統一（DDB・Delpher 対応 + 日付拡大フォールバック）

### DIFF
--- a/mystery_agents/tools/ddb.py
+++ b/mystery_agents/tools/ddb.py
@@ -47,6 +47,11 @@ class DDBSource(ArchiveSource):
 
         # DDB は Lucene クエリ構文をサポート
         query = f"({search_text})"
+        # 年代フィルタ: temporal フィールドへの Lucene 範囲クエリ
+        if date_start and date_end:
+            start_year = date_start[:4] if len(date_start) >= 4 else date_start
+            end_year = date_end[:4] if len(date_end) >= 4 else date_end
+            query += f" AND temporal:[{start_year} TO {end_year}]"
 
         params = {
             "query": query,

--- a/mystery_agents/tools/delpher.py
+++ b/mystery_agents/tools/delpher.py
@@ -137,8 +137,13 @@ class DelpherSource(ArchiveSource):
         if not search_text:
             return ArchiveSearchResult(error="No keywords provided")
 
-        # CQL クエリ構築
-        query = search_text
+        # CQL クエリ構築（年代フィルタ: dc.date への範囲比較）
+        if date_start and date_end:
+            start_year = date_start[:4] if len(date_start) >= 4 else date_start
+            end_year = date_end[:4] if len(date_end) >= 4 else date_end
+            query = f'({search_text}) AND dc.date >= "{start_year}" AND dc.date <= "{end_year}"'
+        else:
+            query = search_text
 
         params = {
             "operation": "searchRetrieve",

--- a/mystery_agents/tools/librarian_tools.py
+++ b/mystery_agents/tools/librarian_tools.py
@@ -359,6 +359,44 @@ def _search_single_source(
             if docs:
                 break
 
+    # 日付範囲拡大フォールバック: 結果なし & 年代指定あり → ±25年拡大して再検索（1回のみ）
+    if not docs and date_start and date_end:
+        try:
+            start_year = int(date_start[:4])
+            end_year = int(date_end[:4])
+            exp_start = str(max(1400, start_year - 25))
+            exp_end = str(min(2025, end_year + 25))
+            if exp_start != str(start_year) or exp_end != str(end_year):
+                fallback_used = True
+                logger.info(
+                    "%s 日付範囲拡大フォールバック: %s-%s → %s-%s",
+                    key, date_start, date_end, exp_start, exp_end,
+                    extra={"api_name": key, "fallback_type": "date_expansion"},
+                )
+                lang_arg = language if (language and source_obj.supports_language_filter) else None
+                for kw_list in keyword_groups:
+                    try:
+                        result = source_obj.search(
+                            keywords=kw_list,
+                            date_start=exp_start,
+                            date_end=exp_end,
+                            max_results=per_source_limit,
+                            language=lang_arg,
+                        )
+                        for doc in result.documents:
+                            if doc.source_url not in seen_urls:
+                                seen_urls.add(doc.source_url)
+                                docs.append(doc)
+                        total_hits += result.total_hits
+                        if result.error:
+                            error = result.error
+                    except Exception as e:
+                        error = str(e)
+                    if docs:
+                        break
+        except (ValueError, IndexError):
+            pass
+
     return key, docs, total_hits, error, fallback_used
 
 

--- a/mystery_agents/tools/trove.py
+++ b/mystery_agents/tools/trove.py
@@ -54,12 +54,14 @@ class TroveSource(ArchiveSource):
         }
 
         # decade フィルタ（年代絞り込み）
+        # Trove API v3 は l-decade パラメータで単一 decade のみフィルタ可能。
+        # 複数 decade にまたがる範囲は API がサポートしないためフィルタなし。
+        # 結果が0件の場合は _search_single_source() の日付拡大フォールバックが発動する。
         if date_start and date_end:
             start_decade = int(date_start[:4]) // 10
             end_decade = int(date_end[:4]) // 10
             if start_decade == end_decade:
                 params["l-decade"] = start_decade * 10
-            # 複数 decade にまたがる場合はフィルタなし（API は単一 decade のみ）
 
         headers = {
             "Accept": "application/json",

--- a/tests/unit/test_ddb.py
+++ b/tests/unit/test_ddb.py
@@ -99,6 +99,50 @@ class TestSearchDDB:
         assert result.error is None
 
 
+class TestDDBDateFilter:
+    """DDB 年代フィルタのテスト。"""
+
+    @responses.activate
+    def test_date_filter_in_query(self):
+        """日付パラメータが Lucene temporal 範囲クエリとしてリクエストに含まれる。"""
+        responses.add(
+            responses.GET, BASE_URL,
+            json={"numberOfResults": 0, "results": []}, status=200,
+        )
+
+        source = DDBSource()
+        with patch.dict("os.environ", {"DDB_API_KEY": "test_key"}):
+            source.search(
+                keywords=["Geist"],
+                date_start="1800",
+                date_end="1899",
+            )
+
+        request = responses.calls[0].request
+        from urllib.parse import unquote_plus
+        query_str = unquote_plus(request.url)
+        assert "temporal:[1800 TO 1899]" in query_str
+
+    @responses.activate
+    def test_no_date_filter_when_dates_empty(self):
+        """date_start/date_end が空文字の場合、temporal クエリが含まれない。"""
+        responses.add(
+            responses.GET, BASE_URL,
+            json={"numberOfResults": 0, "results": []}, status=200,
+        )
+
+        source = DDBSource()
+        with patch.dict("os.environ", {"DDB_API_KEY": "test_key"}):
+            source.search(
+                keywords=["Geist"],
+                date_start="",
+                date_end="",
+            )
+
+        request = responses.calls[0].request
+        assert "temporal" not in request.url
+
+
 class TestParseYear:
     """Tests for ArchiveSource.parse_year() (旧 _parse_year)。"""
 

--- a/tests/unit/test_delpher.py
+++ b/tests/unit/test_delpher.py
@@ -204,3 +204,52 @@ class TestDelpherSource:
         assert result.documents[0].date == "1842-01-01"
         # "1756/08/20 00:00:00" → "1756-01-01"
         assert result.documents[1].date == "1756-01-01"
+
+
+class TestDelpherDateFilter:
+    """Delpher 年代フィルタのテスト。"""
+
+    @responses.activate
+    def test_date_filter_in_cql_query(self):
+        """日付パラメータが CQL dc.date 比較としてリクエストに含まれる。"""
+        responses.add(
+            responses.GET,
+            BASE_URL,
+            body=MOCK_EMPTY_RESPONSE,
+            content_type="application/xml",
+            status=200,
+        )
+
+        source = DelpherSource()
+        source.search(
+            keywords=["spook"],
+            date_start="1800",
+            date_end="1899",
+        )
+
+        request = responses.calls[0].request
+        from urllib.parse import unquote_plus
+        query_str = unquote_plus(request.url)
+        assert 'dc.date >= "1800"' in query_str
+        assert 'dc.date <= "1899"' in query_str
+
+    @responses.activate
+    def test_no_date_filter_when_dates_empty(self):
+        """date_start/date_end が空文字の場合、dc.date が含まれない。"""
+        responses.add(
+            responses.GET,
+            BASE_URL,
+            body=MOCK_EMPTY_RESPONSE,
+            content_type="application/xml",
+            status=200,
+        )
+
+        source = DelpherSource()
+        source.search(
+            keywords=["spook"],
+            date_start="",
+            date_end="",
+        )
+
+        request = responses.calls[0].request
+        assert "dc.date" not in request.url

--- a/tests/unit/test_librarian_tools.py
+++ b/tests/unit/test_librarian_tools.py
@@ -461,6 +461,121 @@ class TestSearchSingleSource:
         assert fallback is True
         assert len(docs) == 1
 
+    def test_date_expansion_when_no_results(self):
+        """結果0件 & 年代指定あり → ±25年拡大で再検索される。"""
+        doc = _make_doc(url="https://expanded.example.com/doc")
+        call_log = []
+
+        class DateExpandSource:
+            source_key = "de_src"
+            source_name = "Date Expand Source"
+            supports_language_filter = False
+
+            def search(self, **kwargs):
+                call_log.append(kwargs)
+                # 元の日付範囲では0件、拡大範囲では結果あり
+                if kwargs["date_start"] == "1800" and kwargs["date_end"] == "1850":
+                    return ArchiveSearchResult(documents=[], total_hits=0)
+                return ArchiveSearchResult(documents=[doc], total_hits=1)
+
+        key, docs, hits, err, fallback = _search_single_source(
+            DateExpandSource(),
+            [["ghost"]],
+            date_start="1800",
+            date_end="1850",
+            per_source_limit=10,
+            language=None,
+        )
+
+        assert fallback is True
+        assert len(docs) == 1
+        assert docs[0].source_url == "https://expanded.example.com/doc"
+        # 拡大後の日付: 1800-25=1775, 1850+25=1875
+        expanded_call = call_log[-1]
+        assert expanded_call["date_start"] == "1775"
+        assert expanded_call["date_end"] == "1875"
+
+    def test_no_date_expansion_when_results_exist(self):
+        """結果がある場合は日付拡大しない。"""
+        doc = _make_doc()
+        call_log = []
+
+        class NoExpandSource:
+            source_key = "ne_src"
+            source_name = "No Expand Source"
+            supports_language_filter = False
+
+            def search(self, **kwargs):
+                call_log.append(kwargs)
+                return ArchiveSearchResult(documents=[doc], total_hits=1)
+
+        key, docs, hits, err, fallback = _search_single_source(
+            NoExpandSource(),
+            [["ghost"]],
+            date_start="1800",
+            date_end="1850",
+            per_source_limit=10,
+            language=None,
+        )
+
+        assert len(docs) == 1
+        assert fallback is False
+        # 元の日付範囲のみで検索（拡大なし）
+        assert all(c["date_start"] == "1800" for c in call_log)
+
+    def test_date_expansion_bounds_clamped(self):
+        """拡大後の日付が 1400-2025 の範囲内に収まる。"""
+        call_log = []
+
+        class ClampSource:
+            source_key = "clamp"
+            source_name = "Clamp Source"
+            supports_language_filter = False
+
+            def search(self, **kwargs):
+                call_log.append(kwargs)
+                return ArchiveSearchResult(documents=[], total_hits=0)
+
+        _search_single_source(
+            ClampSource(),
+            [["ghost"]],
+            date_start="1410",
+            date_end="2020",
+            per_source_limit=10,
+            language=None,
+        )
+
+        # 拡大後: max(1400, 1410-25)=1400, min(2025, 2020+25)=2025
+        expanded_calls = [c for c in call_log if c["date_start"] != "1410"]
+        assert len(expanded_calls) == 1
+        assert expanded_calls[0]["date_start"] == "1400"
+        assert expanded_calls[0]["date_end"] == "2025"
+
+    def test_date_expansion_skipped_when_no_dates(self):
+        """date_start/date_end が空の場合、拡大をスキップ。"""
+        call_log = []
+
+        class NoDatesSource:
+            source_key = "nd"
+            source_name = "No Dates Source"
+            supports_language_filter = False
+
+            def search(self, **kwargs):
+                call_log.append(kwargs)
+                return ArchiveSearchResult(documents=[], total_hits=0)
+
+        _search_single_source(
+            NoDatesSource(),
+            [["ghost"]],
+            date_start="",
+            date_end="",
+            per_source_limit=10,
+            language=None,
+        )
+
+        # 元の検索のみ（日付拡大なし）
+        assert len(call_log) == 1
+
     def test_deduplicates_within_source(self):
         """同一ソース内の URL 重複が除去される。"""
         doc1 = _make_doc(url="https://same.com/doc")
@@ -537,7 +652,8 @@ class TestDefaultDates:
         # date_start / date_end を明示しない → デフォルト値が使われる
         search_archives(keywords="test", sources="loc", language="en")
 
-        assert len(call_log) == 1
+        # 最初の検索はデフォルト日付範囲で実行される
+        # （結果0件の場合、日付拡大フォールバックで追加の検索が発生しうる）
         assert call_log[0]["date_start"] == "1500"
         assert call_log[0]["date_end"] == "1899"
 


### PR DESCRIPTION
## Summary

Closes #203

- **DDB**: Lucene `temporal` 範囲クエリによる年代フィルタを追加（従来は年代指定を無視していた）
- **Delpher**: CQL `dc.date` 範囲比較による年代フィルタを追加（従来は年代指定を無視していた）
- **Trove**: API の `l-decade` 制約をコメントで明文化（コード変更なし）
- **`_search_single_source()`**: ±25年の日付拡大フォールバックを追加
  - 結果0件 & 年代指定あり → 1回のみ拡大して再検索（無限ループ防止）
  - 下限 1400、上限 2025 でクランプ
  - 0件ソースのみ再実行（既に結果のあるソースは影響なし）

### Issue の提案 vs 採用案

Issue #203 は `search_archives()` ラッパー層で ±50年拡大を提案していたが、以下の理由で per-source ±25年を採用：

| 観点 | Issue 提案 (±50年) | 採用案 (±25年) |
|------|-------------------|---------------|
| 効率 | 全ソース再実行 | 0件ソースのみ |
| 精度 | 3時代跨ぎの可能性 | 同時代内を維持 |
| 一貫性 | 新パターン | 既存キーワードフォールバックと同構造 |

## Test plan

- [x] DDB 年代フィルタテスト 2件（フィルタあり/なし）
- [x] Delpher 年代フィルタテスト 2件（フィルタあり/なし）
- [x] 日付拡大フォールバックテスト 4件（拡大発動/不発動/クランプ/日付なし）
- [x] 既存テスト 838件 全 PASS（既存テスト 2件を日付拡大に合わせて修正）

🤖 Generated with [Claude Code](https://claude.com/claude-code)