### PR TITLE
feat: ホームページ改修 — サイトイントロ + Classification Guide

### DIFF
--- a/web-public/src/app/[lang]/page.tsx
+++ b/web-public/src/app/[lang]/page.tsx
@@ -10,6 +10,8 @@ import { getPublishedMysteries } from "@ghost/shared/src/lib/firestore/queries"
 import { HOMEPAGE_MYSTERY_LIMIT } from "@/lib/constants"
 import Link from "next/link"
 import { FileStack, Search } from "lucide-react"
+import { SiteIntro } from "@/components/site-intro"
+import { ClassificationGuide } from "@/components/classification-guide"
 import { isValidLang } from "@/lib/i18n/config"
 import type { SupportedLang } from "@/lib/i18n/config"
 import { getDictionary } from "@/lib/i18n/dictionaries"
@@ -109,25 +111,30 @@ export default async function HomePage({
       <Header lang={lang} nav={dict.nav} />
 
       <main className="flex-1">
-        {/* sr-only h1 */}
-        <h1 className="sr-only">Ghost in the Archive</h1>
+        {/* サイトイントロ */}
+        <SiteIntro dict={dict} />
 
         {/* 記事一覧 */}
-        <section className="py-16 md:py-24">
+        <section className="pb-16 md:pb-24">
           <div className="container mx-auto px-4">
             <Suspense fallback={<MysteryListSkeleton />}>
               <MysteryList lang={lang} dict={dict} />
             </Suspense>
+          </div>
+        </section>
 
-            {/* アーカイブ導線 */}
-            <div className="mt-12 text-center">
-              <Link
-                href={`/${lang}/archive`}
-                className="inline-block text-sm font-mono text-muted-foreground hover:text-gold transition-colors no-underline"
-              >
-                <span className="redacted">████</span> {dict.home.viewAllArticles} → <span className="redacted">████</span>
-              </Link>
-            </div>
+        {/* 分類インデックス */}
+        <ClassificationGuide lang={lang} dict={dict} />
+
+        {/* アーカイブ導線 */}
+        <section className="pb-16">
+          <div className="container mx-auto px-4 text-center">
+            <Link
+              href={`/${lang}/archive`}
+              className="inline-block text-sm font-mono text-muted-foreground hover:text-gold transition-colors no-underline"
+            >
+              <span className="redacted">████</span> {dict.home.viewAllArticles} → <span className="redacted">████</span>
+            </Link>
           </div>
         </section>
       </main>

--- a/web-public/src/components/classification-guide.tsx
+++ b/web-public/src/components/classification-guide.tsx
@@ -1,0 +1,81 @@
+import Link from "next/link"
+import {
+  Scroll,
+  TreePine,
+  Users,
+  Eye,
+  Building2,
+  Search,
+  Flame,
+  MapPin,
+} from "lucide-react"
+import type { LucideIcon } from "lucide-react"
+import type { Dictionary } from "@/lib/i18n/dictionaries"
+import type { SupportedLang } from "@/lib/i18n/config"
+
+type ClassificationCode = "HIS" | "FLK" | "ANT" | "OCC" | "URB" | "CRM" | "REL" | "LOC"
+
+const CODES: ClassificationCode[] = ["HIS", "FLK", "ANT", "OCC", "URB", "CRM", "REL", "LOC"]
+
+const iconMap: Record<ClassificationCode, LucideIcon> = {
+  HIS: Scroll,
+  FLK: TreePine,
+  ANT: Users,
+  OCC: Eye,
+  URB: Building2,
+  CRM: Search,
+  REL: Flame,
+  LOC: MapPin,
+}
+
+const colorMap: Record<ClassificationCode, { icon: string; border: string }> = {
+  HIS: { icon: "text-amber-400", border: "border-amber-900/30" },
+  FLK: { icon: "text-teal-400", border: "border-teal-900/30" },
+  ANT: { icon: "text-orange-400", border: "border-orange-900/30" },
+  OCC: { icon: "text-purple-400", border: "border-purple-900/30" },
+  URB: { icon: "text-slate-400", border: "border-slate-700/30" },
+  CRM: { icon: "text-red-400", border: "border-red-900/30" },
+  REL: { icon: "text-indigo-400", border: "border-indigo-900/30" },
+  LOC: { icon: "text-emerald-400", border: "border-emerald-900/30" },
+}
+
+interface ClassificationGuideProps {
+  lang: SupportedLang
+  dict: Dictionary
+}
+
+export function ClassificationGuide({ lang, dict }: ClassificationGuideProps) {
+  return (
+    <section className="py-12 md:py-16">
+      <div className="container mx-auto px-4">
+        <h2 className="font-serif text-2xl md:text-3xl text-parchment text-center mb-8">
+          {dict.classificationGuide.heading}
+        </h2>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          {CODES.map((code) => {
+            const Icon = iconMap[code]
+            const colors = colorMap[code]
+            return (
+              <Link
+                key={code}
+                href={`/${lang}/archive`}
+                className={`group block rounded-lg border ${colors.border} bg-card p-4 transition-transform hover:scale-[1.02] no-underline`}
+              >
+                <Icon className={`w-6 h-6 ${colors.icon} mb-2`} aria-hidden="true" />
+                <p className="font-mono uppercase text-xs tracking-wider text-muted-foreground group-hover:text-gold transition-colors">
+                  {code}
+                </p>
+                <p className="font-serif text-sm text-parchment mt-1">
+                  {dict.classification[code]}
+                </p>
+                <p className="text-xs text-muted-foreground mt-1 leading-relaxed">
+                  {dict.classificationGuide.descriptions[code]}
+                </p>
+              </Link>
+            )
+          })}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/web-public/src/components/site-intro.tsx
+++ b/web-public/src/components/site-intro.tsx
@@ -1,0 +1,24 @@
+import type { Dictionary } from "@/lib/i18n/dictionaries"
+
+interface SiteIntroProps {
+  dict: Dictionary
+}
+
+export function SiteIntro({ dict }: SiteIntroProps) {
+  return (
+    <section className="py-12 md:py-16">
+      <div className="container mx-auto px-4 text-center">
+        <h1 className="font-serif text-3xl md:text-4xl lg:text-5xl text-parchment mb-4">
+          Ghost in the Archive
+        </h1>
+        <p className="text-gold font-mono uppercase tracking-wider text-sm mb-6">
+          {dict.siteIntro.tagline}
+        </p>
+        <p className="text-muted-foreground leading-relaxed max-w-3xl mx-auto">
+          {dict.siteIntro.description}
+        </p>
+        <div className="mt-8 h-px bg-gradient-to-r from-transparent via-border to-transparent" />
+      </div>
+    </section>
+  )
+}

--- a/web-public/src/lib/i18n/dictionaries/de.ts
+++ b/web-public/src/lib/i18n/dictionaries/de.ts
@@ -117,6 +117,24 @@ const dict: Dictionary = {
     LOC: "Genius Loci",
     moreLocations: "+{count} weitere",
   },
+  siteIntro: {
+    tagline: "Anomalien über Sprachen, Archive und Disziplinen hinweg aufspüren",
+    description:
+      "Ein autonomes KI-Agentensystem, das die öffentlichen digitalen Archive der Welt über fünf akademische Bereiche hinweg kreuzanalysiert — und Widersprüche aufdeckt, die keine einzelne Aufzeichnung, Sprache oder Disziplin allein erklären kann.",
+  },
+  classificationGuide: {
+    heading: "Klassifikationsindex",
+    descriptions: {
+      HIS: "Diskrepanzen in historischen Aufzeichnungen, vermisste Personen, Dokumentenlücken",
+      FLK: "Lokale Traditionen, mündliche Überlieferungen, Volksglauben",
+      ANT: "Rituale, Sozialstrukturen, interkultureller Kontakt",
+      OCC: "Unerklärliche Phänomene, übernatürliche Ereignisse",
+      URB: "Moderne Gerüchte, zeitgenössische Geistergeschichten",
+      CRM: "Ungelöste Verbrechen, Verschwundene, mysteriöse Todesfälle",
+      REL: "Religiöse Tabus, Flüche, verbotene Riten",
+      LOC: "Ortsgebundene Anomalien, Spukorte",
+    },
+  },
   share: {
     shareOnX: "Auf X teilen",
     shareOnFacebook: "Auf Facebook teilen",

--- a/web-public/src/lib/i18n/dictionaries/en.ts
+++ b/web-public/src/lib/i18n/dictionaries/en.ts
@@ -116,6 +116,24 @@ const dict: Dictionary = {
     LOC: "Locus",
     moreLocations: "+{count} more",
   },
+  siteIntro: {
+    tagline: "Unearthing anomalies across languages, archives, and disciplines",
+    description:
+      "An autonomous AI agent system that cross-analyzes the world's public digital archives through five academic fields — surfacing the contradictions that no single record, language, or discipline can explain alone.",
+  },
+  classificationGuide: {
+    heading: "Classification Index",
+    descriptions: {
+      HIS: "Historical record discrepancies, missing persons, document gaps",
+      FLK: "Local traditions, oral folklore, folk beliefs",
+      ANT: "Rituals, social structures, cross-cultural contact",
+      OCC: "Unexplainable phenomena, supernatural events",
+      URB: "Modern rumors, contemporary ghost stories",
+      CRM: "Unsolved crimes, disappearances, mysterious deaths",
+      REL: "Religious taboos, curses, forbidden rites",
+      LOC: "Place-bound anomalies, haunted locations",
+    },
+  },
   share: {
     shareOnX: "Share on X",
     shareOnFacebook: "Share on Facebook",

--- a/web-public/src/lib/i18n/dictionaries/es.ts
+++ b/web-public/src/lib/i18n/dictionaries/es.ts
@@ -117,6 +117,24 @@ const dict: Dictionary = {
     LOC: "Locus",
     moreLocations: "+{count} más",
   },
+  siteIntro: {
+    tagline: "Desenterrando anomalías entre idiomas, archivos y disciplinas",
+    description:
+      "Un sistema autónomo de agentes de IA que analiza cruzadamente los archivos digitales públicos del mundo a través de cinco campos académicos — revelando las contradicciones que ningún registro, idioma o disciplina puede explicar por sí solo.",
+  },
+  classificationGuide: {
+    heading: "Índice de clasificación",
+    descriptions: {
+      HIS: "Discrepancias en registros históricos, personas desaparecidas, lagunas documentales",
+      FLK: "Tradiciones locales, folclore oral, creencias populares",
+      ANT: "Rituales, estructuras sociales, contacto intercultural",
+      OCC: "Fenómenos inexplicables, eventos sobrenaturales",
+      URB: "Rumores modernos, historias de fantasmas contemporáneas",
+      CRM: "Crímenes sin resolver, desapariciones, muertes misteriosas",
+      REL: "Tabúes religiosos, maldiciones, ritos prohibidos",
+      LOC: "Anomalías ligadas a lugares, ubicaciones encantadas",
+    },
+  },
   share: {
     shareOnX: "Compartir en X",
     shareOnFacebook: "Compartir en Facebook",

--- a/web-public/src/lib/i18n/dictionaries/fr.ts
+++ b/web-public/src/lib/i18n/dictionaries/fr.ts
@@ -117,6 +117,24 @@ const dict: Dictionary = {
     LOC: "Genius Loci",
     moreLocations: "+{count} autres",
   },
+  siteIntro: {
+    tagline: "Exhumer les anomalies à travers langues, archives et disciplines",
+    description:
+      "Un système d'agents IA autonomes qui analyse croisément les archives numériques publiques du monde à travers cinq domaines académiques — révélant les contradictions qu'aucun document, aucune langue ni aucune discipline ne peut expliquer seul.",
+  },
+  classificationGuide: {
+    heading: "Index de classification",
+    descriptions: {
+      HIS: "Divergences dans les archives historiques, personnes disparues, lacunes documentaires",
+      FLK: "Traditions locales, folklore oral, croyances populaires",
+      ANT: "Rituels, structures sociales, contacts interculturels",
+      OCC: "Phénomènes inexplicables, événements surnaturels",
+      URB: "Rumeurs modernes, histoires de fantômes contemporaines",
+      CRM: "Crimes non résolus, disparitions, morts mystérieuses",
+      REL: "Tabous religieux, malédictions, rites interdits",
+      LOC: "Anomalies liées aux lieux, endroits hantés",
+    },
+  },
   share: {
     shareOnX: "Partager sur X",
     shareOnFacebook: "Partager sur Facebook",

--- a/web-public/src/lib/i18n/dictionaries/ja.ts
+++ b/web-public/src/lib/i18n/dictionaries/ja.ts
@@ -116,6 +116,24 @@ const dict: Dictionary = {
     LOC: "地霊・場所",
     moreLocations: "他{count}件",
   },
+  siteIntro: {
+    tagline: "言語・記録・学問の境界を越えて、アノマリーを発掘する",
+    description:
+      "世界の公開デジタルアーカイブを5つの学術領域で多言語横断分析する自律型AIエージェントシステム。単一の記録・言語・学問分野では説明できない矛盾を浮かび上がらせる。",
+  },
+  classificationGuide: {
+    heading: "分類索引",
+    descriptions: {
+      HIS: "歴史的記録の矛盾、消失した人物、文書の欠落",
+      FLK: "地方伝承、口承伝統、民間信仰",
+      ANT: "儀礼、社会構造、異文化接触",
+      OCC: "説明不能な現象、超常的事象",
+      URB: "近代の噂話、現代の怪談",
+      CRM: "未解決犯罪、失踪事件、謎の死",
+      REL: "宗教的タブー、呪い、禁じられた儀式",
+      LOC: "場所に紐づく怪異、心霊スポット",
+    },
+  },
   share: {
     shareOnX: "Xでシェア",
     shareOnFacebook: "Facebookでシェア",

--- a/web-public/src/lib/i18n/dictionaries/nl.ts
+++ b/web-public/src/lib/i18n/dictionaries/nl.ts
@@ -117,6 +117,24 @@ const dict: Dictionary = {
     LOC: "Genius Loci",
     moreLocations: "+{count} meer",
   },
+  siteIntro: {
+    tagline: "Anomalieën opgraven over talen, archieven en disciplines heen",
+    description:
+      "Een autonoom AI-agentsysteem dat de openbare digitale archieven van de wereld kruislings analyseert via vijf academische vakgebieden — en tegenstrijdigheden blootlegt die geen enkel document, geen enkele taal of discipline alleen kan verklaren.",
+  },
+  classificationGuide: {
+    heading: "Classificatie-index",
+    descriptions: {
+      HIS: "Discrepanties in historische documenten, vermiste personen, lacunes in archieven",
+      FLK: "Lokale tradities, mondelinge overlevering, volksgeloof",
+      ANT: "Rituelen, sociale structuren, intercultureel contact",
+      OCC: "Onverklaarbare verschijnselen, bovennatuurlijke gebeurtenissen",
+      URB: "Moderne geruchten, hedendaagse spookverhalen",
+      CRM: "Onopgeloste misdaden, verdwijningen, mysterieuze sterfgevallen",
+      REL: "Religieuze taboes, vloeken, verboden rituelen",
+      LOC: "Plaatsgebonden anomalieën, spooklocaties",
+    },
+  },
   share: {
     shareOnX: "Delen op X",
     shareOnFacebook: "Delen op Facebook",

--- a/web-public/src/lib/i18n/dictionaries/pt.ts
+++ b/web-public/src/lib/i18n/dictionaries/pt.ts
@@ -117,6 +117,24 @@ const dict: Dictionary = {
     LOC: "Genius Loci",
     moreLocations: "+{count} mais",
   },
+  siteIntro: {
+    tagline: "Desenterrando anomalias entre idiomas, arquivos e disciplinas",
+    description:
+      "Um sistema autônomo de agentes de IA que analisa cruzadamente os arquivos digitais públicos do mundo através de cinco campos acadêmicos — revelando as contradições que nenhum registro, idioma ou disciplina pode explicar sozinho.",
+  },
+  classificationGuide: {
+    heading: "Índice de classificação",
+    descriptions: {
+      HIS: "Discrepâncias em registros históricos, pessoas desaparecidas, lacunas documentais",
+      FLK: "Tradições locais, folclore oral, crenças populares",
+      ANT: "Rituais, estruturas sociais, contato intercultural",
+      OCC: "Fenômenos inexplicáveis, eventos sobrenaturais",
+      URB: "Rumores modernos, histórias de fantasmas contemporâneas",
+      CRM: "Crimes não resolvidos, desaparecimentos, mortes misteriosas",
+      REL: "Tabus religiosos, maldições, ritos proibidos",
+      LOC: "Anomalias ligadas a lugares, locais assombrados",
+    },
+  },
   share: {
     shareOnX: "Compartilhar no X",
     shareOnFacebook: "Compartilhar no Facebook",

--- a/web-public/src/lib/i18n/dictionaries/types.ts
+++ b/web-public/src/lib/i18n/dictionaries/types.ts
@@ -100,6 +100,23 @@ export interface Dictionary {
     LOC: string;
     moreLocations: string;
   };
+  siteIntro: {
+    tagline: string;
+    description: string;
+  };
+  classificationGuide: {
+    heading: string;
+    descriptions: {
+      HIS: string;
+      FLK: string;
+      ANT: string;
+      OCC: string;
+      URB: string;
+      CRM: string;
+      REL: string;
+      LOC: string;
+    };
+  };
   share: {
     shareOnX: string;
     shareOnFacebook: string;


### PR DESCRIPTION
## Summary

Closes #221

- **SiteIntro** コンポーネント新設: 可視 h1（`Ghost in the Archive`）+ タグライン + 説明文でサイトコンセプトを初訪問者に伝達
- **ClassificationGuide** コンポーネント新設: 8分類のビジュアルインデックス（lucide-react アイコン + colorMap + 1行説明）でカテゴリ起点の探索導線を提供
- 7言語辞書（en/ja/es/de/fr/nl/pt）に `siteIntro` / `classificationGuide` テキスト追加
- `sr-only` の h1 を `SiteIntro` 内の可視 h1 に置き換え
- 記事セクションの padding を `py-16` → `pb-16` に変更（SiteIntro との二重余白防止）

## 改修後のページ構成

```
[Header]
[A. サイトイントロ — h1 + タグライン + 説明文]     ← 新設
[B. Featured Investigation Card（既存維持）]
[C. Latest Discoveries Grid（既存維持）]
[D. Classification Guide — 8分類グリッド]           ← 新設
[E. Archive 導線（既存維持）]
[Footer]
```

## 変更ファイル

| ファイル | 変更種別 |
|----------|----------|
| `web-public/src/components/site-intro.tsx` | 新規 |
| `web-public/src/components/classification-guide.tsx` | 新規 |
| `web-public/src/app/[lang]/page.tsx` | 修正 |
| `web-public/src/lib/i18n/dictionaries/types.ts` | 修正 |
| `web-public/src/lib/i18n/dictionaries/{en,ja,es,de,fr,nl,pt}.ts` | 修正（×7） |

## Test plan

- [x] TypeScript 型チェック通過（`tsc --noEmit`）
- [ ] 7言語パス（`/en`, `/ja`, `/es`, `/de`, `/fr`, `/nl`, `/pt`）でレスポンシブ表示確認
- [ ] アクセシビリティ: 装飾アイコンに `aria-hidden="true"`、h1 が可視テキスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)