### PR TITLE
fix: スケルトン外部ファイル化 + error.tsx 追加

### DIFF
--- a/web-public/src/app/[lang]/archive/[[...page]]/loading.tsx
+++ b/web-public/src/app/[lang]/archive/[[...page]]/loading.tsx
@@ -1,0 +1,33 @@
+/**
+ * アーカイブページのローディング UI
+ * 言語切り替え時のページ遷移中に表示される
+ */
+import { MysteryGridSkeleton } from "@/components/mystery-list-skeleton"
+
+export default function ArchiveLoading() {
+  return (
+    <div className="min-h-screen flex flex-col film-grain">
+      {/* Header skeleton */}
+      <div className="h-16 border-b border-border/50" />
+
+      <main className="flex-1">
+        <section className="py-16 md:py-24">
+          <div className="container mx-auto px-4">
+            {/* 見出しスケルトン */}
+            <div className="mb-12">
+              <div className="flex items-center gap-3 mb-4">
+                <div className="w-6 h-6 bg-muted/20 rounded-sm animate-pulse" />
+                <div className="h-9 w-48 bg-muted/20 rounded-sm animate-pulse" />
+              </div>
+              <div className="h-4 w-80 bg-muted/15 rounded-sm animate-pulse" />
+              <div className="mt-4 h-px bg-gradient-to-r from-border to-transparent" />
+            </div>
+
+            {/* グリッドスケルトン */}
+            <MysteryGridSkeleton />
+          </div>
+        </section>
+      </main>
+    </div>
+  )
+}

--- a/web-public/src/app/[lang]/error.tsx
+++ b/web-public/src/app/[lang]/error.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import { usePathname } from "next/navigation"
+import { AlertTriangle } from "lucide-react"
+
+/**
+ * クライアントサイドエラーバウンダリ
+ * 英語ハードコード — エラー表示中に辞書読み込みが失敗するリスクを回避
+ */
+export default function ErrorPage({
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  const pathname = usePathname()
+  const lang = pathname.split("/")[1] || "en"
+
+  return (
+    <div className="min-h-screen flex flex-col film-grain">
+      {/* 簡易ヘッダー（高さのみ合わせる） */}
+      <div className="h-16 border-b border-border/50" />
+
+      <main className="flex-1 flex items-center justify-center">
+        <div className="text-center px-4">
+          <AlertTriangle className="h-12 w-12 text-gold mx-auto mb-6" />
+          <h1 className="font-serif text-2xl md:text-3xl text-parchment mb-3">
+            Something went wrong
+          </h1>
+          <p className="text-muted-foreground mb-8 max-w-md mx-auto">
+            An unexpected error occurred. Please try again or return to the home page.
+          </p>
+          <div className="flex items-center justify-center gap-4">
+            <button
+              onClick={reset}
+              className="px-6 py-2 border border-border rounded-sm text-parchment hover:bg-muted/20 transition-colors"
+            >
+              Try again
+            </button>
+            <a
+              href={`/${lang}`}
+              className="px-6 py-2 border border-gold/50 rounded-sm text-gold hover:bg-gold/10 transition-colors no-underline"
+            >
+              Return home
+            </a>
+          </div>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/web-public/src/app/[lang]/page.tsx
+++ b/web-public/src/app/[lang]/page.tsx
@@ -3,9 +3,8 @@ import { notFound } from "next/navigation"
 import { Header } from "@/components/header"
 import { PublicFooter } from "@/components/public-footer"
 import { FeaturedMysteryCard } from "@/components/featured-mystery-card"
-import { FeaturedMysteryCardSkeleton } from "@/components/featured-mystery-card-skeleton"
 import { MysteryCard } from "@/components/mystery-card"
-import { MysteryCardSkeleton } from "@/components/mystery-card-skeleton"
+import { MysteryListSkeleton } from "@/components/mystery-list-skeleton"
 import { getPublishedMysteries } from "@ghost/shared/src/lib/firestore/queries"
 import { HOMEPAGE_MYSTERY_LIMIT } from "@/lib/constants"
 import Link from "next/link"
@@ -78,21 +77,6 @@ async function MysteryList({ lang, dict }: { lang: SupportedLang; dict: Dictiona
           </div>
         </>
       )}
-    </>
-  )
-}
-
-function MysteryListSkeleton() {
-  return (
-    <>
-      <div className="mb-12">
-        <FeaturedMysteryCardSkeleton />
-      </div>
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {[...Array(6)].map((_, i) => (
-          <MysteryCardSkeleton key={i} />
-        ))}
-      </div>
     </>
   )
 }

--- a/web-public/src/components/mystery-list-skeleton.tsx
+++ b/web-public/src/components/mystery-list-skeleton.tsx
@@ -1,0 +1,33 @@
+import { FeaturedMysteryCardSkeleton } from "@/components/featured-mystery-card-skeleton"
+import { MysteryCardSkeleton } from "@/components/mystery-card-skeleton"
+
+/**
+ * ホームページ用スケルトン — Featured カード + グリッド
+ */
+export function MysteryListSkeleton() {
+  return (
+    <>
+      <div className="mb-12">
+        <FeaturedMysteryCardSkeleton />
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {[...Array(6)].map((_, i) => (
+          <MysteryCardSkeleton key={i} />
+        ))}
+      </div>
+    </>
+  )
+}
+
+/**
+ * アーカイブページ用スケルトン — グリッドのみ
+ */
+export function MysteryGridSkeleton({ count = 12 }: { count?: number }) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      {[...Array(count)].map((_, i) => (
+        <MysteryCardSkeleton key={i} />
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- `MysteryListSkeleton` / `MysteryGridSkeleton` を `mystery-list-skeleton.tsx` に分離し、ホームページのインライン定義を import に切り替え
- アーカイブページに `loading.tsx` を追加（言語切り替え時のスケルトン表示）
- `[lang]/error.tsx` を追加（クライアントサイドエラー時の白画面を防止）

## 変更内容

| ファイル | 種別 | 内容 |
|----------|------|------|
| `web-public/src/components/mystery-list-skeleton.tsx` | 新規 | `MysteryListSkeleton`（ホーム用） + `MysteryGridSkeleton`（アーカイブ用） |
| `web-public/src/app/[lang]/page.tsx` | 変更 | インラインスケルトン削除 + import 切り替え |
| `web-public/src/app/[lang]/archive/[[...page]]/loading.tsx` | 新規 | アーカイブページ遷移時ローディング |
| `web-public/src/app/[lang]/error.tsx` | 新規 | クライアントサイドエラーバウンダリ |

## Test plan

- [ ] `npm run build --prefix web-public` で SSG ビルドが成功すること
- [ ] ホームページの Suspense fallback が正しく表示されること
- [ ] アーカイブページの言語切り替え時に loading.tsx スケルトンが表示されること
- [ ] error.tsx: "Try again" ボタンと "Return home" リンクが正しく動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)