### PR TITLE
feat: OpenAlex 学術論文検索 API ツール実装 + Polymath 統合

### DIFF
--- a/mystery_agents/agents/armchair_polymath.py
+++ b/mystery_agents/agents/armchair_polymath.py
@@ -11,6 +11,7 @@ from google.adk.agents import LlmAgent
 
 from shared.model_config import create_pro_model
 
+from ..tools.openalex import search_academic_papers
 from ..tools.scholar_tools import save_structured_report
 from ..tools.search_metadata import get_search_metadata
 
@@ -68,6 +69,19 @@ from ..tools.search_metadata import get_search_metadata
 # - デジタル化範囲: この時代・地域の記録のうちデジタル化済みの推定割合
 # - 不在≠不存在: API で見つからない記録は存在しないわけではない
 # - OCR・索引の限界: 歴史文書の OCR 品質や旧式用語による索引の限界
+#
+# ## ツール: search_academic_papers
+# `get_search_metadata` を呼び出した後、ミステリーの中核テーマから導出したクエリで
+# `search_academic_papers` を呼び出す（例: 主要な歴史的事件、人物、現象）。
+# このツールは OpenAlex から論文数、言語分布、年代分布、主要概念、被引用数上位論文を返す。
+#
+# このデータを使って:
+# 1. 構造化レポートの `academic_coverage` フィールドを埋める
+# 2. 言語バイアスを特定する（このトピックは特定言語でのみ研究されていないか？）
+# 3. 時代的ギャップを特定する（学術的関心は増減したか？）
+# 4. 学術的コンセンサスと一次資料の比較
+# 5. `identified_gaps` に学術界が見落としている点を自ら評価して記入
+# 6. `consensus_vs_primary` に学術的ナラティブとアーカイブ証拠の緊張関係を記入
 #
 # ## 学術界のカバレッジと盲点の評価
 # - 言語バイアス: 特定の言語圏の学術伝統でのみ研究されていないか
@@ -173,13 +187,30 @@ Before assigning a confidence level, explicitly evaluate the limits of the inves
 - **OCR and indexing limitations**: Historical documents may be poorly OCR'd or indexed under outdated terminology, making them invisible to keyword searches.
 
 ### 7. Academic Coverage and Blind Spots
+
+## Tool: search_academic_papers
+After calling `get_search_metadata`, call `search_academic_papers` with a query
+derived from the mystery's core theme (e.g., key historical events, figures, or phenomena).
+The tool returns paper counts, language distribution, temporal distribution, key concepts,
+and top-cited papers from OpenAlex.
+
+Use this data to:
+1. Populate the `academic_coverage` field in the structured report
+2. Identify language bias (is this topic studied only in one language?)
+3. Identify temporal gaps (has scholarly interest waxed or waned?)
+4. Compare academic consensus with what primary sources reveal
+5. Fill `identified_gaps` with your own assessment of what scholarship misses
+6. Fill `consensus_vs_primary` with any tension between scholarly narrative and archival evidence
+
+If the tool returns an error (e.g., API key not set), proceed without academic coverage data
+and note this limitation in your analysis. The tool is supplementary — its absence does not
+prevent you from completing the report.
+
 Assess what existing scholarship may already cover this topic:
 - **Language bias**: Is this topic primarily studied in one language's academic tradition? Would scholars working in other languages frame it differently?
 - **Disciplinary bias**: Is this topic well-covered in one field (e.g., political history) but neglected in others (e.g., social history, folklore studies)?
 - **Temporal bias**: Has academic interest in this topic shifted over time? Are there periods of intense study followed by neglect?
 - **Access bias**: Are the key primary sources held in institutions with restricted access, creating a skew in who has published on this topic?
-
-Note: This assessment draws on general scholarly knowledge — no additional API calls required.
 
 ## Output Format
 Structure your integrated analysis as a "Mystery Report":
@@ -333,6 +364,14 @@ The full JSON structure for `save_structured_report`:
     "known_undigitized_sources": [],
     "coverage_assessment": "Coverage assessment text"
   }},
+  "academic_coverage": {{
+    "papers_found": 42,
+    "language_distribution": {{"en": 35, "de": 5, "ja": 2}},
+    "temporal_distribution": {{"pre-1950": 3, "1950-1999": 15, "2000-present": 24}},
+    "key_concepts": ["folklore", "cultural anthropology", "oral tradition"],
+    "identified_gaps": ["No scholarship in Dutch on this topic despite significant Dutch colonial presence"],
+    "consensus_vs_primary": "Academic consensus treats the 1842 incident as a routine maritime loss, but primary sources from two languages suggest deliberate concealment."
+  }},
   "confidence_rationale": "Rationale for the chosen confidence level",
   "languages_analyzed": ["en", "de"]
 }}
@@ -356,6 +395,6 @@ armchair_polymath_agent = LlmAgent(
         "and Anthropology perspectives from all available language sources."
     ),
     instruction=ARMCHAIR_POLYMATH_INSTRUCTION,
-    tools=[save_structured_report, get_search_metadata],
+    tools=[save_structured_report, get_search_metadata, search_academic_papers],
     output_key="mystery_report",  # 既存と同じキー → 下流互換性維持
 )

--- a/mystery_agents/agents/storyteller.py
+++ b/mystery_agents/agents/storyteller.py
@@ -84,6 +84,13 @@ load_dotenv(Path(__file__).parent.parent / ".env")
 # - 確信度を限定する: 「調査したデジタルアーカイブに基づく限り」等の表現で調査の範囲を明示する
 # - 謎を捏造せず保存する: Ghost はアーカイブ制約の修辞的誇張からではなく、真の空白と矛盾から自然に浮かび上がるべき
 #
+# ## 学術的文脈（利用可能な場合）
+# Mystery Report に学術カバレッジデータが含まれる場合がある — このトピックに関する
+# 学術論文の数、言語、時期のデータ。存在する場合、ナラティブに織り込む:
+# - 豊富な学術研究がある場合: アーカイブ証拠がいかに定説に疑問を投げかけるかを記す
+# - 学術研究が乏しい場合: この Ghost が学術的注目の盲点に潜んでいることを強調する
+# - 生の統計を列挙せず、不在または存在のレトリックを強化する素材として使用する
+#
 # ## クリエイティブガイドライン
 # - トーン: 学術的信頼性を維持しつつ、怪異的な情緒を醸し出す
 # - 言語: 英語
@@ -219,6 +226,14 @@ Output the narrative text in Markdown format.
 
 **Do NOT include a Sources (citation list) in the output.** Citations are managed separately as structured data.
 **Do NOT include Open Research Questions in the output.**
+
+## Academic Context (if available)
+The Mystery Report may include academic coverage data — how many scholarly papers
+exist on this topic, in which languages, and from which periods.
+When present, weave this into your narrative:
+- If abundant scholarship exists, note how the archival evidence challenges or complicates the accepted narrative
+- If scholarship is scarce, emphasize that this Ghost lurks in a blind spot of academic attention
+- Never list raw statistics; instead, use them to strengthen your rhetoric of absence or presence
 
 ## Creative Guidelines
 - **Tone**: Maintain academic credibility while evoking an eerie atmosphere

--- a/mystery_agents/schemas/mystery_report.py
+++ b/mystery_agents/schemas/mystery_report.py
@@ -97,6 +97,32 @@ class SourceCoverage(BaseModel):
     )
 
 
+class AcademicCoverage(BaseModel):
+    """学術論文カバレッジ — OpenAlex データに基づく学術界の分析。"""
+
+    papers_found: int = Field(0, description="関連論文の総数")
+    language_distribution: dict[str, int] = Field(
+        default_factory=dict,
+        description="言語別の論文数（例: {'en': 35, 'de': 5}）",
+    )
+    temporal_distribution: dict[str, int] = Field(
+        default_factory=dict,
+        description="時代別の論文数（例: {'pre-1950': 3, '1950-1999': 15, '2000-present': 24}）",
+    )
+    key_concepts: List[str] = Field(
+        default_factory=list,
+        description="頻出概念タグ上位5件",
+    )
+    identified_gaps: List[str] = Field(
+        default_factory=list,
+        description="Polymath が特定した学術的盲点",
+    )
+    consensus_vs_primary: Optional[str] = Field(
+        None,
+        description="学術的コンセンサスと一次資料の緊張関係",
+    )
+
+
 class AgentLogEntry(BaseModel):
     """パイプライン実行中の単一エージェントのログエントリ。"""
 
@@ -157,6 +183,10 @@ class MysteryReport(BaseModel):
     source_coverage: Optional[SourceCoverage] = Field(
         None,
         description="ソースカバレッジ評価（検索範囲と限界の自己評価）",
+    )
+    academic_coverage: Optional[AcademicCoverage] = Field(
+        None,
+        description="学術論文カバレッジ（OpenAlex データに基づく）",
     )
     confidence_rationale: Optional[str] = Field(
         None,

--- a/mystery_agents/tools/openalex.py
+++ b/mystery_agents/tools/openalex.py
@@ -1,0 +1,218 @@
+"""OpenAlex 学術論文検索ツール — Armchair Polymath 専用。
+
+OpenAlex API を使用して学術論文のメタデータを検索し、
+言語分布・年代分布・主要概念タグを返す。
+Polymath が学術界のカバレッジと盲点を客観的に評価するために使用する。
+
+API ドキュメント: https://docs.openalex.org/
+"""
+
+import json
+import logging
+import os
+import time
+from collections import Counter
+
+from shared.http_retry import create_retry_session
+
+logger = logging.getLogger(__name__)
+
+OPENALEX_BASE_URL = "https://api.openalex.org"
+
+# レートリミット: API 呼び出し間の最小間隔（秒）
+_RATE_LIMIT_INTERVAL = 1.0
+
+
+def _build_params(
+    query: str,
+    api_key: str,
+    *,
+    language: str | None = None,
+    year_from: str | None = None,
+    year_to: str | None = None,
+) -> dict:
+    """共通クエリパラメータを構築する。"""
+    params: dict[str, str] = {
+        "search": query,
+        "api_key": api_key,
+    }
+
+    # フィルタ条件の構築
+    filters: list[str] = []
+    if language:
+        filters.append(f"language:{language}")
+    if year_from and year_to:
+        filters.append(f"publication_year:{year_from}-{year_to}")
+    elif year_from:
+        filters.append(f"publication_year:{year_from}-")
+    elif year_to:
+        filters.append(f"publication_year:-{year_to}")
+
+    if filters:
+        params["filter"] = ",".join(filters)
+
+    return params
+
+
+def _aggregate_temporal(year_counts: dict[str, int]) -> dict[str, int]:
+    """個別年を3つの時代区分に集約する。
+
+    - pre-1950: 1949年以前
+    - 1950-1999: 1950〜1999年
+    - 2000-present: 2000年以降
+    """
+    aggregated: dict[str, int] = {"pre-1950": 0, "1950-1999": 0, "2000-present": 0}
+    for year_str, count in year_counts.items():
+        try:
+            year = int(year_str)
+        except ValueError:
+            continue
+        if year < 1950:
+            aggregated["pre-1950"] += count
+        elif year < 2000:
+            aggregated["1950-1999"] += count
+        else:
+            aggregated["2000-present"] += count
+    return aggregated
+
+
+def _extract_key_concepts(works: list[dict], max_concepts: int = 5) -> list[str]:
+    """上位論文から頻出概念タグを抽出する。
+
+    各論文の topics[].display_name と keywords[].display_name を集計し、
+    出現頻度上位の概念を返す。
+    """
+    concept_counter: Counter[str] = Counter()
+
+    for work in works:
+        # topics から概念を抽出
+        for topic in work.get("topics", []):
+            name = topic.get("display_name")
+            if name:
+                concept_counter[name] += 1
+
+        # keywords から概念を抽出
+        for keyword in work.get("keywords", []):
+            name = keyword.get("display_name")
+            if name:
+                concept_counter[name] += 1
+
+    return [name for name, _ in concept_counter.most_common(max_concepts)]
+
+
+def search_academic_papers(
+    query: str,
+    language: str | None = None,
+    year_from: str | None = None,
+    year_to: str | None = None,
+) -> str:
+    """OpenAlex API で学術論文を検索し、カバレッジ分析用データを返す。
+
+    3回の API 呼び出しで効率的にデータを取得:
+    1. 言語分布（group_by=language）
+    2. 年代分布（group_by=publication_year）
+    3. 被引用数上位5件の論文（概念タグ抽出用）
+
+    Args:
+        query: 検索クエリ（テーマ・キーワード）
+        language: 言語フィルタ（ISO 639-1、例: "en", "de"）
+        year_from: 開始年フィルタ（例: "1900"）
+        year_to: 終了年フィルタ（例: "2020"）
+
+    Returns:
+        JSON 文字列（論文数、言語分布、年代分布、主要概念、上位論文）
+    """
+    api_key = os.environ.get("OPENALEX_API_KEY")
+    if not api_key:
+        return json.dumps({
+            "status": "error",
+            "error": "OPENALEX_API_KEY environment variable is not set. "
+                     "Register for a free API key at https://openalex.org/",
+        })
+
+    session = create_retry_session()
+    base_params = _build_params(
+        query, api_key,
+        language=language, year_from=year_from, year_to=year_to,
+    )
+
+    try:
+        # 1. 言語分布を取得
+        lang_params = {**base_params, "group_by": "language"}
+        resp_lang = session.get(f"{OPENALEX_BASE_URL}/works", params=lang_params)
+        if resp_lang.status_code != 200:
+            return json.dumps({
+                "status": "error",
+                "error": f"OpenAlex API error (language distribution): HTTP {resp_lang.status_code}",
+            })
+        lang_data = resp_lang.json()
+
+        # 論文総数と言語分布の集計
+        papers_found = 0
+        language_distribution: dict[str, int] = {}
+        for group in lang_data.get("group_by", []):
+            key = group.get("key", "unknown")
+            count = group.get("count", 0)
+            language_distribution[key] = count
+            papers_found += count
+
+        time.sleep(_RATE_LIMIT_INTERVAL)
+
+        # 2. 年代分布を取得
+        year_params = {**base_params, "group_by": "publication_year"}
+        resp_year = session.get(f"{OPENALEX_BASE_URL}/works", params=year_params)
+        if resp_year.status_code != 200:
+            return json.dumps({
+                "status": "error",
+                "error": f"OpenAlex API error (temporal distribution): HTTP {resp_year.status_code}",
+            })
+        year_data = resp_year.json()
+
+        year_counts: dict[str, int] = {}
+        for group in year_data.get("group_by", []):
+            key = str(group.get("key", ""))
+            count = group.get("count", 0)
+            year_counts[key] = count
+
+        temporal_distribution = _aggregate_temporal(year_counts)
+
+        time.sleep(_RATE_LIMIT_INTERVAL)
+
+        # 3. 被引用数上位5件の論文を取得
+        top_params = {**base_params, "per_page": "5", "sort": "cited_by_count:desc"}
+        resp_top = session.get(f"{OPENALEX_BASE_URL}/works", params=top_params)
+        if resp_top.status_code != 200:
+            return json.dumps({
+                "status": "error",
+                "error": f"OpenAlex API error (top papers): HTTP {resp_top.status_code}",
+            })
+        top_data = resp_top.json()
+
+        works = top_data.get("results", [])
+        key_concepts = _extract_key_concepts(works)
+
+        top_papers = []
+        for work in works:
+            top_papers.append({
+                "title": work.get("title", ""),
+                "publication_year": work.get("publication_year"),
+                "cited_by_count": work.get("cited_by_count", 0),
+                "doi": work.get("doi"),
+                "language": work.get("language"),
+            })
+
+        return json.dumps({
+            "status": "ok",
+            "papers_found": papers_found,
+            "language_distribution": language_distribution,
+            "temporal_distribution": temporal_distribution,
+            "key_concepts": key_concepts,
+            "top_papers": top_papers,
+        })
+
+    except Exception as e:
+        logger.error("OpenAlex 検索エラー: %s", e)
+        return json.dumps({
+            "status": "error",
+            "error": f"OpenAlex search failed: {e}",
+        })

--- a/mystery_agents/tools/publisher_tools.py
+++ b/mystery_agents/tools/publisher_tools.py
@@ -278,7 +278,7 @@ def publish_mystery(
                     "confidence_level", "discrepancy_detected", "discrepancy_type",
                     "historical_context", "research_questions", "story_hooks",
                     "title", "summary",
-                    "source_coverage", "confidence_rationale",
+                    "source_coverage", "academic_coverage", "confidence_rationale",
                 ):
                     if key in structured_report:
                         data[key] = structured_report[key]

--- a/packages/shared/src/types/mystery.ts
+++ b/packages/shared/src/types/mystery.ts
@@ -106,6 +106,25 @@ export interface HistoricalContext {
 }
 
 /**
+ * 学術論文カバレッジ
+ * OpenAlex データに基づく学術界の分析
+ */
+export interface AcademicCoverage {
+  /** 関連論文の総数 */
+  papers_found: number;
+  /** 言語別の論文数 */
+  language_distribution: Record<string, number>;
+  /** 時代別の論文数 */
+  temporal_distribution: Record<string, number>;
+  /** 頻出概念タグ */
+  key_concepts: string[];
+  /** Polymath が特定した学術的盲点 */
+  identified_gaps: string[];
+  /** 学術的コンセンサスと一次資料の緊張関係 */
+  consensus_vs_primary?: string;
+}
+
+/**
  * ソースカバレッジ評価
  * Polymath が行う調査範囲の自己評価
  */
@@ -154,6 +173,8 @@ export interface MysteryReport {
   confidence_level: ConfidenceLevel;
   /** ソースカバレッジ評価（検索範囲と限界の自己評価） */
   source_coverage?: SourceCoverage;
+  /** 学術論文カバレッジ（OpenAlex データに基づく） */
+  academic_coverage?: AcademicCoverage;
   /** confidence_level 判定の根拠 */
   confidence_rationale?: string;
 

--- a/tests/unit/test_openalex.py
+++ b/tests/unit/test_openalex.py
@@ -1,0 +1,278 @@
+"""Unit tests for OpenAlex academic search tool."""
+
+import json
+import os
+
+import responses
+
+from mystery_agents.tools.openalex import (
+    OPENALEX_BASE_URL,
+    _aggregate_temporal,
+    _extract_key_concepts,
+    search_academic_papers,
+)
+
+
+# === テスト用レスポンスデータ ===
+
+_LANG_RESPONSE = {
+    "group_by": [
+        {"key": "en", "count": 35},
+        {"key": "de", "count": 5},
+        {"key": "ja", "count": 2},
+    ]
+}
+
+_YEAR_RESPONSE = {
+    "group_by": [
+        {"key": "1890", "count": 1},
+        {"key": "1945", "count": 2},
+        {"key": "1960", "count": 5},
+        {"key": "1985", "count": 10},
+        {"key": "2005", "count": 15},
+        {"key": "2020", "count": 9},
+    ]
+}
+
+_TOP_PAPERS_RESPONSE = {
+    "results": [
+        {
+            "title": "Salem Witch Trials: A Cultural History",
+            "publication_year": 2018,
+            "cited_by_count": 250,
+            "doi": "https://doi.org/10.1000/test1",
+            "language": "en",
+            "topics": [
+                {"display_name": "folklore"},
+                {"display_name": "cultural anthropology"},
+            ],
+            "keywords": [
+                {"display_name": "witch trials"},
+                {"display_name": "oral tradition"},
+            ],
+        },
+        {
+            "title": "Hexenprozesse und Volksglauben",
+            "publication_year": 2015,
+            "cited_by_count": 120,
+            "doi": "https://doi.org/10.1000/test2",
+            "language": "de",
+            "topics": [
+                {"display_name": "folklore"},
+                {"display_name": "social history"},
+            ],
+            "keywords": [
+                {"display_name": "witch trials"},
+            ],
+        },
+        {
+            "title": "Puritan Society and Spectral Evidence",
+            "publication_year": 2020,
+            "cited_by_count": 95,
+            "doi": "https://doi.org/10.1000/test3",
+            "language": "en",
+            "topics": [
+                {"display_name": "cultural anthropology"},
+            ],
+            "keywords": [
+                {"display_name": "spectral evidence"},
+                {"display_name": "oral tradition"},
+            ],
+        },
+    ]
+}
+
+_EMPTY_LANG_RESPONSE = {"group_by": []}
+_EMPTY_YEAR_RESPONSE = {"group_by": []}
+_EMPTY_TOP_RESPONSE = {"results": []}
+
+
+def _register_standard_responses():
+    """3つの標準 API レスポンスを登録する。"""
+    responses.add(
+        responses.GET,
+        f"{OPENALEX_BASE_URL}/works",
+        json=_LANG_RESPONSE,
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        f"{OPENALEX_BASE_URL}/works",
+        json=_YEAR_RESPONSE,
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        f"{OPENALEX_BASE_URL}/works",
+        json=_TOP_PAPERS_RESPONSE,
+        status=200,
+    )
+
+
+class TestSearchAcademicPapers:
+    """search_academic_papers 関数のテスト。"""
+
+    @responses.activate
+    def test_normal_search(self, monkeypatch):
+        """正常な検索 — 3つの API レスポンスから正しい JSON が返ること。"""
+        monkeypatch.setenv("OPENALEX_API_KEY", "test-key")
+        _register_standard_responses()
+
+        result = json.loads(search_academic_papers("Salem witch trials folklore"))
+
+        assert result["status"] == "ok"
+        assert result["papers_found"] == 42
+        assert result["language_distribution"]["en"] == 35
+        assert result["language_distribution"]["de"] == 5
+        assert result["language_distribution"]["ja"] == 2
+        assert result["temporal_distribution"]["pre-1950"] == 3
+        assert result["temporal_distribution"]["1950-1999"] == 15
+        assert result["temporal_distribution"]["2000-present"] == 24
+        assert len(result["key_concepts"]) > 0
+        assert len(result["top_papers"]) == 3
+        assert result["top_papers"][0]["title"] == "Salem Witch Trials: A Cultural History"
+
+    def test_api_key_not_set(self, monkeypatch):
+        """OPENALEX_API_KEY 未設定時のエラーメッセージ。"""
+        monkeypatch.delenv("OPENALEX_API_KEY", raising=False)
+
+        result = json.loads(search_academic_papers("test query"))
+
+        assert result["status"] == "error"
+        assert "OPENALEX_API_KEY" in result["error"]
+
+    @responses.activate
+    def test_empty_results(self, monkeypatch):
+        """空の検索結果 — papers_found=0。"""
+        monkeypatch.setenv("OPENALEX_API_KEY", "test-key")
+        responses.add(
+            responses.GET,
+            f"{OPENALEX_BASE_URL}/works",
+            json=_EMPTY_LANG_RESPONSE,
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            f"{OPENALEX_BASE_URL}/works",
+            json=_EMPTY_YEAR_RESPONSE,
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            f"{OPENALEX_BASE_URL}/works",
+            json=_EMPTY_TOP_RESPONSE,
+            status=200,
+        )
+
+        result = json.loads(search_academic_papers("nonexistent topic xyz"))
+
+        assert result["status"] == "ok"
+        assert result["papers_found"] == 0
+        assert result["language_distribution"] == {}
+        assert result["key_concepts"] == []
+        assert result["top_papers"] == []
+
+    @responses.activate
+    def test_http_500_error(self, monkeypatch):
+        """HTTP 500 エラー時のエラーハンドリング。"""
+        monkeypatch.setenv("OPENALEX_API_KEY", "test-key")
+        # リトライセッションが 500 を複数回リトライした後にエラーを返す
+        responses.add(
+            responses.GET,
+            f"{OPENALEX_BASE_URL}/works",
+            json={"error": "Internal Server Error"},
+            status=500,
+        )
+
+        result = json.loads(search_academic_papers("test query"))
+
+        assert result["status"] == "error"
+        assert "500" in result["error"]
+
+    @responses.activate
+    def test_language_and_year_filters(self, monkeypatch):
+        """言語・年代フィルタが API リクエストに反映されること。"""
+        monkeypatch.setenv("OPENALEX_API_KEY", "test-key")
+        _register_standard_responses()
+
+        search_academic_papers(
+            "Salem witch trials",
+            language="en",
+            year_from="1900",
+            year_to="2020",
+        )
+
+        # 最初のリクエストのパラメータを検証（URL エンコードされている）
+        from urllib.parse import unquote
+        first_url = unquote(responses.calls[0].request.url)
+        assert "language:en" in first_url
+        assert "publication_year:1900-2020" in first_url
+
+    @responses.activate
+    def test_api_key_in_request(self, monkeypatch):
+        """API キーがリクエストパラメータに含まれること。"""
+        monkeypatch.setenv("OPENALEX_API_KEY", "my-secret-key")
+        _register_standard_responses()
+
+        search_academic_papers("test query")
+
+        for call in responses.calls:
+            assert "api_key=my-secret-key" in call.request.url
+
+
+class TestAggregateTemporalDistribution:
+    """_aggregate_temporal 関数のテスト。"""
+
+    def test_three_ranges(self):
+        """個別年が3つの時代区分に正しく集約されること。"""
+        year_counts = {
+            "1800": 2, "1920": 3, "1949": 1,
+            "1950": 4, "1975": 6, "1999": 2,
+            "2000": 8, "2015": 10, "2025": 5,
+        }
+        result = _aggregate_temporal(year_counts)
+
+        assert result["pre-1950"] == 6
+        assert result["1950-1999"] == 12
+        assert result["2000-present"] == 23
+
+    def test_empty_input(self):
+        """空の入力に対して全レンジが0。"""
+        result = _aggregate_temporal({})
+
+        assert result["pre-1950"] == 0
+        assert result["1950-1999"] == 0
+        assert result["2000-present"] == 0
+
+    def test_invalid_year_ignored(self):
+        """数値に変換できない年は無視される。"""
+        result = _aggregate_temporal({"unknown": 5, "2020": 3})
+
+        assert result["2000-present"] == 3
+        assert result["pre-1950"] == 0
+        assert result["1950-1999"] == 0
+
+
+class TestExtractKeyConcepts:
+    """_extract_key_concepts 関数のテスト。"""
+
+    def test_frequency_ordering(self):
+        """頻出概念が正しく抽出されること。"""
+        works = _TOP_PAPERS_RESPONSE["results"]
+        concepts = _extract_key_concepts(works)
+
+        # "folklore" は 2 回、"witch trials" は 2 回、"cultural anthropology" は 2 回
+        assert len(concepts) <= 5
+        assert "folklore" in concepts
+        assert "witch trials" in concepts
+
+    def test_empty_works(self):
+        """論文がない場合は空リスト。"""
+        concepts = _extract_key_concepts([])
+        assert concepts == []
+
+    def test_max_concepts_limit(self):
+        """max_concepts パラメータが制限として機能すること。"""
+        works = _TOP_PAPERS_RESPONSE["results"]
+        concepts = _extract_key_concepts(works, max_concepts=2)
+        assert len(concepts) <= 2

--- a/web-public/src/app/[lang]/mystery/[id]/page.tsx
+++ b/web-public/src/app/[lang]/mystery/[id]/page.tsx
@@ -287,6 +287,7 @@ export default async function MysteryDetailPage({
                 classificationNotice: dict.detail.classificationNotice,
               }}
               sourceCoverage={mystery.source_coverage}
+              academicCoverage={mystery.academic_coverage}
               languagesAnalyzed={mystery.languages_analyzed}
               confidenceRationale={mystery.confidence_rationale}
               sourceCoverageLabels={dict.sourceCoverage}

--- a/web-public/src/components/mystery/detail-sidebar.tsx
+++ b/web-public/src/components/mystery/detail-sidebar.tsx
@@ -1,4 +1,4 @@
-import type { SourceCoverage } from "@ghost/shared/src/types/mystery"
+import type { SourceCoverage, AcademicCoverage } from "@ghost/shared/src/types/mystery"
 import type { Dictionary } from "@/lib/i18n/dictionaries"
 import { SourceCoverageCard } from "@/components/mystery/source-coverage-card"
 
@@ -11,6 +11,7 @@ interface DetailSidebarProps {
   storyHooks: string[]
   labels?: DetailSidebarLabels
   sourceCoverage?: SourceCoverage
+  academicCoverage?: AcademicCoverage
   languagesAnalyzed?: string[]
   confidenceRationale?: string
   sourceCoverageLabels?: Dictionary["sourceCoverage"]
@@ -21,6 +22,7 @@ export function DetailSidebar({
   storyHooks,
   labels,
   sourceCoverage,
+  academicCoverage,
   languagesAnalyzed,
   confidenceRationale,
   sourceCoverageLabels,
@@ -55,6 +57,7 @@ export function DetailSidebar({
         {sourceCoverage && sourceCoverageLabels && (
           <SourceCoverageCard
             sourceCoverage={sourceCoverage}
+            academicCoverage={academicCoverage}
             languagesAnalyzed={languagesAnalyzed}
             confidenceRationale={confidenceRationale}
             labels={sourceCoverageLabels}

--- a/web-public/src/components/mystery/source-coverage-card.tsx
+++ b/web-public/src/components/mystery/source-coverage-card.tsx
@@ -1,8 +1,9 @@
-import type { SourceCoverage } from "@ghost/shared/src/types/mystery"
+import type { SourceCoverage, AcademicCoverage } from "@ghost/shared/src/types/mystery"
 import type { Dictionary } from "@/lib/i18n/dictionaries"
 
 interface SourceCoverageCardProps {
   sourceCoverage: SourceCoverage
+  academicCoverage?: AcademicCoverage
   languagesAnalyzed?: string[]
   confidenceRationale?: string
   labels: Dictionary["sourceCoverage"]
@@ -10,6 +11,7 @@ interface SourceCoverageCardProps {
 
 export function SourceCoverageCard({
   sourceCoverage,
+  academicCoverage,
   languagesAnalyzed,
   confidenceRationale,
   labels,
@@ -52,6 +54,37 @@ export function SourceCoverageCard({
               </li>
             ))}
           </ul>
+        </div>
+      )}
+
+      {/* 学術論文カバレッジ */}
+      {academicCoverage && academicCoverage.papers_found > 0 && (
+        <div className="mb-3">
+          <p className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground mb-1.5">
+            {labels.academicPapers}
+          </p>
+          <p className="text-xs text-foreground/70 font-mono mb-1.5">
+            {academicCoverage.papers_found.toLocaleString()} papers
+          </p>
+          {Object.keys(academicCoverage.language_distribution).length > 0 && (
+            <div className="flex flex-wrap gap-1.5 mb-1.5">
+              {Object.entries(academicCoverage.language_distribution)
+                .sort(([, a], [, b]) => b - a)
+                .map(([lang, count]) => (
+                  <span
+                    key={lang}
+                    className="inline-flex px-1.5 py-0.5 rounded text-[10px] font-mono uppercase tracking-wider bg-foreground/5 text-foreground/60 border border-border"
+                  >
+                    {lang}: {count}
+                  </span>
+                ))}
+            </div>
+          )}
+          {academicCoverage.consensus_vs_primary && (
+            <p className="text-xs text-foreground/70 leading-relaxed mt-1.5">
+              {academicCoverage.consensus_vs_primary}
+            </p>
+          )}
         </div>
       )}
 

--- a/web-public/src/lib/i18n/dictionaries/de.ts
+++ b/web-public/src/lib/i18n/dictionaries/de.ts
@@ -152,6 +152,7 @@ const dict: Dictionary = {
     heading: "Untersuchungsumfang",
     languagesAnalyzed: "Analysierte Sprachen",
     apisSearched: "Durchsuchte Archive",
+    academicPapers: "Akademische Publikationen",
     coverageNote: "Diese Analyse basiert auf Materialien, die über die oben aufgeführten digitalen Archiv-APIs verfügbar sind.",
     confidenceRationale: "Bewertungsgrundlage",
   },

--- a/web-public/src/lib/i18n/dictionaries/en.ts
+++ b/web-public/src/lib/i18n/dictionaries/en.ts
@@ -151,6 +151,7 @@ const dict: Dictionary = {
     heading: "Investigation Scope",
     languagesAnalyzed: "Languages Analyzed",
     apisSearched: "Archives Searched",
+    academicPapers: "Academic Papers",
     coverageNote: "This analysis is based on materials available through the digital archive APIs listed above.",
     confidenceRationale: "Assessment Rationale",
   },

--- a/web-public/src/lib/i18n/dictionaries/es.ts
+++ b/web-public/src/lib/i18n/dictionaries/es.ts
@@ -152,6 +152,7 @@ const dict: Dictionary = {
     heading: "Alcance de la investigación",
     languagesAnalyzed: "Idiomas analizados",
     apisSearched: "Archivos consultados",
+    academicPapers: "Artículos académicos",
     coverageNote: "Este análisis se basa en materiales disponibles a través de las APIs de archivos digitales mencionadas.",
     confidenceRationale: "Fundamento de la evaluación",
   },

--- a/web-public/src/lib/i18n/dictionaries/fr.ts
+++ b/web-public/src/lib/i18n/dictionaries/fr.ts
@@ -152,6 +152,7 @@ const dict: Dictionary = {
     heading: "Portée de l'investigation",
     languagesAnalyzed: "Langues analysées",
     apisSearched: "Archives consultées",
+    academicPapers: "Articles académiques",
     coverageNote: "Cette analyse repose sur les matériaux accessibles via les APIs d'archives numériques mentionnées ci-dessus.",
     confidenceRationale: "Fondement de l'évaluation",
   },

--- a/web-public/src/lib/i18n/dictionaries/ja.ts
+++ b/web-public/src/lib/i18n/dictionaries/ja.ts
@@ -151,6 +151,7 @@ const dict: Dictionary = {
     heading: "調査範囲",
     languagesAnalyzed: "分析言語",
     apisSearched: "検索アーカイブ",
+    academicPapers: "学術論文",
     coverageNote: "本分析は上記のデジタルアーカイブAPIで取得可能な資料に基づいています。",
     confidenceRationale: "判定根拠",
   },

--- a/web-public/src/lib/i18n/dictionaries/nl.ts
+++ b/web-public/src/lib/i18n/dictionaries/nl.ts
@@ -152,6 +152,7 @@ const dict: Dictionary = {
     heading: "Onderzoeksomvang",
     languagesAnalyzed: "Geanalyseerde talen",
     apisSearched: "Doorzochte archieven",
+    academicPapers: "Academische publicaties",
     coverageNote: "Deze analyse is gebaseerd op materialen die beschikbaar zijn via de hierboven genoemde digitale archief-API's.",
     confidenceRationale: "Beoordelingsgrondslag",
   },

--- a/web-public/src/lib/i18n/dictionaries/pt.ts
+++ b/web-public/src/lib/i18n/dictionaries/pt.ts
@@ -152,6 +152,7 @@ const dict: Dictionary = {
     heading: "Alcance da investigação",
     languagesAnalyzed: "Idiomas analisados",
     apisSearched: "Arquivos pesquisados",
+    academicPapers: "Artigos acadêmicos",
     coverageNote: "Esta análise baseia-se em materiais disponíveis através das APIs de arquivos digitais listadas acima.",
     confidenceRationale: "Fundamento da avaliação",
   },

--- a/web-public/src/lib/i18n/dictionaries/types.ts
+++ b/web-public/src/lib/i18n/dictionaries/types.ts
@@ -134,6 +134,7 @@ export interface Dictionary {
     heading: string;
     languagesAnalyzed: string;
     apisSearched: string;
+    academicPapers: string;
     coverageNote: string;
     confidenceRationale: string;
   };


### PR DESCRIPTION
## Summary

Armchair Polymath が学術界のカバレッジと盲点を**実際の論文データに基づいて**客観的に評価できるよう、OpenAlex API を使った学術論文検索ツールを新設し、パイプラインに統合。

- **OpenAlex ツール新設** (`mystery_agents/tools/openalex.py`): 3回の API 呼び出しで言語分布・年代分布・主要概念・被引用上位論文を取得
- **AcademicCoverage スキーマ追加**: `MysteryReport` の独立フィールドとして追加（Python + TypeScript）
- **Polymath instruction 更新**: `search_academic_papers` の使用ガイドライン + `academic_coverage` を structured_report テンプレートに追加
- **Storyteller instruction 更新**: 学術的文脈の活用ガイドライン追記
- **Publisher**: `academic_coverage` をオーバーレイキーに追加
- **フロントエンド**: SourceCoverageCard に学術論文セクション追加（7言語 i18n 対応）
- **テスト**: 12 テストケース（全 892 テスト通過）

### 設計判断
- OpenAlex ツールは ArchiveSource を継承しない（Polymath 専用、source_registry に登録しない）
- API キー未設定時はエラーを返すが、Polymath は学術カバレッジなしで続行可能（フォールバック）
- `academic_coverage` は `source_coverage` と並列の独立フィールド

Closes #228

## Test plan
- [x] `python -m pytest tests/unit/test_openalex.py -v` — 12 テスト通過
- [x] `python -m pytest tests/unit/ -v` — 全 892 テスト通過（回帰なし）
- [ ] `.env` に `OPENALEX_API_KEY` を設定し手動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)