### PR TITLE
fix: テーマ提案 API のタイムアウトを 120秒→240秒に延長

### DIFF
--- a/web-admin/src/app/api/themes/suggest/route.ts
+++ b/web-admin/src/app/api/themes/suggest/route.ts
@@ -34,7 +34,7 @@ export async function POST() {
         "Content-Type": "application/json",
         ...authHeaders,
       },
-      signal: AbortSignal.timeout(120000),
+      signal: AbortSignal.timeout(240000),
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary
- テーマ提案 API (`/api/themes/suggest`) の `fetch` タイムアウトを 120秒→240秒に延長
- Curator サービスのコールドスタート + 2回の LLM 呼び出しで 120秒を超えるケースがあり、`TimeoutError` (code 23) が発生していた
- Cloud Run の curator サービスタイムアウト（300秒）より短い 240秒に設定し、十分なマージンを確保

## Test plan
- [ ] 管理画面からテーマ提案を実行し、タイムアウトせずに結果が返ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)