### PR TITLE
feat: Ghost 再定義 Phase 2 — 構造化データ拡張（source_coverage + confidence_rationale）

### DIFF
--- a/mystery_agents/agents/armchair_polymath.py
+++ b/mystery_agents/agents/armchair_polymath.py
@@ -12,6 +12,7 @@ from google.adk.agents import LlmAgent
 from shared.model_config import create_pro_model
 
 from ..tools.scholar_tools import save_structured_report
+from ..tools.search_metadata import get_search_metadata
 
 # === 日本語訳 ===
 # あなたは「Ghost in the Archive」プロジェクトの Armchair Polymath です。
@@ -54,6 +55,12 @@ from ..tools.scholar_tools import save_structured_report
 # すべての evidence オブジェクト（evidence_a, evidence_b, additional_evidence 各項目）には
 # 空でない relevant_excerpt を必ず含めること。具体的な抜粋が見つからない場合は、
 # 元資料の内容を簡潔に言い換えること。空の excerpt は絶対に不可。
+#
+# ## ツール: get_search_metadata
+# Source Coverage Assessment を行う前に `get_search_metadata` を呼び出す。
+# このツールは Librarian の raw_search_results からどの API が検索され、
+# どの API で結果が得られたかのコンパクトなサマリを返す。
+# このデータを使って source_coverage フィールドと confidence_rationale を作成する。
 #
 # ## ソースカバレッジ評価（confidence 判定の前提）
 # confidence_level を判定する前に、調査の限界を明示的に評価する:
@@ -107,6 +114,12 @@ Read the following Scholar analysis results from session state (some may be abse
 If the whiteboard is empty, no debate took place (single-language investigation).
 If populated, it contains challenges, corroborations, and synthesis proposals
 from each Scholar after reading other perspectives, organized by round.
+
+## Tool: get_search_metadata
+Before performing the Source Coverage Assessment, call `get_search_metadata` (no arguments needed).
+It returns a compact summary of which APIs the Librarian searched and which returned results,
+extracted from the raw search data in session state. Use this data to populate the
+`source_coverage` object and inform your `confidence_rationale` in the structured report.
 
 ## Critical Rule: Require At Least One Analysis
 Check the session state for Scholar analysis results.
@@ -251,6 +264,14 @@ After completing your analysis, you MUST call `save_structured_report` with a JS
   "hypothesis": "Primary hypothesis in English",
   "alternative_hypotheses": ["Alt 1", "Alt 2"],
   "confidence_level": "high|medium|low",
+  "source_coverage": {{
+    "apis_searched": ["chronicling_america", "loc", "dpla", "europeana"],
+    "apis_with_results": ["chronicling_america", "loc"],
+    "apis_without_results": ["dpla", "europeana"],
+    "known_undigitized_sources": ["Regional parish registers", "Private family archives"],
+    "coverage_assessment": "Approximately 15-20% of records from this period are digitized..."
+  }},
+  "confidence_rationale": "Rated MEDIUM because two independent sources contradict on the date of arrival, but DPLA and Europeana returned no results — the discrepancy might be resolved by undigitized port authority records.",
   "languages_analyzed": ["en", "de"]
 }}
 ```
@@ -305,6 +326,14 @@ The full JSON structure for `save_structured_report`:
   }},
   "research_questions": ["Question 1"],
   "story_hooks": ["Hook 1"],
+  "source_coverage": {{
+    "apis_searched": ["chronicling_america", "loc", "dpla"],
+    "apis_with_results": ["chronicling_america", "loc"],
+    "apis_without_results": ["dpla"],
+    "known_undigitized_sources": [],
+    "coverage_assessment": "Coverage assessment text"
+  }},
+  "confidence_rationale": "Rationale for the chosen confidence level",
   "languages_analyzed": ["en", "de"]
 }}
 ```
@@ -327,6 +356,6 @@ armchair_polymath_agent = LlmAgent(
         "and Anthropology perspectives from all available language sources."
     ),
     instruction=ARMCHAIR_POLYMATH_INSTRUCTION,
-    tools=[save_structured_report],
+    tools=[save_structured_report, get_search_metadata],
     output_key="mystery_report",  # 既存と同じキー → 下流互換性維持
 )

--- a/mystery_agents/schemas/mystery_report.py
+++ b/mystery_agents/schemas/mystery_report.py
@@ -72,6 +72,31 @@ class HistoricalContext(BaseModel):
     )
 
 
+class SourceCoverage(BaseModel):
+    """ソースカバレッジ評価 — Polymath が行う調査範囲の自己評価。"""
+
+    apis_searched: List[str] = Field(
+        default_factory=list,
+        description="検索した API/アーカイブのリスト",
+    )
+    apis_with_results: List[str] = Field(
+        default_factory=list,
+        description="結果を返した API/アーカイブのリスト",
+    )
+    apis_without_results: List[str] = Field(
+        default_factory=list,
+        description="結果を返さなかった API/アーカイブのリスト",
+    )
+    known_undigitized_sources: List[str] = Field(
+        default_factory=list,
+        description="この時代・地域に存在するがデジタル化されていない既知のソース",
+    )
+    coverage_assessment: Optional[str] = Field(
+        None,
+        description="デジタル化範囲と調査限界に関する総合評価",
+    )
+
+
 class AgentLogEntry(BaseModel):
     """パイプライン実行中の単一エージェントのログエントリ。"""
 
@@ -128,6 +153,14 @@ class MysteryReport(BaseModel):
     )
     confidence_level: ConfidenceLevel = Field(
         ..., description="Confidence level in the primary hypothesis"
+    )
+    source_coverage: Optional[SourceCoverage] = Field(
+        None,
+        description="ソースカバレッジ評価（検索範囲と限界の自己評価）",
+    )
+    confidence_rationale: Optional[str] = Field(
+        None,
+        description="confidence_level 判定の根拠（なぜその水準か）",
     )
 
     historical_context: HistoricalContext = Field(

--- a/mystery_agents/tools/__init__.py
+++ b/mystery_agents/tools/__init__.py
@@ -38,6 +38,9 @@ from .scholar_tools import (
 # Debate tools
 from .debate_tools import append_to_whiteboard
 
+# Search metadata tool
+from .search_metadata import get_search_metadata
+
 # ThemeAnalyzer Agent LLM-facing tools
 from .theme_analyzer_tools import save_language_selection
 
@@ -72,6 +75,8 @@ __all__ = [
     "save_structured_report",
     # Debate tools
     "append_to_whiteboard",
+    # Search metadata tool
+    "get_search_metadata",
     # ThemeAnalyzer LLM tools
     "save_language_selection",
 ]

--- a/mystery_agents/tools/publisher_tools.py
+++ b/mystery_agents/tools/publisher_tools.py
@@ -278,6 +278,7 @@ def publish_mystery(
                     "confidence_level", "discrepancy_detected", "discrepancy_type",
                     "historical_context", "research_questions", "story_hooks",
                     "title", "summary",
+                    "source_coverage", "confidence_rationale",
                 ):
                     if key in structured_report:
                         data[key] = structured_report[key]

--- a/mystery_agents/tools/search_metadata.py
+++ b/mystery_agents/tools/search_metadata.py
@@ -1,0 +1,162 @@
+"""検索メタデータ取得ツール。
+
+raw_search_results から API 検索状況のコンパクトなサマリを生成する。
+raw_search_results はドキュメント全文を含み巨大なため、
+ツール経由で必要なメタデータのみ抽出する。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Optional
+
+from google.adk.tools.tool_context import ToolContext
+
+logger = logging.getLogger(__name__)
+
+# 検索結果がない場合のレスポンス
+_NO_DATA_RESPONSE = {
+    "status": "no_data",
+    "message": "No raw_search_results found in session state.",
+    "apis_searched": [],
+    "apis_with_results": [],
+    "apis_without_results": [],
+    "per_api_stats": {},
+    "languages_searched": [],
+}
+
+
+def _extract_from_single_result(result: dict[str, Any]) -> dict[str, Any]:
+    """単一の検索結果エントリからメタデータを抽出する。
+
+    search_newspapers 形式と search_archives 形式の両方に対応。
+
+    Returns:
+        api_name → {total_hits, documents_returned} の dict、
+        および errors / fallback_used 情報
+    """
+    per_api: dict[str, dict[str, int]] = {}
+    errors: dict[str, str] = {}
+    fallback_used = False
+
+    # search_newspapers 形式: source フィールドで API を識別
+    source = result.get("source")
+    if source and source != "none":
+        per_api[source] = {
+            "total_hits": result.get("total_hits", 0),
+            "documents_returned": result.get("documents_returned", 0),
+        }
+        if result.get("error"):
+            errors[source] = result["error"]
+
+    # search_archives 形式: sources_searched dict で各 API の統計を取得
+    sources_searched = result.get("sources_searched")
+    if sources_searched and isinstance(sources_searched, dict):
+        for api_key, stats in sources_searched.items():
+            if isinstance(stats, dict):
+                per_api[api_key] = {
+                    "total_hits": stats.get("total_hits", 0),
+                    "documents_returned": stats.get("documents_returned", 0),
+                }
+
+    # search_archives のエラー情報
+    result_errors = result.get("errors")
+    if result_errors and isinstance(result_errors, dict):
+        errors.update(result_errors)
+
+    # fallback_used
+    if result.get("fallback_used"):
+        fallback_used = True
+
+    return {
+        "per_api": per_api,
+        "errors": errors,
+        "fallback_used": fallback_used,
+    }
+
+
+def get_search_metadata(tool_context: Optional[ToolContext] = None) -> str:
+    """raw_search_results から API 検索状況のサマリを生成する。
+
+    セッション状態の raw_search_results / raw_search_results_{lang} を読み取り、
+    どの API が検索され、どの API で結果が得られたかのコンパクトなサマリを返す。
+
+    Args:
+        tool_context: ADK tool context（セッション状態アクセス用）
+
+    Returns:
+        JSON 文字列: apis_searched, apis_with_results, apis_without_results,
+                     per_api_stats, languages_searched
+    """
+    if tool_context is None:
+        return json.dumps(_NO_DATA_RESPONSE, ensure_ascii=False)
+
+    state = tool_context.state
+
+    # raw_search_results と raw_search_results_{lang} を収集
+    all_results: list[tuple[str, list]] = []
+
+    # ベースキー
+    base_results = state.get("raw_search_results")
+    if base_results and isinstance(base_results, list):
+        all_results.append(("base", base_results))
+
+    # 言語別キー
+    languages_searched: list[str] = []
+    for key in list(state.keys()):
+        if key.startswith("raw_search_results_") and key != "raw_search_results":
+            lang = key.replace("raw_search_results_", "")
+            lang_results = state.get(key)
+            if lang_results and isinstance(lang_results, list):
+                all_results.append((lang, lang_results))
+                languages_searched.append(lang)
+
+    if not all_results:
+        return json.dumps(_NO_DATA_RESPONSE, ensure_ascii=False)
+
+    # 全結果を集約
+    per_api_stats: dict[str, dict[str, int]] = {}
+    all_errors: dict[str, str] = {}
+    any_fallback = False
+
+    for _label, results_list in all_results:
+        for result in results_list:
+            if not isinstance(result, dict):
+                continue
+            extracted = _extract_from_single_result(result)
+            # per_api を集約（同じ API は hits/docs を加算）
+            for api_name, stats in extracted["per_api"].items():
+                if api_name in per_api_stats:
+                    per_api_stats[api_name]["total_hits"] += stats["total_hits"]
+                    per_api_stats[api_name]["documents_returned"] += stats["documents_returned"]
+                else:
+                    per_api_stats[api_name] = dict(stats)
+            all_errors.update(extracted["errors"])
+            if extracted["fallback_used"]:
+                any_fallback = True
+
+    apis_searched = sorted(per_api_stats.keys())
+    apis_with_results = sorted(
+        api for api, stats in per_api_stats.items()
+        if stats["documents_returned"] > 0
+    )
+    apis_without_results = sorted(
+        api for api, stats in per_api_stats.items()
+        if stats["documents_returned"] == 0
+    )
+
+    response = {
+        "status": "ok",
+        "apis_searched": apis_searched,
+        "apis_with_results": apis_with_results,
+        "apis_without_results": apis_without_results,
+        "per_api_stats": per_api_stats,
+        "languages_searched": sorted(languages_searched),
+    }
+    if all_errors:
+        response["errors"] = all_errors
+    if any_fallback:
+        response["fallback_used"] = True
+
+    return json.dumps(response, ensure_ascii=False)

--- a/packages/shared/src/types/mystery.ts
+++ b/packages/shared/src/types/mystery.ts
@@ -106,6 +106,23 @@ export interface HistoricalContext {
 }
 
 /**
+ * ソースカバレッジ評価
+ * Polymath が行う調査範囲の自己評価
+ */
+export interface SourceCoverage {
+  /** 検索した API/アーカイブのリスト */
+  apis_searched: string[];
+  /** 結果を返した API/アーカイブのリスト */
+  apis_with_results: string[];
+  /** 結果を返さなかった API/アーカイブのリスト */
+  apis_without_results: string[];
+  /** この時代・地域に存在するがデジタル化されていない既知のソース */
+  known_undigitized_sources?: string[];
+  /** デジタル化範囲と調査限界に関する総合評価 */
+  coverage_assessment?: string;
+}
+
+/**
  * ミステリーレポート
  * Scholar Agentの出力結果
  */
@@ -135,6 +152,10 @@ export interface MysteryReport {
   alternative_hypotheses: string[];
   /** 信頼度レベル */
   confidence_level: ConfidenceLevel;
+  /** ソースカバレッジ評価（検索範囲と限界の自己評価） */
+  source_coverage?: SourceCoverage;
+  /** confidence_level 判定の根拠 */
+  confidence_rationale?: string;
 
   /** 歴史的コンテキスト */
   historical_context: HistoricalContext;

--- a/shared/state_registry.py
+++ b/shared/state_registry.py
@@ -48,6 +48,18 @@ STATE_KEYS: list[StateKey] = [
         read_by=("scholar_{lang}", "pipeline_gate", "publisher_tools"),
     ),
     StateKey(
+        name="raw_search_results",
+        description="Librarian ツールが直接書き込む検索結果リスト（ベースキー）",
+        written_by=("librarian_tools",),
+        read_by=("search_metadata",),
+    ),
+    StateKey(
+        name="raw_search_results_{lang}",
+        description="Librarian ツールが直接書き込む検索結果リスト（言語別）",
+        written_by=("librarian_tools",),
+        read_by=("search_metadata",),
+    ),
+    StateKey(
         name="scholar_analysis_{lang}",
         description="Scholar（分析モード）の分析レポート（言語別）",
         written_by=("scholar_{lang}",),

--- a/tests/unit/test_armchair_polymath.py
+++ b/tests/unit/test_armchair_polymath.py
@@ -1,6 +1,10 @@
-"""Unit tests for Armchair Polymath agent instruction."""
+"""Unit tests for Armchair Polymath agent instruction and configuration."""
 
-from mystery_agents.agents.armchair_polymath import ARMCHAIR_POLYMATH_INSTRUCTION
+from mystery_agents.agents.armchair_polymath import (
+    ARMCHAIR_POLYMATH_INSTRUCTION,
+    armchair_polymath_agent,
+)
+from mystery_agents.tools.search_metadata import get_search_metadata
 
 
 class TestArmchairPolymathInstruction:
@@ -30,3 +34,23 @@ class TestArmchairPolymathInstruction:
         sca_pos = ARMCHAIR_POLYMATH_INSTRUCTION.index("Source Coverage Assessment")
         clc_pos = ARMCHAIR_POLYMATH_INSTRUCTION.index("Confidence Level Checklist")
         assert sca_pos < clc_pos
+
+    def test_instruction_includes_source_coverage_in_json(self):
+        """instruction の JSON 例に source_coverage フィールドが含まれる。"""
+        assert '"source_coverage"' in ARMCHAIR_POLYMATH_INSTRUCTION
+
+    def test_instruction_includes_confidence_rationale_in_json(self):
+        """instruction の JSON 例に confidence_rationale フィールドが含まれる。"""
+        assert '"confidence_rationale"' in ARMCHAIR_POLYMATH_INSTRUCTION
+
+    def test_instruction_includes_get_search_metadata(self):
+        """instruction に get_search_metadata ツールの説明が含まれる。"""
+        assert "get_search_metadata" in ARMCHAIR_POLYMATH_INSTRUCTION
+
+
+class TestArmchairPolymathTools:
+    def test_tools_include_get_search_metadata(self):
+        """armchair_polymath_agent の tools に get_search_metadata が含まれる。"""
+        tool_functions = [t for t in armchair_polymath_agent.tools if callable(t)]
+        tool_names = [t.__name__ for t in tool_functions]
+        assert "get_search_metadata" in tool_names

--- a/tests/unit/test_publisher_tools.py
+++ b/tests/unit/test_publisher_tools.py
@@ -1009,3 +1009,96 @@ class TestThumbnailUpload:
         assert "thumbnail" in images
         assert "hero" not in images  # サムネイルだけなら hero は設定されない
 
+
+class TestPublishMysteryStructuredDataExtension:
+    """source_coverage / confidence_rationale の Firestore 保存テスト。"""
+
+    @patch("mystery_agents.tools.publisher_tools.get_storage_bucket")
+    @patch("mystery_agents.tools.publisher_tools.get_firestore_client")
+    def test_source_coverage_from_structured_report(self, mock_get_db, mock_get_bucket):
+        """structured_report の source_coverage が Firestore に保存される。"""
+        mock_db = MagicMock()
+        mock_get_db.return_value = mock_db
+        mock_get_bucket.return_value = MagicMock()
+
+        state = {
+            "structured_report": {
+                "classification": "OCC",
+                "country_code": "US",
+                "region_code": "BOS",
+                "title": "Test",
+                "summary": "Test summary",
+                "source_coverage": {
+                    "apis_searched": ["chronicling_america", "loc"],
+                    "apis_with_results": ["chronicling_america"],
+                    "apis_without_results": ["loc"],
+                    "known_undigitized_sources": ["Parish registers"],
+                    "coverage_assessment": "Limited coverage",
+                },
+            }
+        }
+        tool_context = MagicMock()
+        tool_context.state = state
+
+        result = publish_mystery(_make_mystery_json(), "", tool_context)
+        assert json.loads(result)["status"] == "success"
+
+        saved = mock_db.collection.return_value.document.return_value.set.call_args[0][0]
+        assert "source_coverage" in saved
+        assert saved["source_coverage"]["apis_searched"] == ["chronicling_america", "loc"]
+        assert saved["source_coverage"]["coverage_assessment"] == "Limited coverage"
+
+    @patch("mystery_agents.tools.publisher_tools.get_storage_bucket")
+    @patch("mystery_agents.tools.publisher_tools.get_firestore_client")
+    def test_confidence_rationale_from_structured_report(self, mock_get_db, mock_get_bucket):
+        """structured_report の confidence_rationale が Firestore に保存される。"""
+        mock_db = MagicMock()
+        mock_get_db.return_value = mock_db
+        mock_get_bucket.return_value = MagicMock()
+
+        state = {
+            "structured_report": {
+                "classification": "HIS",
+                "country_code": "GB",
+                "region_code": "LHR",
+                "title": "Test",
+                "summary": "Test summary",
+                "confidence_rationale": "Rated MEDIUM because two sources conflict but DPLA was unavailable.",
+            }
+        }
+        tool_context = MagicMock()
+        tool_context.state = state
+
+        result = publish_mystery(_make_mystery_json(), "", tool_context)
+        assert json.loads(result)["status"] == "success"
+
+        saved = mock_db.collection.return_value.document.return_value.set.call_args[0][0]
+        assert saved["confidence_rationale"] == "Rated MEDIUM because two sources conflict but DPLA was unavailable."
+
+    @patch("mystery_agents.tools.publisher_tools.get_storage_bucket")
+    @patch("mystery_agents.tools.publisher_tools.get_firestore_client")
+    def test_missing_new_fields_does_not_break(self, mock_get_db, mock_get_bucket):
+        """source_coverage / confidence_rationale がなくても後方互換で動作する。"""
+        mock_db = MagicMock()
+        mock_get_db.return_value = mock_db
+        mock_get_bucket.return_value = MagicMock()
+
+        state = {
+            "structured_report": {
+                "classification": "OCC",
+                "country_code": "US",
+                "region_code": "BOS",
+                "title": "Legacy Report",
+                "summary": "No new fields",
+            }
+        }
+        tool_context = MagicMock()
+        tool_context.state = state
+
+        result = publish_mystery(_make_mystery_json(), "", tool_context)
+        assert json.loads(result)["status"] == "success"
+
+        saved = mock_db.collection.return_value.document.return_value.set.call_args[0][0]
+        assert "source_coverage" not in saved
+        assert "confidence_rationale" not in saved
+

--- a/tests/unit/test_scholar_tools.py
+++ b/tests/unit/test_scholar_tools.py
@@ -319,3 +319,47 @@ class TestSaveStructuredReportEvidenceValidation:
 
         assert result_data["status"] == "success"
         assert result_data["warnings"] == []
+
+
+class TestSaveStructuredReportNewFields:
+    """source_coverage と confidence_rationale の保存テスト。"""
+
+    def test_source_coverage_preserved(self):
+        """source_coverage オブジェクトがそのまま保存される。"""
+        report_data = {
+            "title": "Test",
+            "source_coverage": {
+                "apis_searched": ["chronicling_america", "loc", "dpla"],
+                "apis_with_results": ["chronicling_america", "loc"],
+                "apis_without_results": ["dpla"],
+                "known_undigitized_sources": ["Parish registers"],
+                "coverage_assessment": "About 20% digitized",
+            },
+        }
+        mock_ctx = MagicMock()
+        mock_ctx.state = {}
+
+        result = save_structured_report(json.dumps(report_data), mock_ctx)
+        result_data = json.loads(result)
+
+        assert result_data["status"] == "success"
+        saved = mock_ctx.state["structured_report"]
+        assert saved["source_coverage"]["apis_searched"] == ["chronicling_america", "loc", "dpla"]
+        assert saved["source_coverage"]["apis_without_results"] == ["dpla"]
+        assert saved["source_coverage"]["coverage_assessment"] == "About 20% digitized"
+
+    def test_confidence_rationale_preserved(self):
+        """confidence_rationale 文字列がそのまま保存される。"""
+        report_data = {
+            "title": "Test",
+            "confidence_rationale": "Rated LOW because only one source was found via API.",
+        }
+        mock_ctx = MagicMock()
+        mock_ctx.state = {}
+
+        result = save_structured_report(json.dumps(report_data), mock_ctx)
+        result_data = json.loads(result)
+
+        assert result_data["status"] == "success"
+        saved = mock_ctx.state["structured_report"]
+        assert saved["confidence_rationale"] == "Rated LOW because only one source was found via API."

--- a/tests/unit/test_search_metadata.py
+++ b/tests/unit/test_search_metadata.py
@@ -1,0 +1,223 @@
+"""Unit tests for get_search_metadata tool."""
+
+import json
+from unittest.mock import MagicMock
+
+from mystery_agents.tools.search_metadata import get_search_metadata
+
+
+class TestGetSearchMetadataNoData:
+    """raw_search_results がない場合のテスト。"""
+
+    def test_no_tool_context_returns_no_data(self):
+        """tool_context が None → no_data を返す。"""
+        result = json.loads(get_search_metadata(None))
+        assert result["status"] == "no_data"
+        assert result["apis_searched"] == []
+
+    def test_empty_state_returns_no_data(self):
+        """state にキーがない → no_data を返す。"""
+        ctx = MagicMock()
+        ctx.state = {}
+        result = json.loads(get_search_metadata(ctx))
+        assert result["status"] == "no_data"
+
+    def test_empty_list_returns_no_data(self):
+        """raw_search_results が空リスト → no_data を返す。"""
+        ctx = MagicMock()
+        ctx.state = {"raw_search_results": []}
+        result = json.loads(get_search_metadata(ctx))
+        assert result["status"] == "no_data"
+
+
+class TestGetSearchMetadataNewspapers:
+    """search_newspapers 形式の結果からの抽出テスト。"""
+
+    def test_extracts_newspaper_source(self):
+        """chronicling_america の検索結果が正しく抽出される。"""
+        ctx = MagicMock()
+        ctx.state = {
+            "raw_search_results": [
+                {
+                    "source": "chronicling_america",
+                    "keywords_used": ["ghost", "ship"],
+                    "total_hits": 42,
+                    "documents_returned": 10,
+                    "documents": [],
+                    "error": None,
+                }
+            ]
+        }
+        result = json.loads(get_search_metadata(ctx))
+        assert result["status"] == "ok"
+        assert "chronicling_america" in result["apis_searched"]
+        assert "chronicling_america" in result["apis_with_results"]
+        assert result["per_api_stats"]["chronicling_america"]["total_hits"] == 42
+        assert result["per_api_stats"]["chronicling_america"]["documents_returned"] == 10
+
+    def test_zero_results_in_without_results(self):
+        """documents_returned が 0 → apis_without_results に含まれる。"""
+        ctx = MagicMock()
+        ctx.state = {
+            "raw_search_results": [
+                {
+                    "source": "chronicling_america",
+                    "total_hits": 0,
+                    "documents_returned": 0,
+                    "documents": [],
+                    "error": None,
+                }
+            ]
+        }
+        result = json.loads(get_search_metadata(ctx))
+        assert "chronicling_america" in result["apis_without_results"]
+        assert result["apis_with_results"] == []
+
+
+class TestGetSearchMetadataArchives:
+    """search_archives 形式の sources_searched dict からの抽出テスト。"""
+
+    def test_extracts_sources_searched(self):
+        """sources_searched dict の各 API 統計が抽出される。"""
+        ctx = MagicMock()
+        ctx.state = {
+            "raw_search_results": [
+                {
+                    "sources_searched": {
+                        "loc": {"name": "Library of Congress", "total_hits": 15, "documents_returned": 5},
+                        "dpla": {"name": "DPLA", "total_hits": 0, "documents_returned": 0},
+                        "europeana": {"name": "Europeana", "total_hits": 3, "documents_returned": 2},
+                    },
+                    "total_documents": 7,
+                    "documents": [],
+                }
+            ]
+        }
+        result = json.loads(get_search_metadata(ctx))
+        assert result["status"] == "ok"
+        assert sorted(result["apis_searched"]) == ["dpla", "europeana", "loc"]
+        assert sorted(result["apis_with_results"]) == ["europeana", "loc"]
+        assert result["apis_without_results"] == ["dpla"]
+
+    def test_errors_propagated(self):
+        """search_archives の errors dict が伝搬される。"""
+        ctx = MagicMock()
+        ctx.state = {
+            "raw_search_results": [
+                {
+                    "sources_searched": {
+                        "loc": {"name": "LOC", "total_hits": 5, "documents_returned": 3},
+                    },
+                    "errors": {"dpla": "Connection timeout"},
+                    "documents": [],
+                }
+            ]
+        }
+        result = json.loads(get_search_metadata(ctx))
+        assert result["errors"]["dpla"] == "Connection timeout"
+
+    def test_fallback_used_propagated(self):
+        """fallback_used フラグが伝搬される。"""
+        ctx = MagicMock()
+        ctx.state = {
+            "raw_search_results": [
+                {
+                    "sources_searched": {
+                        "loc": {"name": "LOC", "total_hits": 1, "documents_returned": 1},
+                    },
+                    "fallback_used": True,
+                    "documents": [],
+                }
+            ]
+        }
+        result = json.loads(get_search_metadata(ctx))
+        assert result["fallback_used"] is True
+
+
+class TestGetSearchMetadataLanguageKeys:
+    """言語別キー（raw_search_results_de 等）の読み取りテスト。"""
+
+    def test_reads_language_specific_keys(self):
+        """raw_search_results_de / raw_search_results_ja が読み取られる。"""
+        ctx = MagicMock()
+        ctx.state = {
+            "raw_search_results_de": [
+                {
+                    "sources_searched": {
+                        "ddb": {"name": "Deutsche Digitale Bibliothek", "total_hits": 8, "documents_returned": 3},
+                    },
+                    "documents": [],
+                }
+            ],
+            "raw_search_results_ja": [
+                {
+                    "sources_searched": {
+                        "ndl": {"name": "National Diet Library", "total_hits": 12, "documents_returned": 7},
+                    },
+                    "documents": [],
+                }
+            ],
+        }
+        # MagicMock.keys() はデフォルトで空なので、dict を使う代わりに state をプレーン dict にする
+        ctx.state = dict(ctx.state)
+        result = json.loads(get_search_metadata(ctx))
+        assert result["status"] == "ok"
+        assert sorted(result["languages_searched"]) == ["de", "ja"]
+        assert "ddb" in result["apis_searched"]
+        assert "ndl" in result["apis_searched"]
+
+    def test_aggregates_same_api_across_languages(self):
+        """同じ API が複数言語で使用された場合、統計が加算される。"""
+        ctx = MagicMock()
+        ctx.state = {
+            "raw_search_results": [
+                {
+                    "sources_searched": {
+                        "europeana": {"name": "Europeana", "total_hits": 10, "documents_returned": 5},
+                    },
+                    "documents": [],
+                }
+            ],
+            "raw_search_results_de": [
+                {
+                    "sources_searched": {
+                        "europeana": {"name": "Europeana", "total_hits": 8, "documents_returned": 3},
+                    },
+                    "documents": [],
+                }
+            ],
+        }
+        ctx.state = dict(ctx.state)
+        result = json.loads(get_search_metadata(ctx))
+        assert result["per_api_stats"]["europeana"]["total_hits"] == 18
+        assert result["per_api_stats"]["europeana"]["documents_returned"] == 8
+
+
+class TestGetSearchMetadataMixed:
+    """newspaper + archives が混在するケースのテスト。"""
+
+    def test_mixed_sources(self):
+        """search_newspapers + search_archives の結果が両方抽出される。"""
+        ctx = MagicMock()
+        ctx.state = {
+            "raw_search_results": [
+                {
+                    "source": "chronicling_america",
+                    "total_hits": 20,
+                    "documents_returned": 8,
+                    "documents": [],
+                    "error": None,
+                },
+                {
+                    "sources_searched": {
+                        "loc": {"name": "LOC", "total_hits": 5, "documents_returned": 2},
+                        "dpla": {"name": "DPLA", "total_hits": 0, "documents_returned": 0},
+                    },
+                    "documents": [],
+                },
+            ]
+        }
+        result = json.loads(get_search_metadata(ctx))
+        assert sorted(result["apis_searched"]) == ["chronicling_america", "dpla", "loc"]
+        assert sorted(result["apis_with_results"]) == ["chronicling_america", "loc"]
+        assert result["apis_without_results"] == ["dpla"]


### PR DESCRIPTION
## Summary

Closes #226

Phase 1（PR #232）で Polymath / Scholar / Storyteller の instruction に知的誠実さの強化を追加済み。Phase 2 では、Polymath が行うソースカバレッジ評価と confidence 判定根拠を**構造化データ**として Firestore に永続化する。

- **`SourceCoverage` Pydantic モデル追加**: `apis_searched`, `apis_with_results`, `apis_without_results`, `known_undigitized_sources`, `coverage_assessment`
- **`get_search_metadata` ツール新規作成**: `raw_search_results` から API 検索状況のコンパクトなサマリを生成（ドキュメント全文を LLM に渡さずメタデータのみ抽出）
- **Polymath エージェント更新**: `get_search_metadata` をツールに追加、instruction に使用手順と JSON 例を追記
- **Publisher 更新**: `structured_report` から `source_coverage` / `confidence_rationale` を Firestore に保存
- **TypeScript 型定義更新**: `SourceCoverage` interface + `MysteryReport` に2フィールド追加
- **ステートレジストリ更新**: `raw_search_results` / `raw_search_results_{lang}` エントリ追加

### 変更ファイル（7修正 + 1新規 + 4テスト）

| ファイル | 変更内容 |
|---|---|
| `mystery_agents/schemas/mystery_report.py` | `SourceCoverage` モデル + `MysteryReport` に2フィールド追加 |
| `mystery_agents/tools/search_metadata.py` | **新規** — `get_search_metadata` ツール |
| `mystery_agents/tools/__init__.py` | ツール登録 |
| `mystery_agents/agents/armchair_polymath.py` | ツール追加 + instruction 更新（日本語訳同期） |
| `mystery_agents/tools/publisher_tools.py` | オーバーレイキーに2キー追加 |
| `packages/shared/src/types/mystery.ts` | `SourceCoverage` interface + `MysteryReport` に2フィールド |
| `shared/state_registry.py` | `raw_search_results` / `raw_search_results_{lang}` エントリ追加 |

## Test plan

- [x] `tests/unit/test_search_metadata.py` — 新規11テスト（no_data, newspapers, archives, 言語別キー, mixed）
- [x] `tests/unit/test_scholar_tools.py` — 2テスト追加（source_coverage / confidence_rationale 保存）
- [x] `tests/unit/test_publisher_tools.py` — 3テスト追加（Firestore 保存 + 後方互換性）
- [x] `tests/unit/test_armchair_polymath.py` — 4テスト追加（instruction + tools 検証）
- [x] 全876ユニットテスト PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)