### PR TITLE
feat: 記事詳細ページ UX 改善（パンくずリスト・目次・関連記事）

### DIFF
--- a/web-public/src/app/[lang]/mystery/[id]/loading.tsx
+++ b/web-public/src/app/[lang]/mystery/[id]/loading.tsx
@@ -10,8 +10,14 @@ export default function MysteryDetailLoading() {
 
       <main className="flex-1 py-8 md:py-12">
         <div className="container mx-auto px-4">
-          {/* Back link skeleton */}
-          <div className="h-5 w-40 bg-muted/20 rounded-sm mb-8 animate-pulse" />
+          {/* パンくずリスト skeleton */}
+          <div className="flex items-center gap-2 mb-8">
+            <div className="h-4 w-12 bg-muted/20 rounded-sm animate-pulse" />
+            <div className="h-3 w-3 bg-muted/20 rounded-sm animate-pulse" />
+            <div className="h-4 w-16 bg-muted/20 rounded-sm animate-pulse" />
+            <div className="h-3 w-3 bg-muted/20 rounded-sm animate-pulse" />
+            <div className="h-4 w-32 bg-muted/20 rounded-sm animate-pulse" />
+          </div>
 
           {/* Case file header skeleton */}
           <div className="mb-12">

--- a/web-public/src/app/[lang]/mystery/[id]/page.tsx
+++ b/web-public/src/app/[lang]/mystery/[id]/page.tsx
@@ -1,5 +1,4 @@
 import { notFound } from "next/navigation"
-import Link from "next/link"
 import { ResponsiveHeroImage } from "@/components/responsive-hero-image"
 import { Header } from "@/components/header"
 import { Footer } from "@ghost/shared/src/components/footer"
@@ -10,12 +9,17 @@ import { DiscrepancySection } from "@/components/mystery/discrepancy-section"
 import { HypothesisSection } from "@/components/mystery/hypothesis-section"
 import { HistoricalContextSection } from "@/components/mystery/historical-context-section"
 import { DetailSidebar } from "@/components/mystery/detail-sidebar"
+import { Breadcrumb } from "@/components/breadcrumb"
+import { TableOfContents, SECTION_IDS } from "@/components/table-of-contents"
+import { RelatedArticles } from "@/components/related-articles"
 import { getMysteryById, getPublishedMysteryIds, getAllPublishedMysteriesMap } from "@ghost/shared/src/lib/firestore/queries"
-import { ArrowLeft, FileText } from "lucide-react"
+import { FileText } from "lucide-react"
 import { localizeMystery, getTranslatedExcerpt } from "@ghost/shared/src/lib/localize"
 import { SUPPORTED_LANGS, isValidLang } from "@/lib/i18n/config"
 import type { SupportedLang } from "@/lib/i18n/config"
 import { getDictionary } from "@/lib/i18n/dictionaries"
+import { findRelatedArticles } from "@/lib/related-articles"
+import type { TocSection } from "@/components/table-of-contents"
 
 // SSG: ビルド時に生成されたページ以外は 404
 export const dynamicParams = false
@@ -93,20 +97,42 @@ export default async function MysteryDetailPage({
   const evidenceAExcerpt = getTranslatedExcerpt(mystery, "a", lang)
   const evidenceBExcerpt = getTranslatedExcerpt(mystery, "b", lang)
 
+  // 目次セクションの動的構築（存在するセクションのみ含める）
+  const tocSections: TocSection[] = [
+    { id: SECTION_IDS.narrative, label: dict.detail.tocNarrative },
+  ]
+  if (discrepancyDetected) {
+    tocSections.push({ id: SECTION_IDS.discrepancy, label: dict.detail.tocDiscrepancy })
+  }
+  tocSections.push({ id: SECTION_IDS.evidence, label: dict.detail.tocEvidence })
+  if (hypothesis) {
+    tocSections.push({ id: SECTION_IDS.hypothesis, label: dict.detail.tocHypothesis })
+  }
+  if (mystery.historical_context) {
+    tocSections.push({ id: SECTION_IDS.historicalContext, label: dict.detail.tocHistoricalContext })
+  }
+
+  // 関連記事の取得（SSG ビルド時は React.cache で共有済み）
+  const relatedArticles = findRelatedArticles(
+    mystery,
+    Array.from(mysteriesMap.values())
+  )
+
   return (
     <div className="min-h-screen flex flex-col film-grain">
       <Header lang={lang} nav={dict.nav} />
 
       <main className="flex-1 py-8 md:py-12">
         <div className="container mx-auto px-4">
-          {/* Back link */}
-          <Link
-            href={`/${lang}`}
-            className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-parchment transition-colors mb-8 no-underline"
-          >
-            <ArrowLeft className="w-4 h-4" />
-            {dict.detail.returnToArchive}
-          </Link>
+          {/* パンくずリスト */}
+          <Breadcrumb
+            lang={lang}
+            title={title}
+            labels={{
+              home: dict.detail.breadcrumbHome,
+              archive: dict.nav.archive,
+            }}
+          />
 
           <CaseFileHeader
             mysteryId={mystery.mystery_id}
@@ -129,6 +155,9 @@ export default async function MysteryDetailPage({
             </div>
           )}
 
+          {/* モバイル目次（Hero 画像下、Grid の前） */}
+          <TableOfContents sections={tocSections} heading={dict.detail.tableOfContents} />
+
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 lg:gap-12">
             {/* Main content */}
             <div className="lg:col-span-2 space-y-12">
@@ -149,7 +178,7 @@ export default async function MysteryDetailPage({
               )}
 
               {/* Evidence */}
-              <section>
+              <section id="section-evidence" className="scroll-mt-24">
                 <div className="flex items-center gap-3 mb-6">
                   <FileText className="w-5 h-5 text-gold" />
                   <h2 className="font-serif text-xl text-parchment">{dict.detail.archivalEvidence}</h2>
@@ -209,8 +238,19 @@ export default async function MysteryDetailPage({
                 storyAngles: dict.detail.storyAngles,
                 classificationNotice: dict.detail.classificationNotice,
               }}
-            />
+            >
+              {/* デスクトップ目次（サイドバー内） */}
+              <TableOfContents sections={tocSections} heading={dict.detail.tableOfContents} />
+            </DetailSidebar>
           </div>
+
+          {/* 関連記事 */}
+          <RelatedArticles
+            articles={relatedArticles}
+            lang={lang as SupportedLang}
+            heading={dict.detail.relatedArticles}
+            classificationLabels={dict.classification}
+          />
         </div>
       </main>
 

--- a/web-public/src/components/breadcrumb.tsx
+++ b/web-public/src/components/breadcrumb.tsx
@@ -1,0 +1,58 @@
+import Link from "next/link"
+import { ChevronRight } from "lucide-react"
+
+interface BreadcrumbProps {
+  lang: string
+  title: string
+  labels: {
+    home: string
+    archive: string
+  }
+}
+
+export function Breadcrumb({ lang, title, labels }: BreadcrumbProps) {
+  const items = [
+    { label: labels.home, href: `/${lang}` },
+    { label: labels.archive, href: `/${lang}/archive` },
+  ]
+
+  // JSON-LD 構造化データ（SSG 環境でドメイン非依存のパスのみ）
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((item, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      name: item.label,
+      item: item.href,
+    })),
+  }
+
+  return (
+    <nav aria-label="Breadcrumb" className="mb-8">
+      <ol className="flex items-center gap-2 text-sm font-mono">
+        {items.map((item, i) => (
+          <li key={item.href} className="flex items-center gap-2">
+            {i > 0 && <ChevronRight className="w-3 h-3 text-muted-foreground/50" />}
+            <Link
+              href={item.href}
+              className="text-muted-foreground hover:text-parchment transition-colors no-underline"
+            >
+              {item.label}
+            </Link>
+          </li>
+        ))}
+        <li className="flex items-center gap-2">
+          <ChevronRight className="w-3 h-3 text-muted-foreground/50" />
+          <span className="text-parchment truncate max-w-[200px] md:max-w-[400px]" aria-current="page">
+            {title}
+          </span>
+        </li>
+      </ol>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+    </nav>
+  )
+}

--- a/web-public/src/components/mystery/detail-sidebar.tsx
+++ b/web-public/src/components/mystery/detail-sidebar.tsx
@@ -6,15 +6,19 @@ interface DetailSidebarLabels {
 interface DetailSidebarProps {
   storyHooks: string[]
   labels?: DetailSidebarLabels
+  children?: React.ReactNode
 }
 
-export function DetailSidebar({ storyHooks, labels }: DetailSidebarProps) {
+export function DetailSidebar({ storyHooks, labels, children }: DetailSidebarProps) {
   const storyAnglesLabel = labels?.storyAngles ?? "Story Angles"
   const noticeText = labels?.classificationNotice ?? "This case file represents AI-generated analysis of archival records. All sources should be independently verified."
 
   return (
     <aside className="lg:col-span-1">
       <div className="sticky top-24 space-y-6">
+        {/* 目次（デスクトップ版、children から受け取る） */}
+        {children}
+
         {/* Story hooks */}
         {storyHooks.length > 0 && (
           <div className="aged-card letterpress-border rounded-sm p-5">

--- a/web-public/src/components/mystery/discrepancy-section.tsx
+++ b/web-public/src/components/mystery/discrepancy-section.tsx
@@ -10,7 +10,7 @@ export function DiscrepancySection({
   label = "Discovered Discrepancy",
 }: DiscrepancySectionProps) {
   return (
-    <section>
+    <section id="section-discrepancy" className="scroll-mt-24">
       <div className="flex items-center gap-3 mb-4">
         <AlertTriangle className="w-5 h-5 text-blood-red" />
         <h2 className="font-serif text-xl text-parchment">{label}</h2>

--- a/web-public/src/components/mystery/historical-context-section.tsx
+++ b/web-public/src/components/mystery/historical-context-section.tsx
@@ -23,7 +23,7 @@ export function HistoricalContextSection({
   const figuresLabel = labels?.keyFigures ?? "Key Figures:"
 
   return (
-    <section>
+    <section id="section-historical-context" className="scroll-mt-24">
       <div className="flex items-center gap-3 mb-4">
         <BookOpen className="w-5 h-5 text-parchment-dark" />
         <h2 className="font-serif text-xl text-parchment">{title}</h2>

--- a/web-public/src/components/mystery/hypothesis-section.tsx
+++ b/web-public/src/components/mystery/hypothesis-section.tsx
@@ -20,7 +20,7 @@ export function HypothesisSection({
   const altLabel = labels?.alternativeHypotheses ?? "Alternative Hypotheses:"
 
   return (
-    <section>
+    <section id="section-hypothesis" className="scroll-mt-24">
       <div className="flex items-center gap-3 mb-4">
         <Lightbulb className="w-5 h-5 text-gold" />
         <h2 className="font-serif text-xl text-parchment">{hypothesisLabel}</h2>

--- a/web-public/src/components/mystery/narrative-section.tsx
+++ b/web-public/src/components/mystery/narrative-section.tsx
@@ -43,7 +43,7 @@ export function NarrativeSection({ narrativeContent, summary, lang = "en" }: Nar
     }
 
     return (
-      <section className="prose prose-lg prose-invert max-w-none prose-headings:font-serif prose-headings:text-parchment prose-headings:mt-12 prose-headings:mb-4 prose-p:text-foreground/90 prose-p:leading-loose prose-p:mb-6 prose-a:text-gold prose-strong:text-parchment prose-hr:border-border">
+      <section id="section-narrative" className="scroll-mt-24 prose prose-lg prose-invert max-w-none prose-headings:font-serif prose-headings:text-parchment prose-headings:mt-12 prose-headings:mb-4 prose-p:text-foreground/90 prose-p:leading-loose prose-p:mb-6 prose-a:text-gold prose-strong:text-parchment prose-hr:border-border">
         <Markdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
           {stripLeadingH1(narrativeContent).replace(/\*\*(.+?)\*\*/g, ' **$1** ')}
         </Markdown>
@@ -52,7 +52,7 @@ export function NarrativeSection({ narrativeContent, summary, lang = "en" }: Nar
   }
 
   return (
-    <section>
+    <section id="section-narrative" className="scroll-mt-24">
       <p className="text-lg text-foreground/90 leading-relaxed">
         {summary}
       </p>

--- a/web-public/src/components/related-articles.tsx
+++ b/web-public/src/components/related-articles.tsx
@@ -1,0 +1,31 @@
+import type { FirestoreMystery } from "@ghost/shared/src/types/mystery"
+import type { SupportedLang } from "@/lib/i18n/config"
+import type { Dictionary } from "@/lib/i18n/dictionaries"
+import { MysteryCard } from "@/components/mystery-card"
+
+interface RelatedArticlesProps {
+  articles: FirestoreMystery[]
+  lang: SupportedLang
+  heading: string
+  classificationLabels: Dictionary["classification"]
+}
+
+export function RelatedArticles({ articles, lang, heading, classificationLabels }: RelatedArticlesProps) {
+  if (articles.length === 0) return null
+
+  return (
+    <section className="mt-16 pt-12 border-t border-border">
+      <h2 className="font-serif text-2xl text-parchment mb-8">{heading}</h2>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        {articles.map((article) => (
+          <MysteryCard
+            key={article.mystery_id}
+            mystery={article}
+            lang={lang}
+            classificationLabels={classificationLabels}
+          />
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/web-public/src/components/table-of-contents.tsx
+++ b/web-public/src/components/table-of-contents.tsx
@@ -1,0 +1,108 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { List } from "lucide-react"
+
+export const SECTION_IDS = {
+  narrative: "section-narrative",
+  discrepancy: "section-discrepancy",
+  evidence: "section-evidence",
+  hypothesis: "section-hypothesis",
+  historicalContext: "section-historical-context",
+} as const
+
+export interface TocSection {
+  id: string
+  label: string
+}
+
+interface TableOfContentsProps {
+  sections: TocSection[]
+  heading: string
+}
+
+function TocLinks({
+  sections,
+  activeId,
+  onClick,
+}: {
+  sections: TocSection[]
+  activeId: string | null
+  onClick: (id: string) => void
+}) {
+  return (
+    <ul className="space-y-1">
+      {sections.map((section) => (
+        <li key={section.id}>
+          <button
+            onClick={() => onClick(section.id)}
+            className={`w-full text-left text-sm font-mono py-1.5 pl-3 border-l-2 transition-colors ${
+              activeId === section.id
+                ? "text-gold border-gold"
+                : "text-muted-foreground border-transparent hover:text-parchment hover:border-muted-foreground/30"
+            }`}
+          >
+            {section.label}
+          </button>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+export function TableOfContents({ sections, heading }: TableOfContentsProps) {
+  const [activeId, setActiveId] = useState<string | null>(null)
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setActiveId(entry.target.id)
+          }
+        }
+      },
+      { rootMargin: "-20% 0px -70% 0px" }
+    )
+
+    for (const section of sections) {
+      const el = document.getElementById(section.id)
+      if (el) observer.observe(el)
+    }
+
+    return () => observer.disconnect()
+  }, [sections])
+
+  const scrollTo = (id: string) => {
+    const el = document.getElementById(id)
+    if (el) el.scrollIntoView({ behavior: "smooth" })
+  }
+
+  return (
+    <>
+      {/* デスクトップ版: サイドバー内で表示 */}
+      <div className="hidden lg:block">
+        <div className="aged-card letterpress-border rounded-sm p-5">
+          <h3 className="font-mono text-xs uppercase tracking-wider text-muted-foreground mb-4 flex items-center gap-2">
+            <List className="w-3.5 h-3.5" />
+            {heading}
+          </h3>
+          <TocLinks sections={sections} activeId={activeId} onClick={scrollTo} />
+        </div>
+      </div>
+
+      {/* モバイル版: details/summary トグル */}
+      <div className="lg:hidden mb-8">
+        <details className="aged-card letterpress-border rounded-sm">
+          <summary className="px-5 py-3 cursor-pointer font-mono text-xs uppercase tracking-wider text-muted-foreground flex items-center gap-2">
+            <List className="w-3.5 h-3.5" />
+            {heading}
+          </summary>
+          <div className="px-5 pb-4">
+            <TocLinks sections={sections} activeId={activeId} onClick={scrollTo} />
+          </div>
+        </details>
+      </div>
+    </>
+  )
+}

--- a/web-public/src/lib/i18n/dictionaries/de.ts
+++ b/web-public/src/lib/i18n/dictionaries/de.ts
@@ -92,6 +92,14 @@ const dict: Dictionary = {
     storyAngles: "Erzählperspektiven",
     classificationNotice:
       "Diese Fallakte stellt eine KI-generierte Analyse von Archivunterlagen dar. Alle Quellen sollten unabhängig überprüft werden.",
+    breadcrumbHome: "Startseite",
+    tableOfContents: "Inhaltsverzeichnis",
+    tocNarrative: "Bericht",
+    tocDiscrepancy: "Diskrepanz",
+    tocEvidence: "Beweislage",
+    tocHypothesis: "Hypothese",
+    tocHistoricalContext: "Historischer Kontext",
+    relatedArticles: "Verwandte Fallakten",
   },
   evidence: {
     source: "Quelle",

--- a/web-public/src/lib/i18n/dictionaries/en.ts
+++ b/web-public/src/lib/i18n/dictionaries/en.ts
@@ -91,6 +91,14 @@ const dict: Dictionary = {
     storyAngles: "Story Angles",
     classificationNotice:
       "This case file represents AI-generated analysis of archival records. All sources should be independently verified.",
+    breadcrumbHome: "Home",
+    tableOfContents: "Table of Contents",
+    tocNarrative: "Narrative",
+    tocDiscrepancy: "Discrepancy",
+    tocEvidence: "Evidence",
+    tocHypothesis: "Hypothesis",
+    tocHistoricalContext: "Historical Context",
+    relatedArticles: "Related Case Files",
   },
   evidence: {
     source: "Source",

--- a/web-public/src/lib/i18n/dictionaries/es.ts
+++ b/web-public/src/lib/i18n/dictionaries/es.ts
@@ -92,6 +92,14 @@ const dict: Dictionary = {
     storyAngles: "Ángulos narrativos",
     classificationNotice:
       "Este expediente representa un análisis generado por IA de registros de archivo. Todas las fuentes deben verificarse de forma independiente.",
+    breadcrumbHome: "Inicio",
+    tableOfContents: "Índice",
+    tocNarrative: "Narrativa",
+    tocDiscrepancy: "Discrepancia",
+    tocEvidence: "Evidencia",
+    tocHypothesis: "Hipótesis",
+    tocHistoricalContext: "Contexto histórico",
+    relatedArticles: "Expedientes relacionados",
   },
   evidence: {
     source: "Fuente",

--- a/web-public/src/lib/i18n/dictionaries/fr.ts
+++ b/web-public/src/lib/i18n/dictionaries/fr.ts
@@ -92,6 +92,14 @@ const dict: Dictionary = {
     storyAngles: "Angles narratifs",
     classificationNotice:
       "Ce dossier représente une analyse générée par IA de documents d'archives. Toutes les sources doivent être vérifiées de manière indépendante.",
+    breadcrumbHome: "Accueil",
+    tableOfContents: "Sommaire",
+    tocNarrative: "Récit",
+    tocDiscrepancy: "Divergence",
+    tocEvidence: "Preuves",
+    tocHypothesis: "Hypothèse",
+    tocHistoricalContext: "Contexte historique",
+    relatedArticles: "Dossiers connexes",
   },
   evidence: {
     source: "Source",

--- a/web-public/src/lib/i18n/dictionaries/ja.ts
+++ b/web-public/src/lib/i18n/dictionaries/ja.ts
@@ -91,6 +91,14 @@ const dict: Dictionary = {
     storyAngles: "物語の視点",
     classificationNotice:
       "このケースファイルはAIによるアーカイブ記録の分析です。すべてのソースを独自に検証してください。",
+    breadcrumbHome: "ホーム",
+    tableOfContents: "目次",
+    tocNarrative: "本文",
+    tocDiscrepancy: "矛盾の発見",
+    tocEvidence: "証拠資料",
+    tocHypothesis: "仮説",
+    tocHistoricalContext: "歴史的背景",
+    relatedArticles: "関連ケースファイル",
   },
   evidence: {
     source: "出典",

--- a/web-public/src/lib/i18n/dictionaries/nl.ts
+++ b/web-public/src/lib/i18n/dictionaries/nl.ts
@@ -92,6 +92,14 @@ const dict: Dictionary = {
     storyAngles: "Verhaalperspectieven",
     classificationNotice:
       "Dit dossier betreft een door AI gegenereerde analyse van archiefstukken. Alle bronnen dienen onafhankelijk te worden geverifieerd.",
+    breadcrumbHome: "Home",
+    tableOfContents: "Inhoudsopgave",
+    tocNarrative: "Verhaal",
+    tocDiscrepancy: "Discrepantie",
+    tocEvidence: "Bewijs",
+    tocHypothesis: "Hypothese",
+    tocHistoricalContext: "Historische context",
+    relatedArticles: "Gerelateerde dossiers",
   },
   evidence: {
     source: "Bron",

--- a/web-public/src/lib/i18n/dictionaries/pt.ts
+++ b/web-public/src/lib/i18n/dictionaries/pt.ts
@@ -92,6 +92,14 @@ const dict: Dictionary = {
     storyAngles: "Ângulos narrativos",
     classificationNotice:
       "Este dossiê representa uma análise gerada por IA de registros de arquivo. Todas as fontes devem ser verificadas de forma independente.",
+    breadcrumbHome: "Início",
+    tableOfContents: "Índice",
+    tocNarrative: "Narrativa",
+    tocDiscrepancy: "Discrepância",
+    tocEvidence: "Evidência",
+    tocHypothesis: "Hipótese",
+    tocHistoricalContext: "Contexto histórico",
+    relatedArticles: "Dossiês relacionados",
   },
   evidence: {
     source: "Fonte",

--- a/web-public/src/lib/i18n/dictionaries/types.ts
+++ b/web-public/src/lib/i18n/dictionaries/types.ts
@@ -75,6 +75,14 @@ export interface Dictionary {
     keyFigures: string;
     storyAngles: string;
     classificationNotice: string;
+    breadcrumbHome: string;
+    tableOfContents: string;
+    tocNarrative: string;
+    tocDiscrepancy: string;
+    tocEvidence: string;
+    tocHypothesis: string;
+    tocHistoricalContext: string;
+    relatedArticles: string;
   };
   evidence: {
     source: string;

--- a/web-public/src/lib/related-articles.ts
+++ b/web-public/src/lib/related-articles.ts
@@ -1,0 +1,46 @@
+import type { FirestoreMystery } from "@ghost/shared/src/types/mystery"
+
+/**
+ * 関連記事をスコアリングで抽出する
+ * - 同じ分類コード（mystery_id 先頭3文字）: +3
+ * - geographic_scope の重複1件あたり: +2
+ * - time_period 完全一致: +1
+ */
+export function findRelatedArticles(
+  current: FirestoreMystery,
+  all: FirestoreMystery[],
+  maxCount = 3
+): FirestoreMystery[] {
+  const currentClassification = current.mystery_id.slice(0, 3)
+  const currentGeo = new Set(current.historical_context?.geographic_scope ?? [])
+  const currentTime = current.historical_context?.time_period ?? ""
+
+  const scored = all
+    .filter((m) => m.mystery_id !== current.mystery_id)
+    .map((m) => {
+      let score = 0
+
+      // 同じ分類コード
+      if (m.mystery_id.slice(0, 3) === currentClassification) {
+        score += 3
+      }
+
+      // geographic_scope の重複
+      const geo = m.historical_context?.geographic_scope ?? []
+      for (const g of geo) {
+        if (currentGeo.has(g)) score += 2
+      }
+
+      // time_period 完全一致
+      if (currentTime && m.historical_context?.time_period === currentTime) {
+        score += 1
+      }
+
+      return { mystery: m, score }
+    })
+    .filter(({ score }) => score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, maxCount)
+
+  return scored.map(({ mystery }) => mystery)
+}


### PR DESCRIPTION
## Summary

- **パンくずリスト**: `Home > Archive > 記事タイトル` のナビゲーション + JSON-LD `BreadcrumbList` 構造化データ
- **目次（Table of Contents）**: Intersection Observer によるスクロール追従ハイライト。デスクトップはサイドバー内、モバイルは `<details>` トグル
- **関連記事**: 分類コード（+3）・地域（+2/件）・年代（+1）のスコアリングで最大3件表示。既存の `MysteryCard` を再利用

### 変更詳細

| 種別 | ファイル |
|---|---|
| **新規** | `breadcrumb.tsx`, `table-of-contents.tsx`, `related-articles.tsx`, `related-articles.ts` |
| **修正** | `page.tsx`, `detail-sidebar.tsx`, `loading.tsx`, 4セクションコンポーネント, `types.ts`, 7辞書ファイル |

- 各セクションに `id` + `scroll-mt-24` 追加（目次アンカーリンク対応）
- `DetailSidebar` に `children` prop 追加（デスクトップ目次の挿入ポイント）
- `loading.tsx` のスケルトンをパンくずリスト形式に更新
- 7言語 i18n 辞書に8キー追加（`breadcrumbHome`, `tableOfContents`, `toc*`, `relatedArticles`）

Closes #164

## Test plan

- [ ] `npm run dev` で7言語全てのパンくずリスト表示確認
- [ ] 目次のスクロール追従 + ハイライト動作確認（Chrome/Safari）
- [ ] モバイルビューで目次トグル動作確認
- [ ] discrepancy/hypothesis が存在しない記事での目次項目の動的除外確認
- [ ] 関連記事の表示（同一分類記事がある場合/ない場合）
- [ ] `view-source` で JSON-LD 構造化データ確認
- [ ] `npx tsc --noEmit` で型チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)