### PR TITLE
feat: 記事一覧のページネーション付きアーカイブページ新設

### DIFF
--- a/web-public/src/app/[lang]/archive/[[...page]]/page.tsx
+++ b/web-public/src/app/[lang]/archive/[[...page]]/page.tsx
@@ -1,0 +1,135 @@
+import { notFound } from "next/navigation"
+import { Header } from "@/components/header"
+import { Footer } from "@ghost/shared/src/components/footer"
+import { MysteryCard } from "@/components/mystery-card"
+import { Pagination } from "@/components/pagination"
+import { getPublishedMysteries, getAllPublishedMysteriesMap } from "@ghost/shared/src/lib/firestore/queries"
+import { ARCHIVE_PAGE_SIZE } from "@/lib/constants"
+import { FileStack, Search } from "lucide-react"
+import { isValidLang, SUPPORTED_LANGS } from "@/lib/i18n/config"
+import type { SupportedLang } from "@/lib/i18n/config"
+import { getDictionary } from "@/lib/i18n/dictionaries"
+
+// SSG: ビルド時に生成されたページ以外は 404
+export const dynamicParams = false
+
+export async function generateStaticParams() {
+  const mysteries = await getPublishedMysteries(1000)
+  const totalPages = Math.max(1, Math.ceil(mysteries.length / ARCHIVE_PAGE_SIZE))
+
+  return SUPPORTED_LANGS.flatMap((lang) => {
+    // ページ 1（パスなし）
+    const pages: { lang: string; page?: string[] }[] = [{ lang, page: [] }]
+    // ページ 2 以降
+    for (let i = 2; i <= totalPages; i++) {
+      pages.push({ lang, page: [String(i)] })
+    }
+    return pages
+  })
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ lang: string; page?: string[] }>
+}) {
+  const { lang, page } = await params
+  if (!isValidLang(lang)) return {}
+
+  const dict = await getDictionary(lang)
+  const currentPage = page?.length ? parseInt(page[0], 10) : 1
+  const pageTitle = currentPage > 1
+    ? `${dict.archive.heading} - ${dict.archive.page} ${currentPage} | Ghost in the Archive`
+    : dict.archive.title
+
+  return {
+    title: pageTitle,
+    alternates: {
+      languages: Object.fromEntries(
+        SUPPORTED_LANGS.map((l) => [l, `/${l}/archive`])
+      ),
+    },
+  }
+}
+
+export default async function ArchivePage({
+  params,
+}: {
+  params: Promise<{ lang: string; page?: string[] }>
+}) {
+  const { lang, page } = await params
+  if (!isValidLang(lang)) notFound()
+
+  const currentPage = page?.length ? parseInt(page[0], 10) : 1
+  if (isNaN(currentPage) || currentPage < 1) notFound()
+
+  const dict = await getDictionary(lang)
+
+  // React.cache 付きで全記事を一度だけ取得
+  const mysteriesMap = await getAllPublishedMysteriesMap()
+  const allMysteries = Array.from(mysteriesMap.values())
+
+  const totalPages = Math.max(1, Math.ceil(allMysteries.length / ARCHIVE_PAGE_SIZE))
+  if (currentPage > totalPages) notFound()
+
+  const startIndex = (currentPage - 1) * ARCHIVE_PAGE_SIZE
+  const pageMysteries = allMysteries.slice(startIndex, startIndex + ARCHIVE_PAGE_SIZE)
+
+  return (
+    <div className="min-h-screen flex flex-col film-grain">
+      <Header lang={lang as SupportedLang} nav={dict.nav} />
+
+      <main className="flex-1">
+        <section className="py-16 md:py-24">
+          <div className="container mx-auto px-4">
+            {/* 見出し */}
+            <div className="mb-12">
+              <div className="flex items-center gap-3 mb-4">
+                <FileStack className="w-6 h-6 text-gold" />
+                <h1 className="font-serif text-3xl md:text-4xl text-parchment">
+                  {dict.archive.heading}
+                </h1>
+              </div>
+              <p className="text-muted-foreground max-w-2xl">
+                {dict.archive.description}
+              </p>
+              <div className="mt-4 h-px bg-gradient-to-r from-border to-transparent" />
+            </div>
+
+            {/* 記事グリッド or 空状態 */}
+            {pageMysteries.length === 0 ? (
+              <div className="text-center py-16">
+                <Search className="h-12 w-12 text-muted-foreground mx-auto mb-4" aria-hidden="true" />
+                <h2 className="font-serif text-xl text-parchment mb-2">
+                  {dict.archive.noArticles}
+                </h2>
+              </div>
+            ) : (
+              <>
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                  {pageMysteries.map((mystery) => (
+                    <MysteryCard
+                      key={mystery.mystery_id}
+                      mystery={mystery}
+                      lang={lang as SupportedLang}
+                      classificationLabels={dict.classification}
+                    />
+                  ))}
+                </div>
+
+                <Pagination
+                  currentPage={currentPage}
+                  totalPages={totalPages}
+                  basePath={`/${lang}/archive`}
+                  labels={dict.archive}
+                />
+              </>
+            )}
+          </div>
+        </section>
+      </main>
+
+      <Footer labels={dict.footer} />
+    </div>
+  )
+}

--- a/web-public/src/app/[lang]/page.tsx
+++ b/web-public/src/app/[lang]/page.tsx
@@ -8,6 +8,7 @@ import { MysteryCard } from "@/components/mystery-card"
 import { MysteryCardSkeleton } from "@/components/mystery-card-skeleton"
 import { getPublishedMysteries } from "@ghost/shared/src/lib/firestore/queries"
 import { HOMEPAGE_MYSTERY_LIMIT } from "@/lib/constants"
+import Link from "next/link"
 import { FileStack, Search } from "lucide-react"
 import { isValidLang } from "@/lib/i18n/config"
 import type { SupportedLang } from "@/lib/i18n/config"
@@ -118,11 +119,14 @@ export default async function HomePage({
               <MysteryList lang={lang} dict={dict} />
             </Suspense>
 
-            {/* View all link */}
+            {/* アーカイブ導線 */}
             <div className="mt-12 text-center">
-              <p className="text-sm text-muted-foreground font-mono">
-                <span className="redacted">████████</span> {dict.home.classifiedRedacted} <span className="redacted">████████</span>
-              </p>
+              <Link
+                href={`/${lang}/archive`}
+                className="inline-block text-sm font-mono text-muted-foreground hover:text-gold transition-colors no-underline"
+              >
+                <span className="redacted">████</span> {dict.home.viewAllArticles} → <span className="redacted">████</span>
+              </Link>
             </div>
           </div>
         </section>

--- a/web-public/src/components/header.tsx
+++ b/web-public/src/components/header.tsx
@@ -8,11 +8,12 @@ import type { SupportedLang } from "@/lib/i18n/config"
 
 interface HeaderProps {
   lang?: SupportedLang
-  nav?: { about: string }
+  nav?: { about: string; archive: string }
 }
 
 export function Header({ lang = "en", nav }: HeaderProps) {
   const pathname = usePathname()
+  const isArchiveActive = pathname.startsWith(`/${lang}/archive`)
   const isAboutActive = pathname === `/${lang}/about`
 
   return (
@@ -33,7 +34,17 @@ export function Header({ lang = "en", nav }: HeaderProps) {
           {/* Nav + Language Switcher */}
           <div className="flex items-center gap-4">
             {nav && (
-              <nav>
+              <nav className="flex items-center gap-4">
+                <Link
+                  href={`/${lang}/archive`}
+                  className={`text-sm font-mono uppercase tracking-wider transition-colors no-underline ${
+                    isArchiveActive
+                      ? "text-gold"
+                      : "text-muted-foreground hover:text-parchment"
+                  }`}
+                >
+                  {nav.archive}
+                </Link>
                 <Link
                   href={`/${lang}/about`}
                   className={`text-sm font-mono uppercase tracking-wider transition-colors no-underline ${

--- a/web-public/src/components/pagination.tsx
+++ b/web-public/src/components/pagination.tsx
@@ -1,0 +1,114 @@
+import Link from "next/link"
+import { ChevronLeft, ChevronRight } from "lucide-react"
+import type { Dictionary } from "@/lib/i18n/dictionaries"
+
+interface PaginationProps {
+  currentPage: number
+  totalPages: number
+  basePath: string
+  labels: Dictionary["archive"]
+}
+
+/**
+ * ページ番号リストを生成（省略表示対応）
+ * 例: 1 ... 4 5 6 ... 10
+ */
+function getPageNumbers(current: number, total: number): (number | "ellipsis")[] {
+  if (total <= 7) {
+    return Array.from({ length: total }, (_, i) => i + 1)
+  }
+
+  const pages: (number | "ellipsis")[] = [1]
+
+  if (current > 3) {
+    pages.push("ellipsis")
+  }
+
+  const start = Math.max(2, current - 1)
+  const end = Math.min(total - 1, current + 1)
+
+  for (let i = start; i <= end; i++) {
+    pages.push(i)
+  }
+
+  if (current < total - 2) {
+    pages.push("ellipsis")
+  }
+
+  pages.push(total)
+
+  return pages
+}
+
+function pageHref(basePath: string, page: number): string {
+  return page === 1 ? basePath : `${basePath}/${page}`
+}
+
+export function Pagination({ currentPage, totalPages, basePath, labels }: PaginationProps) {
+  if (totalPages <= 1) return null
+
+  const pages = getPageNumbers(currentPage, totalPages)
+
+  return (
+    <nav aria-label="Pagination" className="flex items-center justify-center gap-1 mt-12">
+      {/* 前へ */}
+      {currentPage > 1 ? (
+        <Link
+          href={pageHref(basePath, currentPage - 1)}
+          className="flex items-center gap-1 px-3 py-2 text-sm font-mono text-muted-foreground hover:text-parchment transition-colors no-underline"
+        >
+          <ChevronLeft className="w-4 h-4" />
+          <span className="hidden sm:inline">{labels.previous}</span>
+        </Link>
+      ) : (
+        <span className="flex items-center gap-1 px-3 py-2 text-sm font-mono text-muted-foreground/30">
+          <ChevronLeft className="w-4 h-4" />
+          <span className="hidden sm:inline">{labels.previous}</span>
+        </span>
+      )}
+
+      {/* ページ番号 */}
+      <div className="flex items-center gap-1">
+        {pages.map((page, i) =>
+          page === "ellipsis" ? (
+            <span key={`ellipsis-${i}`} className="px-2 py-2 text-sm font-mono text-muted-foreground/50">
+              ...
+            </span>
+          ) : page === currentPage ? (
+            <span
+              key={page}
+              className="px-3 py-2 text-sm font-mono text-gold border border-gold/30 bg-gold/10 rounded-sm"
+              aria-current="page"
+            >
+              {page}
+            </span>
+          ) : (
+            <Link
+              key={page}
+              href={pageHref(basePath, page)}
+              className="px-3 py-2 text-sm font-mono text-muted-foreground hover:text-parchment hover:bg-paper-light rounded-sm transition-colors no-underline"
+            >
+              {page}
+            </Link>
+          )
+        )}
+      </div>
+
+      {/* 次へ */}
+      {currentPage < totalPages ? (
+        <Link
+          href={pageHref(basePath, currentPage + 1)}
+          className="flex items-center gap-1 px-3 py-2 text-sm font-mono text-muted-foreground hover:text-parchment transition-colors no-underline"
+        >
+          <span className="hidden sm:inline">{labels.next}</span>
+          <ChevronRight className="w-4 h-4" />
+        </Link>
+      ) : (
+        <span className="flex items-center gap-1 px-3 py-2 text-sm font-mono text-muted-foreground/30">
+          <span className="hidden sm:inline">{labels.next}</span>
+          <ChevronRight className="w-4 h-4" />
+        </span>
+      )}
+    </nav>
+  )
+}

--- a/web-public/src/lib/constants.ts
+++ b/web-public/src/lib/constants.ts
@@ -1,1 +1,2 @@
 export const HOMEPAGE_MYSTERY_LIMIT = 20
+export const ARCHIVE_PAGE_SIZE = 12

--- a/web-public/src/lib/i18n/dictionaries/de.ts
+++ b/web-public/src/lib/i18n/dictionaries/de.ts
@@ -26,6 +26,7 @@ const dict: Dictionary = {
   },
   nav: {
     about: "Über uns",
+    archive: "Archiv",
   },
   home: {
     latestDiscoveries: "Neueste Entdeckungen",
@@ -34,6 +35,16 @@ const dict: Dictionary = {
     noMysteriesDesc:
       "Derzeit sind keine Mysterien veröffentlicht. Schauen Sie später nach neuen Entdeckungen.",
     classifiedRedacted: "Weitere Fälle bleiben als Verschlusssache eingestuft",
+    viewAllArticles: "Alle Fallakten anzeigen",
+  },
+  archive: {
+    title: "Fallarchiv | Ghost in the Archive",
+    heading: "Fallarchiv",
+    description: "Vollständiges Verzeichnis aller untersuchten Anomalien, Diskrepanzen und unerklärlichen Phänomene aus den öffentlichen Aufzeichnungen der Welt.",
+    noArticles: "Es wurden noch keine Fallakten veröffentlicht.",
+    page: "Seite",
+    previous: "Zurück",
+    next: "Weiter",
   },
   about: {
     title: "Über uns | Ghost in the Archive",

--- a/web-public/src/lib/i18n/dictionaries/en.ts
+++ b/web-public/src/lib/i18n/dictionaries/en.ts
@@ -25,6 +25,7 @@ const dict: Dictionary = {
   },
   nav: {
     about: "About",
+    archive: "Archive",
   },
   home: {
     latestDiscoveries: "Latest Discoveries",
@@ -33,6 +34,16 @@ const dict: Dictionary = {
     noMysteriesDesc:
       "No published mysteries at this time. Check back for new discoveries.",
     classifiedRedacted: "Additional cases remain classified",
+    viewAllArticles: "View all case files",
+  },
+  archive: {
+    title: "Case Archive | Ghost in the Archive",
+    heading: "Case Archive",
+    description: "Complete index of all investigated anomalies, discrepancies, and unexplained phenomena unearthed from the world's public records.",
+    noArticles: "No case files have been published yet.",
+    page: "Page",
+    previous: "Previous",
+    next: "Next",
   },
   about: {
     title: "About | Ghost in the Archive",

--- a/web-public/src/lib/i18n/dictionaries/es.ts
+++ b/web-public/src/lib/i18n/dictionaries/es.ts
@@ -26,6 +26,7 @@ const dict: Dictionary = {
   },
   nav: {
     about: "Acerca de",
+    archive: "Archivo",
   },
   home: {
     latestDiscoveries: "Últimos descubrimientos",
@@ -34,6 +35,16 @@ const dict: Dictionary = {
     noMysteriesDesc:
       "No hay misterios publicados en este momento. Vuelva para nuevos descubrimientos.",
     classifiedRedacted: "Casos adicionales permanecen clasificados",
+    viewAllArticles: "Ver todos los expedientes",
+  },
+  archive: {
+    title: "Archivo de casos | Ghost in the Archive",
+    heading: "Archivo de casos",
+    description: "Índice completo de todas las anomalías, discrepancias y fenómenos inexplicables desenterrados de los registros públicos del mundo.",
+    noArticles: "Aún no se han publicado expedientes.",
+    page: "Página",
+    previous: "Anterior",
+    next: "Siguiente",
   },
   about: {
     title: "Acerca de | Ghost in the Archive",

--- a/web-public/src/lib/i18n/dictionaries/fr.ts
+++ b/web-public/src/lib/i18n/dictionaries/fr.ts
@@ -26,6 +26,7 @@ const dict: Dictionary = {
   },
   nav: {
     about: "À propos",
+    archive: "Archives",
   },
   home: {
     latestDiscoveries: "Dernières découvertes",
@@ -34,6 +35,16 @@ const dict: Dictionary = {
     noMysteriesDesc:
       "Aucun mystère publié pour le moment. Revenez pour de nouvelles découvertes.",
     classifiedRedacted: "Des dossiers supplémentaires restent classifiés",
+    viewAllArticles: "Voir tous les dossiers",
+  },
+  archive: {
+    title: "Archives des dossiers | Ghost in the Archive",
+    heading: "Archives des dossiers",
+    description: "Index complet de toutes les anomalies, divergences et phénomènes inexpliqués exhumés des archives publiques du monde.",
+    noArticles: "Aucun dossier n'a encore été publié.",
+    page: "Page",
+    previous: "Précédent",
+    next: "Suivant",
   },
   about: {
     title: "À propos | Ghost in the Archive",

--- a/web-public/src/lib/i18n/dictionaries/ja.ts
+++ b/web-public/src/lib/i18n/dictionaries/ja.ts
@@ -25,6 +25,7 @@ const dict: Dictionary = {
   },
   nav: {
     about: "このサイトについて",
+    archive: "アーカイブ",
   },
   home: {
     latestDiscoveries: "最新の発見",
@@ -33,6 +34,16 @@ const dict: Dictionary = {
     noMysteriesDesc:
       "現在公開中のミステリーはありません。新しい発見をお待ちください。",
     classifiedRedacted: "追加の事件は機密扱いのままです",
+    viewAllArticles: "すべてのケースファイルを見る",
+  },
+  archive: {
+    title: "ケースアーカイブ | Ghost in the Archive",
+    heading: "ケースアーカイブ",
+    description: "世界の公開記録から発掘された、すべての異常・矛盾・説明不能な現象の完全索引。",
+    noArticles: "まだケースファイルは公開されていません。",
+    page: "ページ",
+    previous: "前へ",
+    next: "次へ",
   },
   about: {
     title: "このサイトについて | Ghost in the Archive",

--- a/web-public/src/lib/i18n/dictionaries/nl.ts
+++ b/web-public/src/lib/i18n/dictionaries/nl.ts
@@ -26,6 +26,7 @@ const dict: Dictionary = {
   },
   nav: {
     about: "Over ons",
+    archive: "Archief",
   },
   home: {
     latestDiscoveries: "Laatste ontdekkingen",
@@ -34,6 +35,16 @@ const dict: Dictionary = {
     noMysteriesDesc:
       "Er zijn momenteel geen gepubliceerde mysteries. Kom later terug voor nieuwe ontdekkingen.",
     classifiedRedacted: "Aanvullende zaken blijven gerubriceerd",
+    viewAllArticles: "Alle dossiers bekijken",
+  },
+  archive: {
+    title: "Zaakarchief | Ghost in the Archive",
+    heading: "Zaakarchief",
+    description: "Volledige index van alle onderzochte anomalieën, discrepanties en onverklaarde verschijnselen uit de openbare archieven van de wereld.",
+    noArticles: "Er zijn nog geen dossiers gepubliceerd.",
+    page: "Pagina",
+    previous: "Vorige",
+    next: "Volgende",
   },
   about: {
     title: "Over ons | Ghost in the Archive",

--- a/web-public/src/lib/i18n/dictionaries/pt.ts
+++ b/web-public/src/lib/i18n/dictionaries/pt.ts
@@ -26,6 +26,7 @@ const dict: Dictionary = {
   },
   nav: {
     about: "Sobre",
+    archive: "Arquivo",
   },
   home: {
     latestDiscoveries: "Últimas descobertas",
@@ -34,6 +35,16 @@ const dict: Dictionary = {
     noMysteriesDesc:
       "Não há mistérios publicados no momento. Volte para novas descobertas.",
     classifiedRedacted: "Casos adicionais permanecem classificados",
+    viewAllArticles: "Ver todos os dossiês",
+  },
+  archive: {
+    title: "Arquivo de casos | Ghost in the Archive",
+    heading: "Arquivo de casos",
+    description: "Índice completo de todas as anomalias, discrepâncias e fenômenos inexplicáveis desenterrados dos registros públicos do mundo.",
+    noArticles: "Nenhum dossiê foi publicado ainda.",
+    page: "Página",
+    previous: "Anterior",
+    next: "Próximo",
   },
   about: {
     title: "Sobre | Ghost in the Archive",

--- a/web-public/src/lib/i18n/dictionaries/types.ts
+++ b/web-public/src/lib/i18n/dictionaries/types.ts
@@ -19,6 +19,7 @@ export interface Dictionary {
   };
   nav: {
     about: string;
+    archive: string;
   };
   home: {
     latestDiscoveries: string;
@@ -26,6 +27,16 @@ export interface Dictionary {
     noMysteries: string;
     noMysteriesDesc: string;
     classifiedRedacted: string;
+    viewAllArticles: string;
+  };
+  archive: {
+    title: string;
+    heading: string;
+    description: string;
+    noArticles: string;
+    page: string;
+    previous: string;
+    next: string;
   };
   about: {
     title: string;


### PR DESCRIPTION
## Summary

Closes #160

記事数の増加に対応し、全記事を閲覧できるアーカイブページをページネーション付きで新設。ホームページは20件までの表示を維持しつつ、アーカイブへの導線を追加。

### 変更内容

- **アーカイブページ新設** (`/[lang]/archive/[[...page]]/page.tsx`)
  - Optional catch-all ルートで SSG 対応（`/en/archive/`, `/en/archive/2/` 等）
  - `getAllPublishedMysteriesMap()` で React.cache 経由のデータ取得
  - 既存 MysteryCard の 3カラムグリッド表示
  - `ARCHIVE_PAGE_SIZE = 12` 件/ページ
- **Pagination コンポーネント** (`pagination.tsx`)
  - 前へ/次へリンク + ページ番号リスト
  - ページ数が多い場合の省略表示（1 ... 4 5 6 ... 10）
  - モバイル・デスクトップ両対応
- **ヘッダーナビ** — Archive リンク追加（アクティブ状態ハイライト）
- **ホームページ導線** — redacted テキストをアーカイブへのリンクに変更
- **i18n 対応** — 7言語すべてに `archive` セクション + `nav.archive` + `home.viewAllArticles` の翻訳追加

### 対象ファイル（13ファイル）

| ファイル | 変更種別 |
|---------|---------|
| `web-public/src/lib/constants.ts` | 編集（`ARCHIVE_PAGE_SIZE` 追加） |
| `web-public/src/lib/i18n/dictionaries/types.ts` | 編集（`archive` セクション追加） |
| `web-public/src/lib/i18n/dictionaries/{en,ja,es,de,fr,nl,pt}.ts` | 編集（翻訳追加） |
| `web-public/src/app/[lang]/archive/[[...page]]/page.tsx` | **新規** |
| `web-public/src/components/pagination.tsx` | **新規** |
| `web-public/src/app/[lang]/page.tsx` | 編集（導線リンク追加） |
| `web-public/src/components/header.tsx` | 編集（Archive リンク追加） |

## Test plan

- [ ] ローカル開発サーバーで `/en/archive` のアーカイブページ表示確認
- [ ] 7言語（`/en/archive`, `/ja/archive`, `/es/archive` 等）を巡回
- [ ] ページネーション動作: ページ 2 以降のリンク遷移、前後ナビの境界条件
- [ ] ホームページ「すべてのケースファイルを見る」リンクがアーカイブに遷移
- [ ] ヘッダーナビの Archive リンク表示とアクティブ状態
- [ ] `npx tsc --noEmit` エラーなし（確認済み）
- [ ] `npm run build` で SSG ビルド正常完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)