### PR TITLE
feat: SEO / ディスカバラビリティ技術基盤整備

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -297,6 +297,448 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
@@ -4608,6 +5050,48 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -5371,6 +5855,21 @@
       },
       "engines": {
         "node": ">= 0.12"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -10276,6 +10775,26 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
     "node_modules/tw-animate-css": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.4.0.tgz",
@@ -11340,6 +11859,7 @@
         "eslint-config-next": "16.1.4",
         "serve": "^14.2.5",
         "tailwindcss": "^4",
+        "tsx": "^4",
         "tw-animate-css": "^1.3.3",
         "typescript": "^5"
       }

--- a/web-public/cloudbuild.yaml
+++ b/web-public/cloudbuild.yaml
@@ -25,7 +25,7 @@ steps:
       - 'NEXT_PUBLIC_FIREBASE_APP_ID=$_NEXT_PUBLIC_FIREBASE_APP_ID'
       - 'NEXT_PUBLIC_SITE_URL=$_NEXT_PUBLIC_SITE_URL'
 
-  # SSG 出力に記事ページが含まれることを検証（空デプロイ防止）
+  # SSG 出力に記事ページ・sitemap・feed が含まれることを検証（空デプロイ防止）
   - name: 'node:20'
     entrypoint: bash
     args:
@@ -37,6 +37,14 @@ steps:
           echo "ERROR: 記事ページが0件です。Firestore 接続エラーの可能性があります。デプロイを中止します。"
           exit 1
         fi
+        # sitemap.xml と feed.xml の存在確認
+        for f in out/sitemap.xml out/feed.xml out/robots.txt; do
+          if [ ! -f "$f" ]; then
+            echo "ERROR: $f が見つかりません。postbuild スクリプトが失敗した可能性があります。"
+            exit 1
+          fi
+          echo "Verified: $f"
+        done
     dir: 'web-public'
 
   # Deploy to Firebase Hosting

--- a/web-public/package.json
+++ b/web-public/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "postbuild": "npx tsx scripts/generate-sitemap.ts && npx tsx scripts/generate-feed.ts",
     "start": "npx serve out",
     "preview": "next build && npx serve out -l 3000",
     "lint": "eslint"
@@ -35,6 +36,7 @@
     "eslint-config-next": "16.1.4",
     "serve": "^14.2.5",
     "tailwindcss": "^4",
+    "tsx": "^4",
     "tw-animate-css": "^1.3.3",
     "typescript": "^5"
   }

--- a/web-public/public/robots.txt
+++ b/web-public/public/robots.txt
@@ -1,0 +1,4 @@
+User-Agent: *
+Allow: /
+
+Sitemap: https://ghostinthearchive.ai/sitemap.xml

--- a/web-public/scripts/generate-feed.ts
+++ b/web-public/scripts/generate-feed.ts
@@ -1,0 +1,134 @@
+/**
+ * Atom フィード (feed.xml) 生成スクリプト
+ * next build (output: "export") 後に out/ ディレクトリから記事情報を抽出して生成
+ *
+ * 使用方法: npx tsx scripts/generate-feed.ts
+ */
+
+import fs from "fs"
+import path from "path"
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://ghostinthearchive.ai"
+const OUT_DIR = path.resolve(__dirname, "../out")
+const FEED_LANG = "en" // フィードは英語版の記事を配信
+
+interface FeedEntry {
+  id: string
+  title: string
+  summary: string
+  url: string
+  published: string
+  updated: string
+}
+
+/**
+ * XML 特殊文字をエスケープ
+ */
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;")
+}
+
+/**
+ * out/en/mystery/ から記事ページを収集し、HTML からメタデータを抽出
+ */
+function collectArticles(): FeedEntry[] {
+  const mysteryDir = path.join(OUT_DIR, FEED_LANG, "mystery")
+  if (!fs.existsSync(mysteryDir)) {
+    console.warn(`[feed] ${mysteryDir} が見つかりません。記事がない可能性があります。`)
+    return []
+  }
+
+  const entries: FeedEntry[] = []
+  const dirs = fs.readdirSync(mysteryDir, { withFileTypes: true })
+
+  for (const dir of dirs) {
+    if (!dir.isDirectory()) continue
+
+    const htmlPath = path.join(mysteryDir, dir.name, "index.html")
+    if (!fs.existsSync(htmlPath)) continue
+
+    const html = fs.readFileSync(htmlPath, "utf-8")
+
+    // <title> からタイトルを抽出
+    const titleMatch = html.match(/<title>([^<]+)<\/title>/)
+    const rawTitle = titleMatch?.[1] || dir.name
+    // " | Ghost in the Archive" サフィックスを除去
+    const title = rawTitle.replace(/\s*\|\s*Ghost in the Archive$/, "")
+
+    // meta description から summary を抽出
+    const descMatch = html.match(/<meta name="description" content="([^"]*)"/)
+    const summary = descMatch?.[1] || ""
+
+    // article:published_time から日時を抽出（JSON-LD からフォールバック）
+    const jsonLdMatch = html.match(/"datePublished"\s*:\s*"([^"]+)"/)
+    const published = jsonLdMatch?.[1] || new Date().toISOString()
+
+    const modifiedMatch = html.match(/"dateModified"\s*:\s*"([^"]+)"/)
+    const updated = modifiedMatch?.[1] || published
+
+    const url = `${SITE_URL}/${FEED_LANG}/mystery/${dir.name}/`
+
+    entries.push({
+      id: dir.name,
+      title,
+      summary,
+      url,
+      published,
+      updated,
+    })
+  }
+
+  // 新しい記事を先頭にソート
+  entries.sort((a, b) => new Date(b.published).getTime() - new Date(a.published).getTime())
+
+  return entries
+}
+
+/**
+ * Atom フィード XML を生成
+ */
+function generateAtomFeed(entries: FeedEntry[]): string {
+  const now = new Date().toISOString()
+  const feedEntries = entries
+    .map(
+      (entry) => `  <entry>
+    <title>${escapeXml(entry.title)}</title>
+    <link href="${escapeXml(entry.url)}" rel="alternate"/>
+    <id>${escapeXml(entry.url)}</id>
+    <published>${entry.published}</published>
+    <updated>${entry.updated}</updated>
+    <summary>${escapeXml(entry.summary)}</summary>
+    <author>
+      <name>Ghost in the Archive</name>
+    </author>
+  </entry>`
+    )
+    .join("\n")
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Ghost in the Archive</title>
+  <subtitle>Unearthing anomalies across languages, archives, and disciplines</subtitle>
+  <link href="${SITE_URL}/feed.xml" rel="self" type="application/atom+xml"/>
+  <link href="${SITE_URL}/" rel="alternate" type="text/html"/>
+  <id>${SITE_URL}/</id>
+  <updated>${now}</updated>
+  <author>
+    <name>Ghost in the Archive</name>
+  </author>
+${feedEntries}
+</feed>
+`
+}
+
+// メイン処理
+const articles = collectArticles()
+const feed = generateAtomFeed(articles)
+const outputPath = path.join(OUT_DIR, "feed.xml")
+fs.writeFileSync(outputPath, feed, "utf-8")
+console.log(`[feed] ${outputPath} を生成しました（${articles.length} エントリ）`)

--- a/web-public/scripts/generate-sitemap.ts
+++ b/web-public/scripts/generate-sitemap.ts
@@ -1,0 +1,95 @@
+/**
+ * sitemap.xml 生成スクリプト
+ * next build (output: "export") 後に out/ ディレクトリをスキャンして生成
+ *
+ * 使用方法: npx tsx scripts/generate-sitemap.ts
+ */
+
+import fs from "fs"
+import path from "path"
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://ghostinthearchive.ai"
+const OUT_DIR = path.resolve(__dirname, "../out")
+const LANGS = ["en", "ja", "es", "de", "fr", "nl", "pt"]
+const DEFAULT_LANG = "en"
+
+interface SitemapEntry {
+  path: string // 言語なしのパス（例: "", "archive", "mystery/OCC-MA-001"）
+  lastmod?: string
+}
+
+/**
+ * out/ ディレクトリをスキャンして URL パスを収集
+ */
+function collectPaths(): SitemapEntry[] {
+  const entries: SitemapEntry[] = []
+  const enDir = path.join(OUT_DIR, "en")
+
+  if (!fs.existsSync(enDir)) {
+    console.error(`[sitemap] ${enDir} が見つかりません。next build を先に実行してください。`)
+    process.exit(1)
+  }
+
+  // 再帰的に index.html を探索
+  function scan(dir: string, prefix: string) {
+    const items = fs.readdirSync(dir, { withFileTypes: true })
+    for (const item of items) {
+      if (item.isDirectory()) {
+        scan(path.join(dir, item.name), `${prefix}${item.name}/`)
+      } else if (item.name === "index.html") {
+        // prefix からパスを抽出（末尾の / を除去）
+        const pagePath = prefix.replace(/\/$/, "")
+        entries.push({ path: pagePath })
+      }
+    }
+  }
+
+  // ルート（ホームページ）
+  if (fs.existsSync(path.join(enDir, "index.html"))) {
+    entries.push({ path: "" })
+  }
+
+  // サブディレクトリを走査
+  const items = fs.readdirSync(enDir, { withFileTypes: true })
+  for (const item of items) {
+    if (item.isDirectory()) {
+      scan(path.join(enDir, item.name), `${item.name}/`)
+    }
+  }
+
+  return entries
+}
+
+/**
+ * sitemap.xml を生成
+ */
+function generateSitemap(entries: SitemapEntry[]): string {
+  const urls = entries.map((entry) => {
+    const langAlternates = LANGS.map(
+      (lang) =>
+        `    <xhtml:link rel="alternate" hreflang="${lang}" href="${SITE_URL}/${lang}/${entry.path}${entry.path ? "/" : ""}"/>`
+    ).join("\n")
+
+    const xDefault = `    <xhtml:link rel="alternate" hreflang="x-default" href="${SITE_URL}/${DEFAULT_LANG}/${entry.path}${entry.path ? "/" : ""}"/>`
+
+    return `  <url>
+    <loc>${SITE_URL}/${DEFAULT_LANG}/${entry.path}${entry.path ? "/" : ""}</loc>
+${langAlternates}
+${xDefault}
+  </url>`
+  })
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml">
+${urls.join("\n")}
+</urlset>
+`
+}
+
+// メイン処理
+const entries = collectPaths()
+const sitemap = generateSitemap(entries)
+const outputPath = path.join(OUT_DIR, "sitemap.xml")
+fs.writeFileSync(outputPath, sitemap, "utf-8")
+console.log(`[sitemap] ${outputPath} を生成しました（${entries.length} URL）`)

--- a/web-public/src/app/[lang]/about/page.tsx
+++ b/web-public/src/app/[lang]/about/page.tsx
@@ -6,6 +6,7 @@ import { BookOpen, ShieldAlert } from "lucide-react"
 import { isValidLang } from "@/lib/i18n/config"
 import { SUPPORTED_LANGS } from "@/lib/i18n/config"
 import { getDictionary } from "@/lib/i18n/dictionaries"
+import { buildOgpMetadata, buildAlternates } from "@/lib/seo"
 
 // SSG: ビルド時に生成されたページ以外は 404
 export const dynamicParams = false
@@ -26,11 +27,13 @@ export async function generateMetadata({
 
   return {
     title: dict.about.title,
-    alternates: {
-      languages: Object.fromEntries(
-        SUPPORTED_LANGS.map((l) => [l, `/${l}/about`])
-      ),
-    },
+    description: dict.seo.aboutDescription,
+    alternates: buildAlternates("about"),
+    ...buildOgpMetadata(lang, {
+      title: dict.about.heading,
+      description: dict.seo.aboutDescription,
+      path: "about",
+    }),
   }
 }
 

--- a/web-public/src/app/[lang]/archive/[[...page]]/page.tsx
+++ b/web-public/src/app/[lang]/archive/[[...page]]/page.tsx
@@ -9,6 +9,7 @@ import { FileStack, Search } from "lucide-react"
 import { isValidLang, SUPPORTED_LANGS } from "@/lib/i18n/config"
 import type { SupportedLang } from "@/lib/i18n/config"
 import { getDictionary } from "@/lib/i18n/dictionaries"
+import { buildOgpMetadata, buildAlternates } from "@/lib/seo"
 
 // SSG: ビルド時に生成されたページ以外は 404
 export const dynamicParams = false
@@ -44,11 +45,13 @@ export async function generateMetadata({
 
   return {
     title: pageTitle,
-    alternates: {
-      languages: Object.fromEntries(
-        SUPPORTED_LANGS.map((l) => [l, `/${l}/archive`])
-      ),
-    },
+    description: dict.seo.archiveDescription,
+    alternates: buildAlternates("archive"),
+    ...buildOgpMetadata(lang, {
+      title: dict.archive.heading,
+      description: dict.seo.archiveDescription,
+      path: "archive",
+    }),
   }
 }
 

--- a/web-public/src/app/[lang]/layout.tsx
+++ b/web-public/src/app/[lang]/layout.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { notFound } from "next/navigation"
 import { SUPPORTED_LANGS, isValidLang } from "@/lib/i18n/config"
+import { buildAlternates } from "@/lib/seo"
 
 export async function generateStaticParams() {
   return SUPPORTED_LANGS.map((lang) => ({ lang }))
@@ -15,12 +16,18 @@ export async function generateMetadata({
   if (!isValidLang(lang)) return {}
 
   return {
-    alternates: {
-      languages: Object.fromEntries(
-        SUPPORTED_LANGS.map((l) => [l, `/${l}`])
-      ),
-    },
+    alternates: buildAlternates(""),
   }
+}
+
+// Organization JSON-LD（全言語ページ共通）
+const organizationJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  name: "Ghost in the Archive",
+  url: "https://ghostinthearchive.ai",
+  description:
+    "An autonomous AI agent system cross-analyzing the world's public digital archives through five academic disciplines — unearthing anomalies that no single record, language, or field can explain.",
 }
 
 export default async function LangLayout({
@@ -36,5 +43,21 @@ export default async function LangLayout({
     notFound()
   }
 
-  return <>{children}</>
+  return (
+    <>
+      {/* SSG では <html lang> を静的に設定できないため、同期スクリプトで即座に設定 */}
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `document.documentElement.lang="${lang}";`,
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(organizationJsonLd),
+        }}
+      />
+      {children}
+    </>
+  )
 }

--- a/web-public/src/app/[lang]/mystery/[id]/page.tsx
+++ b/web-public/src/app/[lang]/mystery/[id]/page.tsx
@@ -13,6 +13,7 @@ import { Breadcrumb } from "@/components/breadcrumb"
 import { TableOfContents, SECTION_IDS } from "@/components/table-of-contents"
 import { RelatedArticles } from "@/components/related-articles"
 import { ShareButtons } from "@/components/share-buttons"
+import { ArticleJsonLd } from "@/components/article-json-ld"
 import { getMysteryById, getPublishedMysteryIds, getAllPublishedMysteriesMap } from "@ghost/shared/src/lib/firestore/queries"
 import { FileText, Share2 } from "lucide-react"
 import { localizeMystery, getTranslatedExcerpt } from "@ghost/shared/src/lib/localize"
@@ -21,18 +22,8 @@ import type { SupportedLang } from "@/lib/i18n/config"
 import { getDictionary } from "@/lib/i18n/dictionaries"
 import { findRelatedArticles } from "@/lib/related-articles"
 import { getSiteUrl } from "@/lib/site-url"
+import { buildOgpMetadata, buildAlternates } from "@/lib/seo"
 import type { TocSection } from "@/components/table-of-contents"
-
-// og:locale マッピング
-const OG_LOCALE_MAP: Record<SupportedLang, string> = {
-  en: "en_US",
-  ja: "ja_JP",
-  es: "es_ES",
-  de: "de_DE",
-  fr: "fr_FR",
-  nl: "nl_NL",
-  pt: "pt_BR",
-}
 
 // SSG: ビルド時に生成されたページ以外は 404
 export const dynamicParams = false
@@ -70,10 +61,6 @@ export async function generateMetadata({
   const { title, summary } = localizeMystery(mystery, lang)
 
   const pageUrl = `${getSiteUrl()}/${lang}/mystery/${id}`
-  const ogLocale = OG_LOCALE_MAP[lang]
-  const alternateLocales = SUPPORTED_LANGS
-    .filter((l) => l !== lang)
-    .map((l) => OG_LOCALE_MAP[l])
 
   // hero 画像がある場合のみ images を設定
   const heroUrl = mystery.images?.hero
@@ -84,24 +71,15 @@ export async function generateMetadata({
     description: summary,
     alternates: {
       canonical: pageUrl,
-      languages: Object.fromEntries(
-        SUPPORTED_LANGS.map((l) => [l, `/${l}/mystery/${id}`])
-      ),
+      ...buildAlternates(`mystery/${id}`),
     },
-    openGraph: {
+    ...buildOgpMetadata(lang, {
       title,
       description: summary,
-      url: pageUrl,
+      path: `mystery/${id}`,
       type: "article",
-      locale: ogLocale,
-      alternateLocale: alternateLocales,
-      ...(images && { images }),
-    },
-    twitter: {
-      title,
-      description: summary,
-      ...(images && { images }),
-    },
+      images,
+    }),
   }
 }
 
@@ -173,6 +151,17 @@ export default async function MysteryDetailPage({
               home: dict.detail.breadcrumbHome,
               archive: dict.nav.archive,
             }}
+          />
+
+          {/* Article 構造化データ */}
+          <ArticleJsonLd
+            title={title}
+            description={summary}
+            url={shareUrl}
+            datePublished={mystery.publishedAt?.toISOString()}
+            dateModified={mystery.updatedAt?.toISOString()}
+            imageUrl={mystery.images?.hero}
+            lang={lang}
           />
 
           <CaseFileHeader

--- a/web-public/src/app/[lang]/page.tsx
+++ b/web-public/src/app/[lang]/page.tsx
@@ -16,6 +16,7 @@ import { isValidLang } from "@/lib/i18n/config"
 import type { SupportedLang } from "@/lib/i18n/config"
 import { getDictionary } from "@/lib/i18n/dictionaries"
 import type { Dictionary } from "@/lib/i18n/dictionaries"
+import { buildOgpMetadata, buildAlternates } from "@/lib/seo"
 
 async function MysteryList({ lang, dict }: { lang: SupportedLang; dict: Dictionary }) {
   let mysteries: Awaited<ReturnType<typeof getPublishedMysteries>> = []
@@ -94,6 +95,30 @@ function MysteryListSkeleton() {
       </div>
     </>
   )
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ lang: string }>
+}) {
+  const { lang } = await params
+  if (!isValidLang(lang)) return {}
+
+  const dict = await getDictionary(lang)
+
+  return {
+    title: "Ghost in the Archive",
+    description: dict.seo.homeDescription,
+    alternates: buildAlternates(""),
+    ...buildOgpMetadata(lang, {
+      title: "Ghost in the Archive",
+      description: dict.seo.homeDescription,
+      path: "",
+      type: "website",
+      images: [{ url: "/images/hero-bg_xl.webp", alt: "Ghost in the Archive" }],
+    }),
+  }
 }
 
 export default async function HomePage({

--- a/web-public/src/app/layout.tsx
+++ b/web-public/src/app/layout.tsx
@@ -34,6 +34,11 @@ export const metadata: Metadata = {
   twitter: {
     card: 'summary_large_image',
   },
+  alternates: {
+    types: {
+      'application/atom+xml': '/feed.xml',
+    },
+  },
 }
 
 const gtmId = process.env.NEXT_PUBLIC_GTM_ID

--- a/web-public/src/components/article-json-ld.tsx
+++ b/web-public/src/components/article-json-ld.tsx
@@ -1,0 +1,52 @@
+/**
+ * Article JSON-LD 構造化データコンポーネント
+ * 記事詳細ページに配置して Google リッチリザルトに対応
+ */
+
+interface ArticleJsonLdProps {
+  title: string
+  description: string
+  url: string
+  datePublished?: string
+  dateModified?: string
+  imageUrl?: string
+  lang: string
+}
+
+export function ArticleJsonLd({
+  title,
+  description,
+  url,
+  datePublished,
+  dateModified,
+  imageUrl,
+  lang,
+}: ArticleJsonLdProps) {
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: title,
+    description,
+    url,
+    inLanguage: lang,
+    ...(datePublished && { datePublished }),
+    ...(dateModified && { dateModified }),
+    ...(imageUrl && { image: imageUrl }),
+    author: {
+      "@type": "Organization",
+      name: "Ghost in the Archive",
+    },
+    publisher: {
+      "@type": "Organization",
+      name: "Ghost in the Archive",
+      url: "https://ghostinthearchive.ai",
+    },
+  }
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+    />
+  )
+}

--- a/web-public/src/lib/i18n/dictionaries/de.ts
+++ b/web-public/src/lib/i18n/dictionaries/de.ts
@@ -143,6 +143,11 @@ const dict: Dictionary = {
     linkCopied: "Link kopiert!",
     shareThisArticle: "Diese Fallakte teilen",
   },
+  seo: {
+    homeDescription: "Ein autonomes KI-Agentensystem, das die öffentlichen digitalen Archive der Welt über fünf akademische Disziplinen hinweg kreuzanalysiert — Anomalien aufdeckend, die kein einzelnes Dokument, keine Sprache und kein Fachgebiet allein erklären kann.",
+    archiveDescription: "Vollständiger Index aller untersuchten Anomalien, Diskrepanzen und unerklärlichen Phänomene, die aus den öffentlichen Aufzeichnungen der Welt ausgegraben wurden.",
+    aboutDescription: "Erfahren Sie mehr über Ghost in the Archive — eine autonome KI-Ermittlungseinheit, die die öffentlichen digitalen Archive der Welt über fünf akademische Disziplinen hinweg analysiert.",
+  },
   footer: {
     description:
       "Mehrsprachige Kreuzanalyse der öffentlichen digitalen Archive der Welt — die Geister aufspüren, die sich in den Lücken zwischen Aufzeichnungen, Sprachen und Disziplinen verbergen.",

--- a/web-public/src/lib/i18n/dictionaries/en.ts
+++ b/web-public/src/lib/i18n/dictionaries/en.ts
@@ -142,6 +142,11 @@ const dict: Dictionary = {
     linkCopied: "Link copied!",
     shareThisArticle: "Share this case file",
   },
+  seo: {
+    homeDescription: "An autonomous AI agent system cross-analyzing the world's public digital archives through five academic disciplines — unearthing anomalies that no single record, language, or field can explain.",
+    archiveDescription: "Complete index of all investigated anomalies, discrepancies, and unexplained phenomena unearthed from the world's public records.",
+    aboutDescription: "Learn about Ghost in the Archive — an autonomous AI investigation unit that cross-analyzes the world's public digital archives across five academic disciplines.",
+  },
   footer: {
     description:
       "Multi-lingual cross-analysis of the world's public digital archives — unearthing the Ghosts hiding in the gaps between records, languages, and disciplines.",

--- a/web-public/src/lib/i18n/dictionaries/es.ts
+++ b/web-public/src/lib/i18n/dictionaries/es.ts
@@ -143,6 +143,11 @@ const dict: Dictionary = {
     linkCopied: "Enlace copiado!",
     shareThisArticle: "Compartir este expediente",
   },
+  seo: {
+    homeDescription: "Un sistema autónomo de agentes de IA que analiza los archivos digitales públicos del mundo a través de cinco disciplinas académicas — revelando anomalías que ningún registro, idioma o campo puede explicar por sí solo.",
+    archiveDescription: "Índice completo de todas las anomalías, discrepancias y fenómenos inexplicables desenterrados de los registros públicos del mundo.",
+    aboutDescription: "Descubre Ghost in the Archive — una unidad autónoma de investigación con IA que analiza los archivos digitales públicos del mundo a través de cinco disciplinas académicas.",
+  },
   footer: {
     description:
       "Análisis multilingüe cruzado de los archivos digitales públicos del mundo — desenterrando los Fantasmas ocultos en las brechas entre registros, idiomas y disciplinas.",

--- a/web-public/src/lib/i18n/dictionaries/fr.ts
+++ b/web-public/src/lib/i18n/dictionaries/fr.ts
@@ -143,6 +143,11 @@ const dict: Dictionary = {
     linkCopied: "Lien copié !",
     shareThisArticle: "Partager ce dossier",
   },
+  seo: {
+    homeDescription: "Un système autonome d'agents IA qui analyse les archives numériques publiques du monde à travers cinq disciplines académiques — révélant les anomalies qu'aucun document, langue ou domaine ne peut expliquer seul.",
+    archiveDescription: "Index complet de toutes les anomalies, divergences et phénomènes inexpliqués exhumés des archives publiques du monde.",
+    aboutDescription: "Découvrez Ghost in the Archive — une unité d'investigation autonome par IA qui analyse les archives numériques publiques du monde à travers cinq disciplines académiques.",
+  },
   footer: {
     description:
       "Analyse croisée multilingue des archives numériques publiques du monde — exhumant les Fantômes cachés dans les interstices entre documents, langues et disciplines.",

--- a/web-public/src/lib/i18n/dictionaries/ja.ts
+++ b/web-public/src/lib/i18n/dictionaries/ja.ts
@@ -142,6 +142,11 @@ const dict: Dictionary = {
     linkCopied: "コピーしました！",
     shareThisArticle: "このケースファイルをシェア",
   },
+  seo: {
+    homeDescription: "世界の公開デジタルアーカイブを5つの学術領域で多言語横断分析する自律型AIエージェントシステム。単一の記録・言語・学問分野では説明できないアノマリーを発掘する。",
+    archiveDescription: "世界の公開記録から発掘された、すべての異常・矛盾・説明不能な現象の完全索引。",
+    aboutDescription: "Ghost in the Archive について——世界の公開デジタルアーカイブを5つの学術領域で横断分析する自律型AI調査ユニットの概要。",
+  },
   footer: {
     description:
       "世界の公開デジタルアーカイブの多言語横断分析——記録と言語と学問の隙間に潜むGhostを発掘する。",

--- a/web-public/src/lib/i18n/dictionaries/nl.ts
+++ b/web-public/src/lib/i18n/dictionaries/nl.ts
@@ -143,6 +143,11 @@ const dict: Dictionary = {
     linkCopied: "Link gekopieerd!",
     shareThisArticle: "Dit dossier delen",
   },
+  seo: {
+    homeDescription: "Een autonoom AI-agentsysteem dat de openbare digitale archieven van de wereld kruislings analyseert via vijf academische disciplines — anomalieën blootleggend die geen enkel document, taal of vakgebied alleen kan verklaren.",
+    archiveDescription: "Volledige index van alle onderzochte anomalieën, discrepanties en onverklaarde fenomenen opgegraven uit de openbare archieven van de wereld.",
+    aboutDescription: "Ontdek Ghost in the Archive — een autonome AI-onderzoekseenheid die de openbare digitale archieven van de wereld analyseert via vijf academische disciplines.",
+  },
   footer: {
     description:
       "Meertalige kruisanalyse van de openbare digitale archieven van de wereld — de Geesten opgraven die zich verschuilen in de hiaten tussen documenten, talen en disciplines.",

--- a/web-public/src/lib/i18n/dictionaries/pt.ts
+++ b/web-public/src/lib/i18n/dictionaries/pt.ts
@@ -143,6 +143,11 @@ const dict: Dictionary = {
     linkCopied: "Link copiado!",
     shareThisArticle: "Compartilhar este dossiê",
   },
+  seo: {
+    homeDescription: "Um sistema autônomo de agentes de IA que analisa os arquivos digitais públicos do mundo através de cinco disciplinas acadêmicas — revelando anomalias que nenhum registro, idioma ou campo pode explicar sozinho.",
+    archiveDescription: "Índice completo de todas as anomalias, discrepâncias e fenômenos inexplicáveis desenterrados dos registros públicos do mundo.",
+    aboutDescription: "Conheça o Ghost in the Archive — uma unidade autônoma de investigação com IA que analisa os arquivos digitais públicos do mundo através de cinco disciplinas acadêmicas.",
+  },
   footer: {
     description:
       "Análise cruzada multilíngue dos arquivos digitais públicos do mundo — desenterrando os Fantasmas escondidos nas lacunas entre registros, idiomas e disciplinas.",

--- a/web-public/src/lib/i18n/dictionaries/types.ts
+++ b/web-public/src/lib/i18n/dictionaries/types.ts
@@ -125,6 +125,11 @@ export interface Dictionary {
     linkCopied: string;
     shareThisArticle: string;
   };
+  seo: {
+    homeDescription: string;
+    archiveDescription: string;
+    aboutDescription: string;
+  };
   footer: {
     description: string;
     primarySources: string;

--- a/web-public/src/lib/seo.ts
+++ b/web-public/src/lib/seo.ts
@@ -1,0 +1,75 @@
+/**
+ * SEO 共通ユーティリティ
+ * OGP メタデータ・hreflang alternates の生成ヘルパー
+ */
+
+import type { Metadata } from "next"
+import { SUPPORTED_LANGS, DEFAULT_LANG } from "@/lib/i18n/config"
+import type { SupportedLang } from "@/lib/i18n/config"
+import { getSiteUrl } from "@/lib/site-url"
+
+// og:locale マッピング（各言語 → OpenGraph ロケール形式）
+export const OG_LOCALE_MAP: Record<SupportedLang, string> = {
+  en: "en_US",
+  ja: "ja_JP",
+  es: "es_ES",
+  de: "de_DE",
+  fr: "fr_FR",
+  nl: "nl_NL",
+  pt: "pt_BR",
+}
+
+/**
+ * OGP + Twitter Card メタデータを生成
+ */
+export function buildOgpMetadata(
+  lang: SupportedLang,
+  options: {
+    title: string
+    description: string
+    path: string
+    type?: "website" | "article"
+    images?: { url: string; alt: string }[]
+  }
+): Pick<Metadata, "openGraph" | "twitter"> {
+  const { title, description, path, type = "website", images } = options
+  const pageUrl = `${getSiteUrl()}/${lang}${path ? `/${path}` : ""}`
+  const ogLocale = OG_LOCALE_MAP[lang]
+  const alternateLocales = SUPPORTED_LANGS
+    .filter((l) => l !== lang)
+    .map((l) => OG_LOCALE_MAP[l])
+
+  return {
+    openGraph: {
+      title,
+      description,
+      url: pageUrl,
+      type,
+      locale: ogLocale,
+      alternateLocale: alternateLocales,
+      ...(images && { images }),
+    },
+    twitter: {
+      title,
+      description,
+      ...(images && { images }),
+    },
+  }
+}
+
+/**
+ * hreflang alternates を生成（x-default 込み）
+ */
+export function buildAlternates(
+  path: string
+): Metadata["alternates"] {
+  const prefix = path ? `/${path}` : ""
+  return {
+    languages: {
+      ...Object.fromEntries(
+        SUPPORTED_LANGS.map((l) => [l, `/${l}${prefix}`])
+      ),
+      "x-default": `/${DEFAULT_LANG}${prefix}`,
+    },
+  }
+}


### PR DESCRIPTION
## Summary

Issue #155 の P0〜P4 全コード施策を一括実装。検索エンジン・SNS からの流入に必要な技術的 SEO 基盤を整備。

### 実装内容

- **SEO 共通ユーティリティ** (`lib/seo.ts`): `buildOgpMetadata()`, `buildAlternates()` — OG/Twitter Card メタデータと hreflang alternates の生成を一元化
- **全ページ OGP メタデータ** (P1): ホーム・アーカイブ・About・記事詳細ページに og:title, og:description, og:url, og:locale, og:type を追加
- **hreflang x-default** (P4): 全ページの alternates に `x-default` → `/en/...` を追加
- **html lang 動的設定** (P4): SSG 環境で `document.documentElement.lang` を同期スクリプトで即座に設定
- **Organization JSON-LD** (P2): `[lang]/layout.tsx` に全ページ共通で配置
- **Article JSON-LD** (P2): 記事詳細ページに `<ArticleJsonLd>` コンポーネントを配置（headline, datePublished, dateModified, author, publisher）
- **robots.txt** (P0): `public/robots.txt` に Sitemap URL 付きで配置
- **sitemap.xml** (P0): ビルド後スクリプトが `out/` をスキャンして全 URL + 7言語 hreflang + x-default を含む sitemap を生成
- **Atom フィード** (P3): ビルド後スクリプトが記事 HTML からメタデータを抽出して `feed.xml` を生成
- **i18n SEO description**: 7言語の辞書に `seo.homeDescription`, `seo.archiveDescription`, `seo.aboutDescription` を追加
- **記事詳細リファクタ**: ローカル `OG_LOCALE_MAP` を `lib/seo.ts` に移行、共通ユーティリティを使用

### 変更ファイル一覧

| 種別 | ファイル |
|------|----------|
| 新規 | `web-public/src/lib/seo.ts` |
| 新規 | `web-public/src/components/article-json-ld.tsx` |
| 新規 | `web-public/public/robots.txt` |
| 新規 | `web-public/scripts/generate-sitemap.ts` |
| 新規 | `web-public/scripts/generate-feed.ts` |
| 変更 | `web-public/src/lib/i18n/dictionaries/types.ts` + 7辞書 |
| 変更 | `web-public/src/app/layout.tsx` (RSS link) |
| 変更 | `web-public/src/app/[lang]/layout.tsx` (html lang + Organization JSON-LD + x-default) |
| 変更 | `web-public/src/app/[lang]/page.tsx` (generateMetadata 追加) |
| 変更 | `web-public/src/app/[lang]/about/page.tsx` (OGP 補完) |
| 変更 | `web-public/src/app/[lang]/archive/[[...page]]/page.tsx` (OGP 補完) |
| 変更 | `web-public/src/app/[lang]/mystery/[id]/page.tsx` (OGP リファクタ + Article JSON-LD) |
| 変更 | `web-public/package.json` (postbuild + tsx) |
| 変更 | `web-public/cloudbuild.yaml` (sitemap/feed 検証) |

## Test plan

- [ ] `npx tsc --noEmit` — TypeScript 型チェック通過 ✅
- [ ] `npm run build` 後に `out/sitemap.xml`, `out/feed.xml`, `out/robots.txt` が存在する
- [ ] `out/en/index.html` に OG メタタグが含まれる
- [ ] `out/ja/index.html` に `og:locale` = `ja_JP` が設定される
- [ ] `out/en/mystery/*/index.html` に Article JSON-LD が含まれる
- [ ] 全言語ページに Organization JSON-LD が含まれる
- [ ] 全ページの hreflang に `x-default` が含まれる
- [ ] デプロイ後: [Google Rich Results Test](https://search.google.com/test/rich-results) で JSON-LD 検証
- [ ] デプロイ後: [W3C Feed Validator](https://validator.w3.org/feed/) で Atom フィード検証

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)