### PR TITLE
feat: ヘッダー改修 — モバイルでのロゴテキスト最適化

### DIFF
--- a/web-public/src/components/header.tsx
+++ b/web-public/src/components/header.tsx
@@ -26,7 +26,7 @@ export function Header({ lang = "en", nav }: HeaderProps) {
               <Archive className="w-6 h-6 text-gold" />
               <div className="absolute -top-0.5 -right-0.5 w-2 h-2 bg-blood-red rounded-full animate-pulse" />
             </div>
-            <span className="font-serif text-lg text-parchment leading-tight group-hover:text-gold transition-colors">
+            <span className="hidden sm:inline font-serif text-lg text-parchment leading-tight group-hover:text-gold transition-colors">
               Ghost in the Archive
             </span>
           </Link>


### PR DESCRIPTION
## Summary

- モバイル（< 640px）でロゴテキスト「Ghost in the Archive」を非表示にし、Archive アイコン + 赤い点のみ表示
- ナビゲーション要素（Archive / About / 言語切り替え）との間隔の窮屈さを解消
- `hidden sm:inline` クラスの追加のみで、レイアウト崩れなし

## Changes

- `web-public/src/components/header.tsx`: ロゴ `<span>` に `hidden sm:inline` を追加

## Test plan

- [ ] DevTools でモバイル幅（< 640px）にしてロゴテキストが非表示になることを確認
- [ ] 640px 以上でフルテキストが表示されることを確認
- [ ] モバイルでアイコンのタップ可能エリアが十分か確認

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)