### PR TITLE
fix: 管理画面の記事リンク・言語バグ修正

### DIFF
--- a/web-admin/src/app/(main)/page.tsx
+++ b/web-admin/src/app/(main)/page.tsx
@@ -499,7 +499,7 @@ function AdminMysteryCard({ mystery, lang, onApprove, onArchive, onUnpublish }: 
           <>
             <div className="flex items-center gap-3">
               <a
-                href={`${process.env.NEXT_PUBLIC_SITE_URL || ""}/en/mystery/${mystery.mystery_id}`}
+                href={`${process.env.NEXT_PUBLIC_SITE_URL || ""}/${lang}/mystery/${mystery.mystery_id}`}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-2 text-sm text-gold hover:text-parchment transition-colors no-underline"

--- a/web-admin/src/app/(main)/preview/[id]/preview-content.tsx
+++ b/web-admin/src/app/(main)/preview/[id]/preview-content.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { useState, useEffect } from "react"
 import Link from "next/link"
 import Image from "next/image"
 import { EvidenceBlock } from "@ghost/shared/src/components/evidence-block"
@@ -39,13 +38,7 @@ interface PreviewContentProps {
 }
 
 export function PreviewContent({ mystery }: PreviewContentProps) {
-  const { lang: globalLang } = useLanguage()
-  const [lang, setLang] = useState<PreviewLang>(globalLang)
-
-  // グローバル言語が初期化された場合に同期（SSR→クライアント遷移時）
-  useEffect(() => {
-    setLang(globalLang)
-  }, [globalLang])
+  const { lang, setLang } = useLanguage()
 
   // translations map に存在する言語
   const availableLangs = Object.keys(mystery.translations ?? {})


### PR DESCRIPTION
## Summary

- View Published リンクの言語が `/en/` にハードコードされていた問題を `/${lang}/` に修正し、グローバル言語セレクタと連動するようにした
- プレビューページがローカルの言語状態を持っていたため、ヘッダーのグローバル言語セレクタと同期しなかった問題を修正（`useLanguage()` を直接使用）
- `.env.production` に `NEXT_PUBLIC_SITE_URL` を追加し、View Published リンクが公開サイトドメインに正しく飛ぶようにした（git 管理外）

## Test plan

- [ ] 管理画面で published 記事の「View Published」リンクが `ghostinthearchive.ai/{lang}/mystery/...` に飛ぶことを確認
- [ ] グローバル言語セレクタで言語変更 → リンクの言語部分が追従することを確認
- [ ] プレビューページを開いた際にグローバル言語設定が反映されることを確認
- [ ] プレビューバナーの言語セレクタで言語変更 → ヘッダーの言語セレクタにも反映されることを確認
- [x] `pytest tests/unit/ -v` — 878 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)