### PR TITLE
fix: ADK State の .keys() AttributeError を修正

### DIFF
--- a/mystery_agents/tools/search_metadata.py
+++ b/mystery_agents/tools/search_metadata.py
@@ -104,7 +104,9 @@ def get_search_metadata(tool_context: Optional[ToolContext] = None) -> str:
 
     # 言語別キー
     languages_searched: list[str] = []
-    for key in list(state.keys()):
+    # ADK State は .keys() を持たないため to_dict() 経由、テスト用 dict はそのまま
+    state_dict = state.to_dict() if hasattr(state, "to_dict") else state
+    for key in list(state_dict.keys()):
         if key.startswith("raw_search_results_") and key != "raw_search_results":
             lang = key.replace("raw_search_results_", "")
             lang_results = state.get(key)


### PR DESCRIPTION
## Summary

- `mystery_agents/tools/search_metadata.py:107` で `state.keys()` を呼び出していたが、ADK の `State` クラスは `.keys()` メソッドを持たないため本番環境で `AttributeError` が発生していた
- `state.to_dict().keys()` に変更し、テスト用の `dict` との互換性も `hasattr` で保持

## Test plan

- [x] `pytest tests/unit/ -v -k "search_metadata"` — 全13テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)