### PR TITLE
feat: Librarian 年代フィルタをデフォルト OFF に変更（date_hint 方式）

### DIFF
--- a/mystery_agents/agents/language_librarians.py
+++ b/mystery_agents/agents/language_librarians.py
@@ -47,9 +47,9 @@ def _resolve_sources_hint(lang_code: str) -> str:
 #    - `sources` パラメータで関連アーカイブを指定: {sources_hint}
 #    - `language` パラメータを "{lang_code}" に設定して言語フィルタリングを行う
 #    - 例: keywords="Bell Witch, Adams Tennessee, poltergeist, haunting"
-#    - テーマが特定の時代を示唆する場合、`date_start` / `date_end` で年パラメータを設定する
+#    - 年代フィルタはオプション。テーマの年代が明確な場合のみ `date_start`/`date_end` を設定してもよい
 #      （例: date_start="1700", date_end="1800"）
-#    - デフォルト範囲は 1500-1899。テーマの歴史的文脈に応じて調整する
+#    - 年代が不明確な場合はフィルタを使わず広く検索する（検索漏れ防止）
 # 3. 歴史的な新聞記事を検索するには **search_newspapers** を呼び出す
 #    - ツールは対象言語で利用可能な新聞ソースに自動ルーティングする
 #    - 対象言語の新聞ソースが存在しない場合、空の結果を返す（エラーではない）
@@ -82,9 +82,9 @@ Search digital archives for {language_name}-language primary sources related to 
    - Use the `sources` parameter to target relevant archives: {sources_hint}
    - Use the `language` parameter set to "{lang_code}" for language filtering
    - Example: keywords="Bell Witch, Adams Tennessee, poltergeist, haunting"
-   - If the theme suggests a specific time period, set `date_start` and `date_end` year parameters
-     (e.g., date_start="1700", date_end="1800")
-   - Default range is 1500-1899; adjust based on the historical context of the theme
+   - Date filtering is OPTIONAL. Only set `date_start` and `date_end` when the theme clearly
+     indicates a specific time period (e.g., date_start="1700", date_end="1800")
+   - When the time period is uncertain, omit date parameters to cast a wider net
 3. {newspaper_instruction}
 
 ## Output Format

--- a/mystery_agents/tools/archive_source_base.py
+++ b/mystery_agents/tools/archive_source_base.py
@@ -71,8 +71,8 @@ class ArchiveSource(ABC):
     def search(
         self,
         keywords: list[str],
-        date_start: str = "1500",
-        date_end: str = "1899",
+        date_start: str | None = None,
+        date_end: str | None = None,
         max_results: int = 20,
         language: str | None = None,
     ) -> ArchiveSearchResult:
@@ -130,8 +130,8 @@ class ArchiveSource(ABC):
     def _search_impl(
         self,
         keywords: list[str],
-        date_start: str,
-        date_end: str,
+        date_start: str | None,
+        date_end: str | None,
         max_results: int,
         language: str | None,
     ) -> ArchiveSearchResult:

--- a/mystery_agents/tools/chronicling_america.py
+++ b/mystery_agents/tools/chronicling_america.py
@@ -46,8 +46,8 @@ class ChroniclingAmericaSource(ArchiveSource):
     def _search_impl(
         self,
         keywords: list[str],
-        date_start: str,
-        date_end: str,
+        date_start: str | None,
+        date_end: str | None,
         max_results: int,
         language: str | None,
     ) -> ArchiveSearchResult:
@@ -129,8 +129,8 @@ class ChroniclingAmericaSource(ArchiveSource):
 
 def search_chronicling_america(
     keywords: list[str],
-    date_start: str = "1780",
-    date_end: str = "1899",
+    date_start: str | None = None,
+    date_end: str | None = None,
     states: list[str] | None = None,
     page: int = 1,
     rows: int = 20,

--- a/mystery_agents/tools/ddb.py
+++ b/mystery_agents/tools/ddb.py
@@ -34,8 +34,8 @@ class DDBSource(ArchiveSource):
     def _search_impl(
         self,
         keywords: list[str],
-        date_start: str,
-        date_end: str,
+        date_start: str | None,
+        date_end: str | None,
         max_results: int,
         language: str | None,
     ) -> ArchiveSearchResult:

--- a/mystery_agents/tools/delpher.py
+++ b/mystery_agents/tools/delpher.py
@@ -128,8 +128,8 @@ class DelpherSource(ArchiveSource):
     def _search_impl(
         self,
         keywords: list[str],
-        date_start: str,
-        date_end: str,
+        date_start: str | None,
+        date_end: str | None,
         max_results: int,
         language: str | None,
     ) -> ArchiveSearchResult:

--- a/mystery_agents/tools/digitalnz.py
+++ b/mystery_agents/tools/digitalnz.py
@@ -66,8 +66,8 @@ class DigitalNZSource(ArchiveSource):
     def _search_impl(
         self,
         keywords: list[str],
-        date_start: str,
-        date_end: str,
+        date_start: str | None,
+        date_end: str | None,
         max_results: int,
         language: str | None,
     ) -> ArchiveSearchResult:

--- a/mystery_agents/tools/dpla.py
+++ b/mystery_agents/tools/dpla.py
@@ -41,8 +41,8 @@ class DPLASource(ArchiveSource):
     def _search_impl(
         self,
         keywords: list[str],
-        date_start: str,
-        date_end: str,
+        date_start: str | None,
+        date_end: str | None,
         max_results: int,
         language: str | None,
     ) -> ArchiveSearchResult:

--- a/mystery_agents/tools/europeana.py
+++ b/mystery_agents/tools/europeana.py
@@ -44,8 +44,8 @@ class EuropeanaSource(ArchiveSource):
     def _search_impl(
         self,
         keywords: list[str],
-        date_start: str,
-        date_end: str,
+        date_start: str | None,
+        date_end: str | None,
         max_results: int,
         language: str | None,
     ) -> ArchiveSearchResult:

--- a/mystery_agents/tools/internet_archive.py
+++ b/mystery_agents/tools/internet_archive.py
@@ -42,8 +42,8 @@ class InternetArchiveSource(ArchiveSource):
     def _search_impl(
         self,
         keywords: list[str],
-        date_start: str,
-        date_end: str,
+        date_start: str | None,
+        date_end: str | None,
         max_results: int,
         language: str | None,
     ) -> ArchiveSearchResult:

--- a/mystery_agents/tools/librarian_tools.py
+++ b/mystery_agents/tools/librarian_tools.py
@@ -30,8 +30,8 @@ _TOTAL_DOCS_CAP = 30
 
 def search_newspapers(
     keywords: str,
-    date_start: str = "1500",
-    date_end: str = "1899",
+    date_start: Optional[str] = None,
+    date_end: Optional[str] = None,
     states: Optional[str] = None,
     max_results: int = 20,
     min_results: int = 3,
@@ -45,12 +45,12 @@ def search_newspapers(
     languages, returns an empty result (not an error).
 
     When a newspaper source is found, applies progressive fallback strategies:
-    individual keyword search, geographic expansion, and date range expansion.
+    individual keyword search and geographic expansion.
 
     Args:
         keywords: Comma-separated list of search keywords related to historical mysteries
-        date_start: Start year (default: 1500)
-        date_end: End year (default: 1899)
+        date_start: Optional start year for filtering (e.g., "1700"). Omit to search all dates.
+        date_end: Optional end year for filtering (e.g., "1800"). Omit to search all dates.
         states: Comma-separated US states to search (default: East Coast states)
         max_results: Maximum number of results to return (default: 20)
         min_results: Minimum documents before stopping fallback (default: 3)
@@ -168,22 +168,6 @@ def search_newspapers(
             if len(all_docs) >= min_results:
                 break
 
-    # Level 4: 日付範囲拡大（±10年）
-    if len(all_docs) < min_results:
-        expanded_start = str(max(1400, int(date_start) - 10))
-        expanded_end = str(min(1920, int(date_end) + 10))
-        if expanded_start != date_start or expanded_end != date_end:
-            logger.info(
-                "Chronicling America フォールバック L4 発動: 日付範囲拡大 %s-%s",
-                expanded_start, expanded_end,
-                extra={"search_level": "L4", "current_count": len(all_docs)},
-            )
-            levels_used.append(f"L4_date_expanded_{expanded_start}_{expanded_end}")
-            for kw_list in [en_keywords, es_keywords]:
-                _search_and_collect(kw_list, search_states=None, start=expanded_start, end=expanded_end)
-                if len(all_docs) >= min_results:
-                    break
-
     # リンク品質検証（失敗時は検証スキップで全ドキュメント保持）
     try:
         validation = validate_documents(all_docs)
@@ -292,8 +276,8 @@ def _search_single_source(
     source_obj,
     keyword_groups: list[list[str]],
     *,
-    date_start: str,
-    date_end: str,
+    date_start: str | None,
+    date_end: str | None,
     per_source_limit: int,
     language: str | None,
 ) -> tuple[str, list[ArchiveDocument], int, str | None, bool]:
@@ -359,44 +343,6 @@ def _search_single_source(
             if docs:
                 break
 
-    # 日付範囲拡大フォールバック: 結果なし & 年代指定あり → ±25年拡大して再検索（1回のみ）
-    if not docs and date_start and date_end:
-        try:
-            start_year = int(date_start[:4])
-            end_year = int(date_end[:4])
-            exp_start = str(max(1400, start_year - 25))
-            exp_end = str(min(2025, end_year + 25))
-            if exp_start != str(start_year) or exp_end != str(end_year):
-                fallback_used = True
-                logger.info(
-                    "%s 日付範囲拡大フォールバック: %s-%s → %s-%s",
-                    key, date_start, date_end, exp_start, exp_end,
-                    extra={"api_name": key, "fallback_type": "date_expansion"},
-                )
-                lang_arg = language if (language and source_obj.supports_language_filter) else None
-                for kw_list in keyword_groups:
-                    try:
-                        result = source_obj.search(
-                            keywords=kw_list,
-                            date_start=exp_start,
-                            date_end=exp_end,
-                            max_results=per_source_limit,
-                            language=lang_arg,
-                        )
-                        for doc in result.documents:
-                            if doc.source_url not in seen_urls:
-                                seen_urls.add(doc.source_url)
-                                docs.append(doc)
-                        total_hits += result.total_hits
-                        if result.error:
-                            error = result.error
-                    except Exception as e:
-                        error = str(e)
-                    if docs:
-                        break
-        except (ValueError, IndexError):
-            pass
-
     return key, docs, total_hits, error, fallback_used
 
 
@@ -412,8 +358,8 @@ def _rank_documents(
 
 def search_archives(
     keywords: str,
-    date_start: str = "1500",
-    date_end: str = "1899",
+    date_start: Optional[str] = None,
+    date_end: Optional[str] = None,
     sources: Optional[str] = None,
     max_results: int = 10,
     language: Optional[str] = None,
@@ -427,8 +373,8 @@ def search_archives(
 
     Args:
         keywords: Comma-separated search keywords
-        date_start: Start year (default: 1500)
-        date_end: End year (default: 1899)
+        date_start: Optional start year for filtering (e.g., "1700"). Omit to search all dates.
+        date_end: Optional end year for filtering (e.g., "1800"). Omit to search all dates.
         sources: Comma-separated source names to search (default: all US sources).
                  Options: loc, dpla, nypl, internet_archive, ddb, europeana
         max_results: Max results per source (default: 10)

--- a/mystery_agents/tools/loc_digital.py
+++ b/mystery_agents/tools/loc_digital.py
@@ -33,8 +33,8 @@ class LOCDigitalSource(ArchiveSource):
     def _search_impl(
         self,
         keywords: list[str],
-        date_start: str,
-        date_end: str,
+        date_start: str | None,
+        date_end: str | None,
         max_results: int,
         language: str | None,
     ) -> ArchiveSearchResult:

--- a/mystery_agents/tools/ndl_search.py
+++ b/mystery_agents/tools/ndl_search.py
@@ -45,8 +45,8 @@ class NDLSearchSource(ArchiveSource):
     def _search_impl(
         self,
         keywords: list[str],
-        date_start: str,
-        date_end: str,
+        date_start: str | None,
+        date_end: str | None,
         max_results: int,
         language: str | None,
     ) -> ArchiveSearchResult:

--- a/mystery_agents/tools/nypl_digital.py
+++ b/mystery_agents/tools/nypl_digital.py
@@ -33,8 +33,8 @@ class NYPLSource(ArchiveSource):
     def _search_impl(
         self,
         keywords: list[str],
-        date_start: str,
-        date_end: str,
+        date_start: str | None,
+        date_end: str | None,
         max_results: int,
         language: str | None,
     ) -> ArchiveSearchResult:

--- a/mystery_agents/tools/trove.py
+++ b/mystery_agents/tools/trove.py
@@ -31,8 +31,8 @@ class TroveSource(ArchiveSource):
     def _search_impl(
         self,
         keywords: list[str],
-        date_start: str,
-        date_end: str,
+        date_start: str | None,
+        date_end: str | None,
         max_results: int,
         language: str | None,
     ) -> ArchiveSearchResult:

--- a/mystery_agents/tools/wellcome_collection.py
+++ b/mystery_agents/tools/wellcome_collection.py
@@ -175,8 +175,8 @@ class WellcomeSource(ArchiveSource):
     def _search_impl(
         self,
         keywords: list[str],
-        date_start: str,
-        date_end: str,
+        date_start: str | None,
+        date_end: str | None,
         max_results: int,
         language: str | None,
     ) -> ArchiveSearchResult:

--- a/tests/unit/test_librarian_tools.py
+++ b/tests/unit/test_librarian_tools.py
@@ -461,42 +461,8 @@ class TestSearchSingleSource:
         assert fallback is True
         assert len(docs) == 1
 
-    def test_date_expansion_when_no_results(self):
-        """結果0件 & 年代指定あり → ±25年拡大で再検索される。"""
-        doc = _make_doc(url="https://expanded.example.com/doc")
-        call_log = []
-
-        class DateExpandSource:
-            source_key = "de_src"
-            source_name = "Date Expand Source"
-            supports_language_filter = False
-
-            def search(self, **kwargs):
-                call_log.append(kwargs)
-                # 元の日付範囲では0件、拡大範囲では結果あり
-                if kwargs["date_start"] == "1800" and kwargs["date_end"] == "1850":
-                    return ArchiveSearchResult(documents=[], total_hits=0)
-                return ArchiveSearchResult(documents=[doc], total_hits=1)
-
-        key, docs, hits, err, fallback = _search_single_source(
-            DateExpandSource(),
-            [["ghost"]],
-            date_start="1800",
-            date_end="1850",
-            per_source_limit=10,
-            language=None,
-        )
-
-        assert fallback is True
-        assert len(docs) == 1
-        assert docs[0].source_url == "https://expanded.example.com/doc"
-        # 拡大後の日付: 1800-25=1775, 1850+25=1875
-        expanded_call = call_log[-1]
-        assert expanded_call["date_start"] == "1775"
-        assert expanded_call["date_end"] == "1875"
-
-    def test_no_date_expansion_when_results_exist(self):
-        """結果がある場合は日付拡大しない。"""
+    def test_passes_date_params_to_source(self):
+        """日付パラメータがソースに正しく渡される。"""
         doc = _make_doc()
         call_log = []
 
@@ -523,58 +489,32 @@ class TestSearchSingleSource:
         # 元の日付範囲のみで検索（拡大なし）
         assert all(c["date_start"] == "1800" for c in call_log)
 
-    def test_date_expansion_bounds_clamped(self):
-        """拡大後の日付が 1400-2025 の範囲内に収まる。"""
+    def test_none_dates_passed_to_source(self):
+        """date_start=None, date_end=None でクラッシュしない。"""
         call_log = []
 
-        class ClampSource:
-            source_key = "clamp"
-            source_name = "Clamp Source"
-            supports_language_filter = False
-
-            def search(self, **kwargs):
-                call_log.append(kwargs)
-                return ArchiveSearchResult(documents=[], total_hits=0)
-
-        _search_single_source(
-            ClampSource(),
-            [["ghost"]],
-            date_start="1410",
-            date_end="2020",
-            per_source_limit=10,
-            language=None,
-        )
-
-        # 拡大後: max(1400, 1410-25)=1400, min(2025, 2020+25)=2025
-        expanded_calls = [c for c in call_log if c["date_start"] != "1410"]
-        assert len(expanded_calls) == 1
-        assert expanded_calls[0]["date_start"] == "1400"
-        assert expanded_calls[0]["date_end"] == "2025"
-
-    def test_date_expansion_skipped_when_no_dates(self):
-        """date_start/date_end が空の場合、拡大をスキップ。"""
-        call_log = []
-
-        class NoDatesSource:
+        class NullDatesSource:
             source_key = "nd"
-            source_name = "No Dates Source"
+            source_name = "Null Dates Source"
             supports_language_filter = False
 
             def search(self, **kwargs):
                 call_log.append(kwargs)
                 return ArchiveSearchResult(documents=[], total_hits=0)
 
-        _search_single_source(
-            NoDatesSource(),
+        key, docs, hits, err, fallback = _search_single_source(
+            NullDatesSource(),
             [["ghost"]],
-            date_start="",
-            date_end="",
+            date_start=None,
+            date_end=None,
             per_source_limit=10,
             language=None,
         )
 
-        # 元の検索のみ（日付拡大なし）
         assert len(call_log) == 1
+        assert call_log[0]["date_start"] is None
+        assert call_log[0]["date_end"] is None
+        assert err is None
 
     def test_deduplicates_within_source(self):
         """同一ソース内の URL 重複が除去される。"""
@@ -624,14 +564,14 @@ class TestNoBilingualExpansion:
 
 
 class TestDefaultDates:
-    """デフォルト日付が 1500-1899 であることを確認"""
+    """デフォルト日付が None であることを確認"""
 
     @patch("mystery_agents.tools.librarian_tools.validate_documents")
     @patch("mystery_agents.tools.librarian_tools.get_all_sources")
-    def test_search_archives_default_dates_1500_1899(
+    def test_search_archives_default_dates_none(
         self, mock_get_all, mock_validate
     ):
-        """search_archives のデフォルト日付が 1500-1899 でソースに渡される。"""
+        """search_archives のデフォルト日付が None でソースに渡される。"""
         call_log = []
 
         class LogSource:
@@ -649,13 +589,11 @@ class TestDefaultDates:
             "removed_urls": [], "duration_ms": 0, "verified_documents": [],
         })()
 
-        # date_start / date_end を明示しない → デフォルト値が使われる
+        # date_start / date_end を明示しない → None が渡される
         search_archives(keywords="test", sources="loc", language="en")
 
-        # 最初の検索はデフォルト日付範囲で実行される
-        # （結果0件の場合、日付拡大フォールバックで追加の検索が発生しうる）
-        assert call_log[0]["date_start"] == "1500"
-        assert call_log[0]["date_end"] == "1899"
+        assert call_log[0]["date_start"] is None
+        assert call_log[0]["date_end"] is None
 
 
 class TestNewspaperDispatcher:


### PR DESCRIPTION
## Summary

- Librarian の年代フィルタを「デフォルト 1500-1899」→「デフォルト None（フィルタなし）」に変更
- LLM がテーマの年代を明確に判断できる場合のみ `date_start`/`date_end` を指定する date_hint 方式に移行
- `search_newspapers` の Level 4（±10年拡大）と `_search_single_source` の ±25年拡大フォールバックを削除し、API コール数を削減

## 変更ファイル（16ファイル）

| カテゴリ | ファイル | 変更内容 |
|---------|---------|---------|
| 基底クラス | `archive_source_base.py` | `search()` / `_search_impl()` の `date_start`/`date_end` を `str \| None = None` に |
| 12ソース | `loc_digital.py` 他11件 | `_search_impl` の型アノテーションを `str \| None` に |
| ラッパー | `chronicling_america.py` | `search_chronicling_america()` のデフォルト値を `None` に |
| メインツール | `librarian_tools.py` | シグネチャ変更 + 日付拡大フォールバック2箇所を削除 |
| Instruction | `language_librarians.py` | 「年代フィルタはオプション」に instruction 更新 |
| テスト | `test_librarian_tools.py` | 日付拡大テスト3件削除、None テスト1件追加、デフォルト日付テスト修正 |

## 影響なし

- 各ソースの `if date_start and date_end:` ガードが既に None を正しくスキップ
- 下流エージェント（Scholar, Armchair Polymath 等）は `collected_documents` を参照するだけで date params に依存しない
- `_TOTAL_DOCS_CAP=30` でノイズ抑制済み

## Test plan

- [x] `tests/unit/test_librarian_tools.py` — 22テスト全パス
- [x] `tests/unit/` — 878テスト全パス

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)