### PR TITLE
feat: Ghost 再定義 Phase 3 — confidence_level・source_coverage フロントエンド表示

### DIFF
--- a/web-admin/src/app/(main)/preview/[id]/preview-content.tsx
+++ b/web-admin/src/app/(main)/preview/[id]/preview-content.tsx
@@ -8,6 +8,7 @@ import { localizeMystery, getTranslatedExcerpt } from "@ghost/shared/src/lib/loc
 import { LanguageSelector, type PreviewLang } from "@/components/language-selector"
 import { useLanguage } from "@/contexts/language-context"
 import type { FirestoreMystery } from "@ghost/shared/src/types/mystery"
+import { ConfidenceBadge } from "@/components/status-badge"
 import {
   ArrowLeft,
   MapPin,
@@ -119,6 +120,7 @@ export function PreviewContent({ mystery }: PreviewContentProps) {
               <div className={`px-3 py-1.5 border rounded-sm text-xs font-mono uppercase ${statusColors[mystery.status] || statusColors.pending}`}>
                 {mystery.status}
               </div>
+              <ConfidenceBadge level={mystery.confidence_level} />
               <div className="h-px flex-1 bg-border" />
             </div>
 
@@ -326,6 +328,63 @@ export function PreviewContent({ mystery }: PreviewContentProps) {
                     Content may change before final publication.
                   </p>
                 </div>
+
+                {/* Source coverage */}
+                {mystery.source_coverage && (
+                  <div className="aged-card letterpress-border rounded-sm p-5">
+                    <h3 className="font-mono text-xs uppercase tracking-wider text-muted-foreground mb-4">
+                      Investigation Scope
+                    </h3>
+
+                    {mystery.languages_analyzed && mystery.languages_analyzed.length > 0 && (
+                      <div className="mb-3">
+                        <p className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground mb-1.5">
+                          Languages Analyzed
+                        </p>
+                        <div className="flex flex-wrap gap-1.5">
+                          {mystery.languages_analyzed.map((lang) => (
+                            <span
+                              key={lang}
+                              className="inline-flex px-1.5 py-0.5 rounded text-[10px] font-mono uppercase tracking-wider bg-gold/10 text-gold border border-gold/20"
+                            >
+                              {lang}
+                            </span>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+
+                    {mystery.source_coverage.apis_searched.length > 0 && (
+                      <div className="mb-3">
+                        <p className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground mb-1.5">
+                          Archives Searched
+                        </p>
+                        <ul className="space-y-0.5">
+                          {mystery.source_coverage.apis_searched.map((api) => (
+                            <li key={api} className="text-xs text-foreground/70 font-mono">
+                              &bull; {api}
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+
+                    {mystery.confidence_rationale && (
+                      <div className="mb-3">
+                        <p className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground mb-1.5">
+                          Assessment Rationale
+                        </p>
+                        <p className="text-xs text-foreground/70 leading-relaxed">
+                          {mystery.confidence_rationale}
+                        </p>
+                      </div>
+                    )}
+
+                    <p className="text-[10px] text-muted-foreground/60 leading-relaxed mt-3 pt-3 border-t border-border">
+                      This analysis is based on materials available through the digital archive APIs listed above.
+                    </p>
+                  </div>
+                )}
 
                 {/* Classification notice */}
                 <div className="border border-blood-red/30 bg-blood-red/5 rounded-sm p-4">

--- a/web-public/src/app/[lang]/mystery/[id]/page.tsx
+++ b/web-public/src/app/[lang]/mystery/[id]/page.tsx
@@ -171,6 +171,8 @@ export default async function MysteryDetailPage({
             timePeriod={timePeriod}
             publishedAt={mystery.publishedAt}
             publishedLabel={dict.detail.published}
+            confidenceLevel={mystery.confidence_level}
+            confidenceLabels={dict.confidence}
           />
 
           {/* シェアボタン（compact） */}
@@ -284,6 +286,10 @@ export default async function MysteryDetailPage({
                 storyAngles: dict.detail.storyAngles,
                 classificationNotice: dict.detail.classificationNotice,
               }}
+              sourceCoverage={mystery.source_coverage}
+              languagesAnalyzed={mystery.languages_analyzed}
+              confidenceRationale={mystery.confidence_rationale}
+              sourceCoverageLabels={dict.sourceCoverage}
             >
               {/* デスクトップ目次（サイドバー内） */}
               <TableOfContents sections={tocSections} heading={dict.detail.tableOfContents} />

--- a/web-public/src/components/ghost-confidence-badge.tsx
+++ b/web-public/src/components/ghost-confidence-badge.tsx
@@ -1,0 +1,37 @@
+import { Ghost } from "lucide-react"
+import { cn } from "@ghost/shared/src/lib/utils"
+import type { ConfidenceLevel } from "@ghost/shared/src/types/mystery"
+import type { Dictionary } from "@/lib/i18n/dictionaries"
+
+interface GhostConfidenceBadgeProps {
+  level: ConfidenceLevel
+  labels: Dictionary["confidence"]
+  className?: string
+}
+
+const colorMap: Record<ConfidenceLevel, string> = {
+  high: "bg-emerald-900/30 text-emerald-400",
+  medium: "bg-amber-900/30 text-amber-400",
+  low: "bg-zinc-700/30 text-zinc-400",
+}
+
+const labelMap: Record<ConfidenceLevel, keyof Dictionary["confidence"]> = {
+  high: "confirmedGhost",
+  medium: "suspectedGhost",
+  low: "archivalEcho",
+}
+
+export function GhostConfidenceBadge({ level, labels, className }: GhostConfidenceBadgeProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-[10px] font-mono uppercase tracking-wider",
+        colorMap[level],
+        className
+      )}
+    >
+      <Ghost className="w-3 h-3" />
+      {labels[labelMap[level]]}
+    </span>
+  )
+}

--- a/web-public/src/components/mystery/case-file-header.tsx
+++ b/web-public/src/components/mystery/case-file-header.tsx
@@ -1,4 +1,7 @@
 import { MapPin, Clock, Calendar, FileText } from "lucide-react"
+import type { ConfidenceLevel } from "@ghost/shared/src/types/mystery"
+import type { Dictionary } from "@/lib/i18n/dictionaries"
+import { GhostConfidenceBadge } from "@/components/ghost-confidence-badge"
 
 interface CaseFileHeaderProps {
   mysteryId: string
@@ -7,6 +10,8 @@ interface CaseFileHeaderProps {
   timePeriod: string
   publishedAt?: Date
   publishedLabel?: string
+  confidenceLevel?: ConfidenceLevel
+  confidenceLabels?: Dictionary["confidence"]
 }
 
 export function CaseFileHeader({
@@ -16,6 +21,8 @@ export function CaseFileHeader({
   timePeriod,
   publishedAt,
   publishedLabel = "Published:",
+  confidenceLevel,
+  confidenceLabels,
 }: CaseFileHeaderProps) {
   return (
     <div className="mb-12">
@@ -51,6 +58,9 @@ export function CaseFileHeader({
             <Calendar className="w-4 h-4 text-gold" />
             {publishedLabel} {publishedAt.toLocaleDateString()}
           </span>
+        )}
+        {confidenceLevel && confidenceLabels && (
+          <GhostConfidenceBadge level={confidenceLevel} labels={confidenceLabels} />
         )}
       </div>
     </div>

--- a/web-public/src/components/mystery/detail-sidebar.tsx
+++ b/web-public/src/components/mystery/detail-sidebar.tsx
@@ -1,3 +1,7 @@
+import type { SourceCoverage } from "@ghost/shared/src/types/mystery"
+import type { Dictionary } from "@/lib/i18n/dictionaries"
+import { SourceCoverageCard } from "@/components/mystery/source-coverage-card"
+
 interface DetailSidebarLabels {
   storyAngles?: string
   classificationNotice?: string
@@ -6,10 +10,22 @@ interface DetailSidebarLabels {
 interface DetailSidebarProps {
   storyHooks: string[]
   labels?: DetailSidebarLabels
+  sourceCoverage?: SourceCoverage
+  languagesAnalyzed?: string[]
+  confidenceRationale?: string
+  sourceCoverageLabels?: Dictionary["sourceCoverage"]
   children?: React.ReactNode
 }
 
-export function DetailSidebar({ storyHooks, labels, children }: DetailSidebarProps) {
+export function DetailSidebar({
+  storyHooks,
+  labels,
+  sourceCoverage,
+  languagesAnalyzed,
+  confidenceRationale,
+  sourceCoverageLabels,
+  children,
+}: DetailSidebarProps) {
   const storyAnglesLabel = labels?.storyAngles ?? "Story Angles"
   const noticeText = labels?.classificationNotice ?? "This case file represents AI-generated analysis of archival records. All sources should be independently verified."
 
@@ -33,6 +49,16 @@ export function DetailSidebar({ storyHooks, labels, children }: DetailSidebarPro
               ))}
             </ul>
           </div>
+        )}
+
+        {/* Source coverage（schema_version=2 の記事のみ表示） */}
+        {sourceCoverage && sourceCoverageLabels && (
+          <SourceCoverageCard
+            sourceCoverage={sourceCoverage}
+            languagesAnalyzed={languagesAnalyzed}
+            confidenceRationale={confidenceRationale}
+            labels={sourceCoverageLabels}
+          />
         )}
 
         {/* Classification notice */}

--- a/web-public/src/components/mystery/source-coverage-card.tsx
+++ b/web-public/src/components/mystery/source-coverage-card.tsx
@@ -1,0 +1,76 @@
+import type { SourceCoverage } from "@ghost/shared/src/types/mystery"
+import type { Dictionary } from "@/lib/i18n/dictionaries"
+
+interface SourceCoverageCardProps {
+  sourceCoverage: SourceCoverage
+  languagesAnalyzed?: string[]
+  confidenceRationale?: string
+  labels: Dictionary["sourceCoverage"]
+}
+
+export function SourceCoverageCard({
+  sourceCoverage,
+  languagesAnalyzed,
+  confidenceRationale,
+  labels,
+}: SourceCoverageCardProps) {
+  return (
+    <div className="aged-card letterpress-border rounded-sm p-5">
+      <h3 className="font-mono text-xs uppercase tracking-wider text-muted-foreground mb-4">
+        {labels.heading}
+      </h3>
+
+      {/* 分析言語 */}
+      {languagesAnalyzed && languagesAnalyzed.length > 0 && (
+        <div className="mb-3">
+          <p className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground mb-1.5">
+            {labels.languagesAnalyzed}
+          </p>
+          <div className="flex flex-wrap gap-1.5">
+            {languagesAnalyzed.map((lang) => (
+              <span
+                key={lang}
+                className="inline-flex px-1.5 py-0.5 rounded text-[10px] font-mono uppercase tracking-wider bg-gold/10 text-gold border border-gold/20"
+              >
+                {lang}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* 検索アーカイブ */}
+      {sourceCoverage.apis_searched.length > 0 && (
+        <div className="mb-3">
+          <p className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground mb-1.5">
+            {labels.apisSearched}
+          </p>
+          <ul className="space-y-0.5">
+            {sourceCoverage.apis_searched.map((api) => (
+              <li key={api} className="text-xs text-foreground/70 font-mono">
+                &bull; {api}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* 判定根拠 */}
+      {confidenceRationale && (
+        <div className="mb-3">
+          <p className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground mb-1.5">
+            {labels.confidenceRationale}
+          </p>
+          <p className="text-xs text-foreground/70 leading-relaxed">
+            {confidenceRationale}
+          </p>
+        </div>
+      )}
+
+      {/* カバレッジ注記 */}
+      <p className="text-[10px] text-muted-foreground/60 leading-relaxed mt-3 pt-3 border-t border-border">
+        {labels.coverageNote}
+      </p>
+    </div>
+  )
+}

--- a/web-public/src/lib/i18n/dictionaries/de.ts
+++ b/web-public/src/lib/i18n/dictionaries/de.ts
@@ -143,6 +143,18 @@ const dict: Dictionary = {
     linkCopied: "Link kopiert!",
     shareThisArticle: "Diese Fallakte teilen",
   },
+  confidence: {
+    confirmedGhost: "Bestätigter Geist",
+    suspectedGhost: "Verdächtiger Geist",
+    archivalEcho: "Archivisches Echo",
+  },
+  sourceCoverage: {
+    heading: "Untersuchungsumfang",
+    languagesAnalyzed: "Analysierte Sprachen",
+    apisSearched: "Durchsuchte Archive",
+    coverageNote: "Diese Analyse basiert auf Materialien, die über die oben aufgeführten digitalen Archiv-APIs verfügbar sind.",
+    confidenceRationale: "Bewertungsgrundlage",
+  },
   seo: {
     homeDescription: "Ein autonomes KI-Agentensystem, das die öffentlichen digitalen Archive der Welt über fünf akademische Disziplinen hinweg kreuzanalysiert — Anomalien aufdeckend, die kein einzelnes Dokument, keine Sprache und kein Fachgebiet allein erklären kann.",
     archiveDescription: "Vollständiger Index aller untersuchten Anomalien, Diskrepanzen und unerklärlichen Phänomene, die aus den öffentlichen Aufzeichnungen der Welt ausgegraben wurden.",

--- a/web-public/src/lib/i18n/dictionaries/en.ts
+++ b/web-public/src/lib/i18n/dictionaries/en.ts
@@ -142,6 +142,18 @@ const dict: Dictionary = {
     linkCopied: "Link copied!",
     shareThisArticle: "Share this case file",
   },
+  confidence: {
+    confirmedGhost: "Confirmed Ghost",
+    suspectedGhost: "Suspected Ghost",
+    archivalEcho: "Archival Echo",
+  },
+  sourceCoverage: {
+    heading: "Investigation Scope",
+    languagesAnalyzed: "Languages Analyzed",
+    apisSearched: "Archives Searched",
+    coverageNote: "This analysis is based on materials available through the digital archive APIs listed above.",
+    confidenceRationale: "Assessment Rationale",
+  },
   seo: {
     homeDescription: "An autonomous AI agent system cross-analyzing the world's public digital archives through five academic disciplines — unearthing anomalies that no single record, language, or field can explain.",
     archiveDescription: "Complete index of all investigated anomalies, discrepancies, and unexplained phenomena unearthed from the world's public records.",

--- a/web-public/src/lib/i18n/dictionaries/es.ts
+++ b/web-public/src/lib/i18n/dictionaries/es.ts
@@ -143,6 +143,18 @@ const dict: Dictionary = {
     linkCopied: "Enlace copiado!",
     shareThisArticle: "Compartir este expediente",
   },
+  confidence: {
+    confirmedGhost: "Fantasma confirmado",
+    suspectedGhost: "Fantasma sospechado",
+    archivalEcho: "Eco de archivo",
+  },
+  sourceCoverage: {
+    heading: "Alcance de la investigación",
+    languagesAnalyzed: "Idiomas analizados",
+    apisSearched: "Archivos consultados",
+    coverageNote: "Este análisis se basa en materiales disponibles a través de las APIs de archivos digitales mencionadas.",
+    confidenceRationale: "Fundamento de la evaluación",
+  },
   seo: {
     homeDescription: "Un sistema autónomo de agentes de IA que analiza los archivos digitales públicos del mundo a través de cinco disciplinas académicas — revelando anomalías que ningún registro, idioma o campo puede explicar por sí solo.",
     archiveDescription: "Índice completo de todas las anomalías, discrepancias y fenómenos inexplicables desenterrados de los registros públicos del mundo.",

--- a/web-public/src/lib/i18n/dictionaries/fr.ts
+++ b/web-public/src/lib/i18n/dictionaries/fr.ts
@@ -143,6 +143,18 @@ const dict: Dictionary = {
     linkCopied: "Lien copié !",
     shareThisArticle: "Partager ce dossier",
   },
+  confidence: {
+    confirmedGhost: "Fantôme confirmé",
+    suspectedGhost: "Fantôme suspecté",
+    archivalEcho: "Écho archivistique",
+  },
+  sourceCoverage: {
+    heading: "Portée de l'investigation",
+    languagesAnalyzed: "Langues analysées",
+    apisSearched: "Archives consultées",
+    coverageNote: "Cette analyse repose sur les matériaux accessibles via les APIs d'archives numériques mentionnées ci-dessus.",
+    confidenceRationale: "Fondement de l'évaluation",
+  },
   seo: {
     homeDescription: "Un système autonome d'agents IA qui analyse les archives numériques publiques du monde à travers cinq disciplines académiques — révélant les anomalies qu'aucun document, langue ou domaine ne peut expliquer seul.",
     archiveDescription: "Index complet de toutes les anomalies, divergences et phénomènes inexpliqués exhumés des archives publiques du monde.",

--- a/web-public/src/lib/i18n/dictionaries/ja.ts
+++ b/web-public/src/lib/i18n/dictionaries/ja.ts
@@ -142,6 +142,18 @@ const dict: Dictionary = {
     linkCopied: "コピーしました！",
     shareThisArticle: "このケースファイルをシェア",
   },
+  confidence: {
+    confirmedGhost: "確認済みゴースト",
+    suspectedGhost: "疑わしいゴースト",
+    archivalEcho: "アーカイブの残響",
+  },
+  sourceCoverage: {
+    heading: "調査範囲",
+    languagesAnalyzed: "分析言語",
+    apisSearched: "検索アーカイブ",
+    coverageNote: "本分析は上記のデジタルアーカイブAPIで取得可能な資料に基づいています。",
+    confidenceRationale: "判定根拠",
+  },
   seo: {
     homeDescription: "世界の公開デジタルアーカイブを5つの学術領域で多言語横断分析する自律型AIエージェントシステム。単一の記録・言語・学問分野では説明できないアノマリーを発掘する。",
     archiveDescription: "世界の公開記録から発掘された、すべての異常・矛盾・説明不能な現象の完全索引。",

--- a/web-public/src/lib/i18n/dictionaries/nl.ts
+++ b/web-public/src/lib/i18n/dictionaries/nl.ts
@@ -143,6 +143,18 @@ const dict: Dictionary = {
     linkCopied: "Link gekopieerd!",
     shareThisArticle: "Dit dossier delen",
   },
+  confidence: {
+    confirmedGhost: "Bevestigde Geest",
+    suspectedGhost: "Vermoede Geest",
+    archivalEcho: "Archiefecho",
+  },
+  sourceCoverage: {
+    heading: "Onderzoeksomvang",
+    languagesAnalyzed: "Geanalyseerde talen",
+    apisSearched: "Doorzochte archieven",
+    coverageNote: "Deze analyse is gebaseerd op materialen die beschikbaar zijn via de hierboven genoemde digitale archief-API's.",
+    confidenceRationale: "Beoordelingsgrondslag",
+  },
   seo: {
     homeDescription: "Een autonoom AI-agentsysteem dat de openbare digitale archieven van de wereld kruislings analyseert via vijf academische disciplines — anomalieën blootleggend die geen enkel document, taal of vakgebied alleen kan verklaren.",
     archiveDescription: "Volledige index van alle onderzochte anomalieën, discrepanties en onverklaarde fenomenen opgegraven uit de openbare archieven van de wereld.",

--- a/web-public/src/lib/i18n/dictionaries/pt.ts
+++ b/web-public/src/lib/i18n/dictionaries/pt.ts
@@ -143,6 +143,18 @@ const dict: Dictionary = {
     linkCopied: "Link copiado!",
     shareThisArticle: "Compartilhar este dossiê",
   },
+  confidence: {
+    confirmedGhost: "Fantasma confirmado",
+    suspectedGhost: "Fantasma suspeito",
+    archivalEcho: "Eco arquivístico",
+  },
+  sourceCoverage: {
+    heading: "Alcance da investigação",
+    languagesAnalyzed: "Idiomas analisados",
+    apisSearched: "Arquivos pesquisados",
+    coverageNote: "Esta análise baseia-se em materiais disponíveis através das APIs de arquivos digitais listadas acima.",
+    confidenceRationale: "Fundamento da avaliação",
+  },
   seo: {
     homeDescription: "Um sistema autônomo de agentes de IA que analisa os arquivos digitais públicos do mundo através de cinco disciplinas acadêmicas — revelando anomalias que nenhum registro, idioma ou campo pode explicar sozinho.",
     archiveDescription: "Índice completo de todas as anomalias, discrepâncias e fenômenos inexplicáveis desenterrados dos registros públicos do mundo.",

--- a/web-public/src/lib/i18n/dictionaries/types.ts
+++ b/web-public/src/lib/i18n/dictionaries/types.ts
@@ -125,6 +125,18 @@ export interface Dictionary {
     linkCopied: string;
     shareThisArticle: string;
   };
+  confidence: {
+    confirmedGhost: string;
+    suspectedGhost: string;
+    archivalEcho: string;
+  };
+  sourceCoverage: {
+    heading: string;
+    languagesAnalyzed: string;
+    apisSearched: string;
+    coverageNote: string;
+    confidenceRationale: string;
+  };
   seo: {
     homeDescription: string;
     archiveDescription: string;


### PR DESCRIPTION
## Summary

Phase 2（PR #235）で Firestore に保存された `confidence_level`、`source_coverage`、`confidence_rationale` を公開サイト・管理画面に表示。読者は Ghost の認定根拠と調査範囲の透明性を確認できるようになる。

- **GhostConfidenceBadge**: CaseFileHeader のメタ情報行に表示（HIGH=緑, MEDIUM=黄, LOW=灰 + Ghost アイコン + 7言語 i18n ラベル）
- **SourceCoverageCard**: DetailSidebar に表示（分析言語タグ、検索アーカイブ一覧、判定根拠テキスト、カバレッジ注記）
- **i18n 辞書**: 7言語すべてに `confidence` / `sourceCoverage` セクション追加
- **web-admin プレビュー**: ConfidenceBadge をステータスバッジ横に追加、source_coverage カードをサイドバーに追加
- **後方互換**: `source_coverage` / `confidence_rationale` / `languages_analyzed` がないレガシー記事ではカバレッジカード非表示

## 変更ファイル（14ファイル）

| ファイル | 変更内容 |
|---------|---------|
| `types.ts` | Dictionary に confidence / sourceCoverage セクション追加 |
| `{en,ja,es,de,fr,nl,pt}.ts` | 7言語翻訳追加 |
| `ghost-confidence-badge.tsx` | **新規** — Ghost アイコン付き confidence バッジ |
| `source-coverage-card.tsx` | **新規** — 調査範囲サイドバーカード |
| `case-file-header.tsx` | confidenceLevel / confidenceLabels props 追加 |
| `detail-sidebar.tsx` | sourceCoverage 関連 props + SourceCoverageCard 表示 |
| `[id]/page.tsx` | mystery データから CaseFileHeader / DetailSidebar にデータ接続 |
| `preview-content.tsx` | ConfidenceBadge + source_coverage カード追加 |

## Test plan

- [x] `tsc --noEmit` で web-public / web-admin の型エラーなし（既存の async component エラーのみ）
- [ ] `npm run dev` で記事詳細ページに confidence バッジが表示される
- [ ] 7言語すべてでラベルが正しく表示される
- [ ] source_coverage がない記事でカバレッジカードが非表示である
- [ ] web-admin プレビューページに ConfidenceBadge と source_coverage カードが表示される

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)