### PR TITLE
refactor: AdminPage コンポーネント分割 + トースト共通化

### DIFF
--- a/web-admin/src/app/(main)/page.tsx
+++ b/web-admin/src/app/(main)/page.tsx
@@ -1,33 +1,22 @@
 "use client"
 
 import { useEffect, useState, useCallback, useRef, useMemo } from "react"
-import Link from "next/link"
-import { StatusBadge } from "@/components/status-badge"
 import { cn } from "@ghost/shared/src/lib/utils"
-import { Button } from "@ghost/shared/src/components/ui/button"
-import { getAllMysteries, approveMystery, archiveMystery, unpublishMystery } from "@/lib/firestore/mysteries"
-import type { FirestoreMystery, MysteryStatus, PipelineRun } from "@ghost/shared/src/types/mystery"
-import { localizeMystery } from "@ghost/shared/src/lib/localize"
+import { getAllMysteries } from "@/lib/firestore/mysteries"
+import type { FirestoreMystery, PipelineRun } from "@ghost/shared/src/types/mystery"
+import { AdminMysteryCard } from "@/components/admin-mystery-card"
+import { ActionToast } from "@/components/action-toast"
+import { InvestigationForm } from "@/components/investigation-form"
 import { ActivePipelinePanel } from "@/components/active-pipeline-panel"
 import { usePipelineRuns } from "@/hooks/use-pipeline-runs"
 import { usePipelineRun } from "@/hooks/use-pipeline-run"
+import { useMysteryActions } from "@/hooks/use-mystery-actions"
+import { useInvestigation } from "@/hooks/use-investigation"
 import { useLanguage } from "@/contexts/language-context"
-import type { PreviewLang } from "@/components/language-selector"
 import {
   Shield,
-  FileText,
-  CheckCircle,
-  XCircle,
-  Eye,
-  EyeOff,
-  Clock,
-  MapPin,
   Filter,
-  RefreshCw,
   Inbox,
-  Loader2,
-  Search,
-  Sparkles,
 } from "lucide-react"
 
 type FilterStatus = "all" | "pending" | "published" | "archived"
@@ -37,12 +26,6 @@ export default function AdminPage() {
   const [filter, setFilter] = useState<FilterStatus>("all")
   const [mysteries, setMysteries] = useState<FirestoreMystery[]>([])
   const [loading, setLoading] = useState(true)
-  const [actionFeedback, setActionFeedback] = useState<string | null>(null)
-  const [actionFeedbackIsError, setActionFeedbackIsError] = useState(false)
-  const [themeInput, setThemeInput] = useState("")
-  const [suggestions, setSuggestions] = useState<{ theme: string; description: string; theme_ja?: string; description_ja?: string }[]>([])
-  const [suggestLoading, setSuggestLoading] = useState(false)
-  const [pipelineLoading, setPipelineLoading] = useState(false)
   const [currentRunId, setCurrentRunId] = useState<string | null>(null)
   const [dismissedRunIds, setDismissedRunIds] = useState<Set<string>>(new Set())
 
@@ -100,6 +83,15 @@ export default function AdminPage() {
     }
   }, [dismissRunning, currentRunId])
 
+  // 記事アクション（Approve / Archive / Unpublish）
+  const { actions, feedback: actionFeedback } = useMysteryActions({ onSuccess: fetchMysteries })
+
+  // 新規調査（パイプライン開始 / テーマ提案）
+  const investigation = useInvestigation({ onPipelineStarted: setCurrentRunId })
+
+  // 直近のアクティブなフィードバックを表示
+  const activeFeedback = investigation.feedback.message ? investigation.feedback : actionFeedback
+
   const filteredMysteries = filter === "all"
     ? mysteries
     : mysteries.filter((m) => m.status === filter)
@@ -109,125 +101,6 @@ export default function AdminPage() {
     pending: mysteries.filter((m) => m.status === "pending").length,
     published: mysteries.filter((m) => m.status === "published").length,
     archived: mysteries.filter((m) => m.status === "archived").length,
-  }
-
-  // リビルド失敗は approve/archive の成否に影響しない（fire-and-forget）
-  const triggerRebuild = async () => {
-    try {
-      await fetch("/api/deployments/rebuild", { method: "POST" })
-    } catch (error) {
-      console.error("Failed to trigger rebuild:", error)
-    }
-  }
-
-  const handleApprove = async (id: string) => {
-    try {
-      await approveMystery(id)
-      setActionFeedback(`Case ${id} approved and published`)
-      setActionFeedbackIsError(false)
-      fetchMysteries()
-      triggerRebuild()
-      setTimeout(() => setActionFeedback(null), 3000)
-    } catch (error) {
-      console.error("Failed to approve:", error)
-      const message = error instanceof Error ? error.message : "不明なエラー"
-      setActionFeedback(`承認に失敗しました: ${message}`)
-      setActionFeedbackIsError(true)
-      setTimeout(() => setActionFeedback(null), 5000)
-    }
-  }
-
-  const handleArchive = async (id: string) => {
-    try {
-      await archiveMystery(id)
-      setActionFeedback(`Case ${id} archived`)
-      setActionFeedbackIsError(false)
-      fetchMysteries()
-      triggerRebuild()
-      setTimeout(() => setActionFeedback(null), 3000)
-    } catch (error) {
-      console.error("Failed to archive:", error)
-      const message = error instanceof Error ? error.message : "不明なエラー"
-      setActionFeedback(`アーカイブに失敗しました: ${message}`)
-      setActionFeedbackIsError(true)
-      setTimeout(() => setActionFeedback(null), 5000)
-    }
-  }
-
-  const handleUnpublish = async (id: string) => {
-    if (!window.confirm("この記事を非公開に戻しますか？公開サイトから削除されます。")) return
-    try {
-      await unpublishMystery(id)
-      setActionFeedback(`Case ${id} unpublished`)
-      setActionFeedbackIsError(false)
-      fetchMysteries()
-      triggerRebuild()
-      setTimeout(() => setActionFeedback(null), 3000)
-    } catch (error) {
-      console.error("Failed to unpublish:", error)
-      const message = error instanceof Error ? error.message : "不明なエラー"
-      setActionFeedback(`非公開への変更に失敗しました: ${message}`)
-      setActionFeedbackIsError(true)
-      setTimeout(() => setActionFeedback(null), 5000)
-    }
-  }
-
-  const handleStartPipeline = async () => {
-    if (!themeInput.trim()) return
-    setPipelineLoading(true)
-    try {
-      const res = await fetch("/api/mysteries/investigate", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ query: themeInput.trim() }),
-      })
-      if (!res.ok) {
-        const errorData = await res.json().catch(() => ({}))
-        throw new Error(errorData.detail || errorData.error || `API error (${res.status})`)
-      }
-      const data = await res.json()
-      if (data.run_id) {
-        setCurrentRunId(data.run_id)
-      }
-      setActionFeedback("調査パイプラインを開始しました")
-      setActionFeedbackIsError(false)
-      setThemeInput("")
-      setSuggestions([])
-      setTimeout(() => setActionFeedback(null), 3000)
-    } catch (error) {
-      console.error("Failed to start pipeline:", error)
-      const message = error instanceof Error ? error.message : "不明なエラー"
-      setActionFeedback(`パイプラインの開始に失敗しました: ${message}`)
-      setActionFeedbackIsError(true)
-      setTimeout(() => setActionFeedback(null), 5000)
-    } finally {
-      setPipelineLoading(false)
-    }
-  }
-
-  const handleSuggestThemes = async () => {
-    setSuggestLoading(true)
-    setSuggestions([])
-    try {
-      const res = await fetch("/api/themes/suggest", { method: "POST" })
-      if (!res.ok) {
-        const errorData = await res.json().catch(() => ({}))
-        if (errorData.error_type === "auth_error") {
-          throw new Error("Google Cloud の認証が切れています。サーバーで再認証を実行してください。")
-        }
-        throw new Error(errorData.detail || errorData.error || `API error (${res.status})`)
-      }
-      const data = await res.json()
-      setSuggestions(Array.isArray(data.suggestions) ? data.suggestions : [])
-    } catch (error) {
-      console.error("Failed to get suggestions:", error)
-      const message = error instanceof Error ? error.message : "不明なエラー"
-      setActionFeedback(`テーマ提案の取得に失敗しました: ${message}`)
-      setActionFeedbackIsError(true)
-      setTimeout(() => setActionFeedback(null), 5000)
-    } finally {
-      setSuggestLoading(false)
-    }
   }
 
   return (
@@ -254,82 +127,21 @@ export default function AdminPage() {
         </div>
 
         {/* New Investigation section */}
-        <div className="aged-card letterpress-border rounded-sm p-5 mb-8">
-          <h2 className="font-serif text-xl text-parchment mb-4">
-            新規調査
-          </h2>
-          <div className="flex gap-3 mb-3">
-            <input
-              type="text"
-              value={themeInput}
-              onChange={(e) => setThemeInput(e.target.value)}
-              onKeyDown={(e) => { if (e.key === "Enter") handleStartPipeline() }}
-              placeholder="調査テーマを入力（例: 1840年代のボストンにおけるスペイン関連の歴史的矛盾を調査せよ）"
-              className="flex-1 px-3 py-2 bg-background border border-border rounded-sm text-sm text-parchment placeholder:text-muted-foreground focus:outline-none focus:border-gold/50"
-            />
-            <Button
-              size="sm"
-              onClick={handleStartPipeline}
-              disabled={!themeInput.trim() || pipelineLoading}
-              className="bg-teal/20 border border-teal/30 text-[#5fb3a1] hover:bg-teal/30"
-            >
-              {pipelineLoading ? (
-                <Loader2 className="w-4 h-4 mr-1 animate-spin" />
-              ) : (
-                <Search className="w-4 h-4 mr-1" />
-              )}
-              調査開始
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleSuggestThemes}
-              disabled={suggestLoading}
-              className="border-gold/30 text-gold hover:bg-gold/20 hover:text-gold bg-transparent"
-            >
-              {suggestLoading ? (
-                <Loader2 className="w-4 h-4 mr-1 animate-spin" />
-              ) : (
-                <Sparkles className="w-4 h-4 mr-1" />
-              )}
-              テーマ提案
-            </Button>
-          </div>
-          {suggestions.length > 0 && (
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-2 mt-4">
-              {suggestions.map((s, i) => (
-                <button
-                  key={i}
-                  onClick={() => { setThemeInput(s.theme); setSuggestions([]) }}
-                  className="text-left p-3 border border-border/50 rounded-sm hover:border-gold/30 hover:bg-gold/5 transition-colors"
-                >
-                  <p className="text-sm font-medium text-parchment mb-1">{s.theme}</p>
-                  {s.theme_ja && (
-                    <p className="text-xs text-muted-foreground mb-1">{s.theme_ja}</p>
-                  )}
-                  <p className="text-xs text-muted-foreground">{s.description_ja || s.description}</p>
-                </button>
-              ))}
-            </div>
-          )}
-        </div>
+        <InvestigationForm
+          themeInput={investigation.themeInput}
+          onThemeInputChange={investigation.setThemeInput}
+          suggestions={investigation.suggestions}
+          onSelectSuggestion={(theme) => {
+            investigation.setThemeInput(theme)
+            investigation.clearSuggestions()
+          }}
+          suggestLoading={investigation.suggestLoading}
+          pipelineLoading={investigation.pipelineLoading}
+          onStartPipeline={investigation.handleStartPipeline}
+          onSuggestThemes={investigation.handleSuggestThemes}
+        />
 
-        {/* Action feedback toast */}
-        {actionFeedback && (
-          <div className={cn(
-            "fixed top-20 right-4 z-50 px-4 py-3 rounded-sm animate-in fade-in slide-in-from-right-5",
-            actionFeedbackIsError
-              ? "bg-blood-red/10 border border-blood-red/30"
-              : "bg-teal/20 border border-teal/30"
-          )}>
-            <p className={cn(
-              "text-sm font-mono",
-              actionFeedbackIsError ? "text-[#ff6b6b]" : "text-[#5fb3a1]"
-            )}>
-              {actionFeedback}
-            </p>
-          </div>
-        )}
+        <ActionToast message={activeFeedback.message} isError={activeFeedback.isError} />
 
         {/* 実行中のパイプライン */}
         {mergedRuns.length > 0 && (
@@ -430,143 +242,14 @@ export default function AdminPage() {
                 key={mystery.mystery_id}
                 mystery={mystery}
                 lang={lang}
-                onApprove={() => handleApprove(mystery.mystery_id)}
-                onArchive={() => handleArchive(mystery.mystery_id)}
-                onUnpublish={() => handleUnpublish(mystery.mystery_id)}
+                onApprove={() => actions.handleApprove(mystery.mystery_id)}
+                onArchive={() => actions.handleArchive(mystery.mystery_id)}
+                onUnpublish={() => actions.handleUnpublish(mystery.mystery_id)}
               />
             ))}
           </div>
         )}
       </div>
     </div>
-  )
-}
-
-interface AdminMysteryCardProps {
-  mystery: FirestoreMystery
-  lang: PreviewLang
-  onApprove: () => void
-  onArchive: () => void
-  onUnpublish: () => void
-}
-
-function AdminMysteryCard({ mystery, lang, onApprove, onArchive, onUnpublish }: AdminMysteryCardProps) {
-  const isPending = mystery.status === "pending"
-  const location = mystery.historical_context?.geographic_scope?.[0] || ""
-  const timePeriod = mystery.historical_context?.time_period || ""
-  const { title, summary } = localizeMystery(mystery, lang)
-
-  return (
-    <article className="aged-card letterpress-border rounded-sm p-5">
-      {/* Header */}
-      <div className="flex items-start justify-between gap-4 mb-4">
-        <div className="flex items-center gap-2 text-xs text-muted-foreground font-mono">
-          <FileText className="w-3.5 h-3.5 text-gold" />
-          <span>{mystery.mystery_id}</span>
-        </div>
-        <StatusBadge status={mystery.status} />
-      </div>
-
-      {/* タイトル（グローバル言語設定に連動） */}
-      <h3 className="font-serif text-lg text-parchment mb-1 leading-tight">
-        {title}
-      </h3>
-
-      {/* サマリー（グローバル言語設定に連動） */}
-      <p className="text-sm text-foreground/80 leading-relaxed mb-4 line-clamp-2">
-        {summary}
-      </p>
-
-      {/* Metadata */}
-      <div className="flex items-center gap-4 text-xs text-muted-foreground mb-4 pb-4 border-b border-border/50">
-        {location && (
-          <span className="flex items-center gap-1">
-            <MapPin className="w-3 h-3" />
-            {location}
-          </span>
-        )}
-        {timePeriod && (
-          <span className="flex items-center gap-1">
-            <Clock className="w-3 h-3" />
-            {timePeriod}
-          </span>
-        )}
-      </div>
-
-      {/* Actions */}
-      <div className="flex items-center justify-between gap-4">
-        {mystery.status === "published" ? (
-          <>
-            <div className="flex items-center gap-3">
-              <a
-                href={`${process.env.NEXT_PUBLIC_SITE_URL || ""}/${lang}/mystery/${mystery.mystery_id}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 text-sm text-gold hover:text-parchment transition-colors no-underline"
-              >
-                <Eye className="w-4 h-4" />
-                View Published
-              </a>
-            </div>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={onUnpublish}
-              className="border-blood-red/30 text-[#ff6b6b] hover:bg-blood-red/20 hover:text-[#ff6b6b] bg-transparent"
-            >
-              <EyeOff className="w-4 h-4 mr-1" />
-              Unpublish
-            </Button>
-          </>
-        ) : (
-          <div className="flex items-center gap-3">
-            <Link
-              href={`/preview/${mystery.mystery_id}`}
-              className="inline-flex items-center gap-2 text-sm text-gold hover:text-parchment transition-colors no-underline"
-            >
-              <Eye className="w-4 h-4" />
-              Preview
-            </Link>
-            <span className="text-xs text-muted-foreground">
-              Created: {mystery.createdAt.toLocaleDateString()}
-            </span>
-          </div>
-        )}
-
-        {isPending && (
-          <div className="flex items-center gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={onArchive}
-              className="border-blood-red/30 text-[#ff6b6b] hover:bg-blood-red/20 hover:text-[#ff6b6b] bg-transparent"
-            >
-              <XCircle className="w-4 h-4 mr-1" />
-              Archive
-            </Button>
-            <Button
-              size="sm"
-              onClick={onApprove}
-              className="bg-teal/20 border border-teal/30 text-[#5fb3a1] hover:bg-teal/30"
-            >
-              <CheckCircle className="w-4 h-4 mr-1" />
-              Approve
-            </Button>
-          </div>
-        )}
-
-        {mystery.status === "archived" && (
-          <Button
-            variant="ghost"
-            size="sm"
-            className="text-muted-foreground hover:text-parchment"
-          >
-            <RefreshCw className="w-4 h-4 mr-1" />
-            Reconsider
-          </Button>
-        )}
-
-      </div>
-    </article>
   )
 }

--- a/web-admin/src/app/(main)/podcasts/[id]/podcast-detail.tsx
+++ b/web-admin/src/app/(main)/podcasts/[id]/podcast-detail.tsx
@@ -2,14 +2,15 @@
 
 import { useState, useCallback, useRef, useEffect } from "react"
 import Link from "next/link"
-import { cn } from "@ghost/shared/src/lib/utils"
 import { Button } from "@ghost/shared/src/components/ui/button"
 import { usePodcast } from "@/hooks/use-podcast"
 import { usePipelineRun } from "@/hooks/use-pipeline-run"
+import { useActionFeedback } from "@/hooks/use-action-feedback"
 import { updatePodcastScript } from "@/lib/firestore/podcasts"
 import { PodcastStatusBadge } from "@/components/podcast-status-badge"
 import { AudioPlayer } from "@/components/audio-player"
 import { ScriptEditor } from "@/components/script-editor"
+import { ActionToast } from "@/components/action-toast"
 import { ActivePipelinePanel } from "@/components/active-pipeline-panel"
 import type { PodcastScript } from "@ghost/shared/src/types/mystery"
 import {
@@ -32,8 +33,7 @@ export function PodcastDetail({ podcastId }: PodcastDetailProps) {
   const [editedScript, setEditedScript] = useState<PodcastScript | null>(null)
   const [saving, setSaving] = useState(false)
   const [audioGenerating, setAudioGenerating] = useState(false)
-  const [feedback, setFeedback] = useState<string | null>(null)
-  const [feedbackIsError, setFeedbackIsError] = useState(false)
+  const feedback = useActionFeedback()
   const hasUnsavedChanges = useRef(false)
 
   // podcast のステータスが audio_generating に変わったらローカルの generating フラグもリセット
@@ -54,15 +54,11 @@ export function PodcastDetail({ podcastId }: PodcastDetailProps) {
     try {
       await updatePodcastScript(podcastId, editedScript)
       hasUnsavedChanges.current = false
-      setFeedback("脚本を保存しました")
-      setFeedbackIsError(false)
-      setTimeout(() => setFeedback(null), 3000)
+      feedback.showSuccess("脚本を保存しました")
     } catch (error) {
       console.error("Failed to save script:", error)
       const message = error instanceof Error ? error.message : "不明なエラー"
-      setFeedback(`脚本の保存に失敗しました: ${message}`)
-      setFeedbackIsError(true)
-      setTimeout(() => setFeedback(null), 5000)
+      feedback.showError(`脚本の保存に失敗しました: ${message}`)
     } finally {
       setSaving(false)
     }
@@ -87,16 +83,12 @@ export function PodcastDetail({ podcastId }: PodcastDetailProps) {
         const errorData = await res.json().catch(() => ({}))
         throw new Error(errorData.detail || errorData.error || `API error (${res.status})`)
       }
-      setFeedback("音声生成を開始しました")
-      setFeedbackIsError(false)
-      setTimeout(() => setFeedback(null), 3000)
+      feedback.showSuccess("音声生成を開始しました")
     } catch (error) {
       console.error("Failed to generate audio:", error)
       setAudioGenerating(false)
       const message = error instanceof Error ? error.message : "不明なエラー"
-      setFeedback(`音声生成の開始に失敗しました: ${message}`)
-      setFeedbackIsError(true)
-      setTimeout(() => setFeedback(null), 5000)
+      feedback.showError(`音声生成の開始に失敗しました: ${message}`)
     }
   }, [podcast, podcastId, editedScript])
 
@@ -120,9 +112,7 @@ export function PodcastDetail({ podcastId }: PodcastDetailProps) {
     } catch (error) {
       console.error("Failed to retry:", error)
       const message = error instanceof Error ? error.message : "不明なエラー"
-      setFeedback(`再試行に失敗しました: ${message}`)
-      setFeedbackIsError(true)
-      setTimeout(() => setFeedback(null), 5000)
+      feedback.showError(`再試行に失敗しました: ${message}`)
     }
   }, [podcast])
 
@@ -156,20 +146,7 @@ export function PodcastDetail({ podcastId }: PodcastDetailProps) {
   return (
     <div className="py-8 md:py-12">
       <div className="container mx-auto px-4">
-        {/* フィードバック */}
-        {feedback && (
-          <div className={cn(
-            "fixed top-20 right-4 z-50 px-4 py-3 rounded-sm animate-in fade-in slide-in-from-right-5",
-            feedbackIsError
-              ? "bg-blood-red/10 border border-blood-red/30"
-              : "bg-teal/20 border border-teal/30"
-          )}>
-            <p className={cn(
-              "text-sm font-mono",
-              feedbackIsError ? "text-[#ff6b6b]" : "text-[#5fb3a1]"
-            )}>{feedback}</p>
-          </div>
-        )}
+        <ActionToast message={feedback.message} isError={feedback.isError} />
 
         {/* パンくずリスト */}
         <div className="flex items-center gap-4 mb-8">

--- a/web-admin/src/app/(main)/podcasts/page.tsx
+++ b/web-admin/src/app/(main)/podcasts/page.tsx
@@ -7,8 +7,10 @@ import { Button } from "@ghost/shared/src/components/ui/button"
 import { getAllPodcasts } from "@/lib/firestore/podcasts"
 import { getAllMysteries } from "@/lib/firestore/mysteries"
 import { PodcastCard } from "@/components/podcast-card"
+import { ActionToast } from "@/components/action-toast"
 import { ActivePipelinePanel } from "@/components/active-pipeline-panel"
 import { usePipelineRuns } from "@/hooks/use-pipeline-runs"
+import { useActionFeedback } from "@/hooks/use-action-feedback"
 import type { FirestorePodcast, PodcastStatus, FirestoreMystery } from "@ghost/shared/src/types/mystery"
 import {
   Mic,
@@ -29,8 +31,7 @@ export default function PodcastsPage() {
   const [selectedMysteryId, setSelectedMysteryId] = useState("")
   const [customInstructions, setCustomInstructions] = useState("")
   const [generating, setGenerating] = useState(false)
-  const [feedback, setFeedback] = useState<string | null>(null)
-  const [feedbackIsError, setFeedbackIsError] = useState(false)
+  const feedback = useActionFeedback()
 
   // Podcast タイプのパイプラインのみ表示
   const { runs: runningPipelines, dismiss: dismissRunning } = usePipelineRuns()
@@ -98,17 +99,13 @@ export default function PodcastsPage() {
       if (data.podcast_id) {
         router.push(`/podcasts/${data.podcast_id}`)
       } else {
-        setFeedback("脚本生成を開始しました")
-        setFeedbackIsError(false)
+        feedback.showSuccess("脚本生成を開始しました")
         fetchData()
-        setTimeout(() => setFeedback(null), 3000)
       }
     } catch (error) {
       console.error("Failed to generate script:", error)
       const message = error instanceof Error ? error.message : "不明なエラー"
-      setFeedback(`脚本生成の開始に失敗しました: ${message}`)
-      setFeedbackIsError(true)
-      setTimeout(() => setFeedback(null), 5000)
+      feedback.showError(`脚本生成の開始に失敗しました: ${message}`)
     } finally {
       setGenerating(false)
     }
@@ -193,20 +190,7 @@ export default function PodcastsPage() {
           </div>
         </div>
 
-        {/* フィードバック */}
-        {feedback && (
-          <div className={cn(
-            "fixed top-20 right-4 z-50 px-4 py-3 rounded-sm animate-in fade-in slide-in-from-right-5",
-            feedbackIsError
-              ? "bg-blood-red/10 border border-blood-red/30"
-              : "bg-teal/20 border border-teal/30"
-          )}>
-            <p className={cn(
-              "text-sm font-mono",
-              feedbackIsError ? "text-[#ff6b6b]" : "text-[#5fb3a1]"
-            )}>{feedback}</p>
-          </div>
-        )}
+        <ActionToast message={feedback.message} isError={feedback.isError} />
 
         {/* 実行中のパイプライン */}
         {podcastRuns.length > 0 && (

--- a/web-admin/src/components/action-toast.tsx
+++ b/web-admin/src/components/action-toast.tsx
@@ -1,0 +1,26 @@
+import { cn } from "@ghost/shared/src/lib/utils"
+
+interface ActionToastProps {
+  message: string | null
+  isError: boolean
+}
+
+export function ActionToast({ message, isError }: ActionToastProps) {
+  if (!message) return null
+
+  return (
+    <div className={cn(
+      "fixed top-20 right-4 z-50 px-4 py-3 rounded-sm animate-in fade-in slide-in-from-right-5",
+      isError
+        ? "bg-blood-red/10 border border-blood-red/30"
+        : "bg-teal/20 border border-teal/30"
+    )}>
+      <p className={cn(
+        "text-sm font-mono",
+        isError ? "text-[#ff6b6b]" : "text-[#5fb3a1]"
+      )}>
+        {message}
+      </p>
+    </div>
+  )
+}

--- a/web-admin/src/components/admin-mystery-card.tsx
+++ b/web-admin/src/components/admin-mystery-card.tsx
@@ -1,0 +1,145 @@
+import Link from "next/link"
+import { StatusBadge } from "@/components/status-badge"
+import { Button } from "@ghost/shared/src/components/ui/button"
+import { localizeMystery } from "@ghost/shared/src/lib/localize"
+import type { FirestoreMystery } from "@ghost/shared/src/types/mystery"
+import type { PreviewLang } from "@/components/language-selector"
+import {
+  FileText,
+  CheckCircle,
+  XCircle,
+  Eye,
+  EyeOff,
+  Clock,
+  MapPin,
+  RefreshCw,
+} from "lucide-react"
+
+interface AdminMysteryCardProps {
+  mystery: FirestoreMystery
+  lang: PreviewLang
+  onApprove: () => void
+  onArchive: () => void
+  onUnpublish: () => void
+}
+
+export function AdminMysteryCard({ mystery, lang, onApprove, onArchive, onUnpublish }: AdminMysteryCardProps) {
+  const isPending = mystery.status === "pending"
+  const location = mystery.historical_context?.geographic_scope?.[0] || ""
+  const timePeriod = mystery.historical_context?.time_period || ""
+  const { title, summary } = localizeMystery(mystery, lang)
+
+  return (
+    <article className="aged-card letterpress-border rounded-sm p-5">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4 mb-4">
+        <div className="flex items-center gap-2 text-xs text-muted-foreground font-mono">
+          <FileText className="w-3.5 h-3.5 text-gold" />
+          <span>{mystery.mystery_id}</span>
+        </div>
+        <StatusBadge status={mystery.status} />
+      </div>
+
+      {/* タイトル（グローバル言語設定に連動） */}
+      <h3 className="font-serif text-lg text-parchment mb-1 leading-tight">
+        {title}
+      </h3>
+
+      {/* サマリー（グローバル言語設定に連動） */}
+      <p className="text-sm text-foreground/80 leading-relaxed mb-4 line-clamp-2">
+        {summary}
+      </p>
+
+      {/* Metadata */}
+      <div className="flex items-center gap-4 text-xs text-muted-foreground mb-4 pb-4 border-b border-border/50">
+        {location && (
+          <span className="flex items-center gap-1">
+            <MapPin className="w-3 h-3" />
+            {location}
+          </span>
+        )}
+        {timePeriod && (
+          <span className="flex items-center gap-1">
+            <Clock className="w-3 h-3" />
+            {timePeriod}
+          </span>
+        )}
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center justify-between gap-4">
+        {mystery.status === "published" ? (
+          <>
+            <div className="flex items-center gap-3">
+              <a
+                href={`${process.env.NEXT_PUBLIC_SITE_URL || ""}/${lang}/mystery/${mystery.mystery_id}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 text-sm text-gold hover:text-parchment transition-colors no-underline"
+              >
+                <Eye className="w-4 h-4" />
+                View Published
+              </a>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onUnpublish}
+              className="border-blood-red/30 text-[#ff6b6b] hover:bg-blood-red/20 hover:text-[#ff6b6b] bg-transparent"
+            >
+              <EyeOff className="w-4 h-4 mr-1" />
+              Unpublish
+            </Button>
+          </>
+        ) : (
+          <div className="flex items-center gap-3">
+            <Link
+              href={`/preview/${mystery.mystery_id}`}
+              className="inline-flex items-center gap-2 text-sm text-gold hover:text-parchment transition-colors no-underline"
+            >
+              <Eye className="w-4 h-4" />
+              Preview
+            </Link>
+            <span className="text-xs text-muted-foreground">
+              Created: {mystery.createdAt.toLocaleDateString()}
+            </span>
+          </div>
+        )}
+
+        {isPending && (
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onArchive}
+              className="border-blood-red/30 text-[#ff6b6b] hover:bg-blood-red/20 hover:text-[#ff6b6b] bg-transparent"
+            >
+              <XCircle className="w-4 h-4 mr-1" />
+              Archive
+            </Button>
+            <Button
+              size="sm"
+              onClick={onApprove}
+              className="bg-teal/20 border border-teal/30 text-[#5fb3a1] hover:bg-teal/30"
+            >
+              <CheckCircle className="w-4 h-4 mr-1" />
+              Approve
+            </Button>
+          </div>
+        )}
+
+        {mystery.status === "archived" && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-muted-foreground hover:text-parchment"
+          >
+            <RefreshCw className="w-4 h-4 mr-1" />
+            Reconsider
+          </Button>
+        )}
+
+      </div>
+    </article>
+  )
+}

--- a/web-admin/src/components/investigation-form.tsx
+++ b/web-admin/src/components/investigation-form.tsx
@@ -1,0 +1,97 @@
+import { Button } from "@ghost/shared/src/components/ui/button"
+import {
+  Loader2,
+  Search,
+  Sparkles,
+} from "lucide-react"
+
+interface ThemeSuggestion {
+  theme: string
+  description: string
+  theme_ja?: string
+  description_ja?: string
+}
+
+interface InvestigationFormProps {
+  themeInput: string
+  onThemeInputChange: (value: string) => void
+  suggestions: ThemeSuggestion[]
+  onSelectSuggestion: (theme: string) => void
+  suggestLoading: boolean
+  pipelineLoading: boolean
+  onStartPipeline: () => void
+  onSuggestThemes: () => void
+}
+
+export function InvestigationForm({
+  themeInput,
+  onThemeInputChange,
+  suggestions,
+  onSelectSuggestion,
+  suggestLoading,
+  pipelineLoading,
+  onStartPipeline,
+  onSuggestThemes,
+}: InvestigationFormProps) {
+  return (
+    <div className="aged-card letterpress-border rounded-sm p-5 mb-8">
+      <h2 className="font-serif text-xl text-parchment mb-4">
+        新規調査
+      </h2>
+      <div className="flex gap-3 mb-3">
+        <input
+          type="text"
+          value={themeInput}
+          onChange={(e) => onThemeInputChange(e.target.value)}
+          onKeyDown={(e) => { if (e.key === "Enter") onStartPipeline() }}
+          placeholder="調査テーマを入力（例: 1840年代のボストンにおけるスペイン関連の歴史的矛盾を調査せよ）"
+          className="flex-1 px-3 py-2 bg-background border border-border rounded-sm text-sm text-parchment placeholder:text-muted-foreground focus:outline-none focus:border-gold/50"
+        />
+        <Button
+          size="sm"
+          onClick={onStartPipeline}
+          disabled={!themeInput.trim() || pipelineLoading}
+          className="bg-teal/20 border border-teal/30 text-[#5fb3a1] hover:bg-teal/30"
+        >
+          {pipelineLoading ? (
+            <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+          ) : (
+            <Search className="w-4 h-4 mr-1" />
+          )}
+          調査開始
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onSuggestThemes}
+          disabled={suggestLoading}
+          className="border-gold/30 text-gold hover:bg-gold/20 hover:text-gold bg-transparent"
+        >
+          {suggestLoading ? (
+            <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+          ) : (
+            <Sparkles className="w-4 h-4 mr-1" />
+          )}
+          テーマ提案
+        </Button>
+      </div>
+      {suggestions.length > 0 && (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-2 mt-4">
+          {suggestions.map((s, i) => (
+            <button
+              key={i}
+              onClick={() => onSelectSuggestion(s.theme)}
+              className="text-left p-3 border border-border/50 rounded-sm hover:border-gold/30 hover:bg-gold/5 transition-colors"
+            >
+              <p className="text-sm font-medium text-parchment mb-1">{s.theme}</p>
+              {s.theme_ja && (
+                <p className="text-xs text-muted-foreground mb-1">{s.theme_ja}</p>
+              )}
+              <p className="text-xs text-muted-foreground">{s.description_ja || s.description}</p>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web-admin/src/hooks/use-action-feedback.ts
+++ b/web-admin/src/hooks/use-action-feedback.ts
@@ -1,0 +1,46 @@
+"use client"
+
+import { useState, useRef, useCallback } from "react"
+
+export interface ActionFeedback {
+  message: string | null
+  isError: boolean
+  showSuccess: (msg: string) => void
+  showError: (msg: string) => void
+  clear: () => void
+}
+
+export function useActionFeedback(): ActionFeedback {
+  const [message, setMessage] = useState<string | null>(null)
+  const [isError, setIsError] = useState(false)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+  }, [])
+
+  const clear = useCallback(() => {
+    clearTimer()
+    setMessage(null)
+    setIsError(false)
+  }, [clearTimer])
+
+  const showSuccess = useCallback((msg: string) => {
+    clearTimer()
+    setMessage(msg)
+    setIsError(false)
+    timerRef.current = setTimeout(() => setMessage(null), 3000)
+  }, [clearTimer])
+
+  const showError = useCallback((msg: string) => {
+    clearTimer()
+    setMessage(msg)
+    setIsError(true)
+    timerRef.current = setTimeout(() => setMessage(null), 5000)
+  }, [clearTimer])
+
+  return { message, isError, showSuccess, showError, clear }
+}

--- a/web-admin/src/hooks/use-investigation.ts
+++ b/web-admin/src/hooks/use-investigation.ts
@@ -1,0 +1,91 @@
+"use client"
+
+import { useState, useCallback } from "react"
+import { useActionFeedback, type ActionFeedback } from "@/hooks/use-action-feedback"
+
+interface ThemeSuggestion {
+  theme: string
+  description: string
+  theme_ja?: string
+  description_ja?: string
+}
+
+interface UseInvestigationOptions {
+  onPipelineStarted: (runId: string) => void
+}
+
+export function useInvestigation({ onPipelineStarted }: UseInvestigationOptions) {
+  const [themeInput, setThemeInput] = useState("")
+  const [suggestions, setSuggestions] = useState<ThemeSuggestion[]>([])
+  const [suggestLoading, setSuggestLoading] = useState(false)
+  const [pipelineLoading, setPipelineLoading] = useState(false)
+  const feedback = useActionFeedback()
+
+  const clearSuggestions = useCallback(() => {
+    setSuggestions([])
+  }, [])
+
+  const handleStartPipeline = useCallback(async () => {
+    if (!themeInput.trim()) return
+    setPipelineLoading(true)
+    try {
+      const res = await fetch("/api/mysteries/investigate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ query: themeInput.trim() }),
+      })
+      if (!res.ok) {
+        const errorData = await res.json().catch(() => ({}))
+        throw new Error(errorData.detail || errorData.error || `API error (${res.status})`)
+      }
+      const data = await res.json()
+      if (data.run_id) {
+        onPipelineStarted(data.run_id)
+      }
+      feedback.showSuccess("調査パイプラインを開始しました")
+      setThemeInput("")
+      setSuggestions([])
+    } catch (error) {
+      console.error("Failed to start pipeline:", error)
+      const message = error instanceof Error ? error.message : "不明なエラー"
+      feedback.showError(`パイプラインの開始に失敗しました: ${message}`)
+    } finally {
+      setPipelineLoading(false)
+    }
+  }, [themeInput, feedback, onPipelineStarted])
+
+  const handleSuggestThemes = useCallback(async () => {
+    setSuggestLoading(true)
+    setSuggestions([])
+    try {
+      const res = await fetch("/api/themes/suggest", { method: "POST" })
+      if (!res.ok) {
+        const errorData = await res.json().catch(() => ({}))
+        if (errorData.error_type === "auth_error") {
+          throw new Error("Google Cloud の認証が切れています。サーバーで再認証を実行してください。")
+        }
+        throw new Error(errorData.detail || errorData.error || `API error (${res.status})`)
+      }
+      const data = await res.json()
+      setSuggestions(Array.isArray(data.suggestions) ? data.suggestions : [])
+    } catch (error) {
+      console.error("Failed to get suggestions:", error)
+      const message = error instanceof Error ? error.message : "不明なエラー"
+      feedback.showError(`テーマ提案の取得に失敗しました: ${message}`)
+    } finally {
+      setSuggestLoading(false)
+    }
+  }, [feedback])
+
+  return {
+    themeInput,
+    setThemeInput,
+    suggestions,
+    clearSuggestions,
+    suggestLoading,
+    pipelineLoading,
+    handleStartPipeline,
+    handleSuggestThemes,
+    feedback,
+  }
+}

--- a/web-admin/src/hooks/use-mystery-actions.ts
+++ b/web-admin/src/hooks/use-mystery-actions.ts
@@ -1,0 +1,67 @@
+"use client"
+
+import { useCallback } from "react"
+import { approveMystery, archiveMystery, unpublishMystery } from "@/lib/firestore/mysteries"
+import { useActionFeedback, type ActionFeedback } from "@/hooks/use-action-feedback"
+
+interface UseMysteryActionsOptions {
+  onSuccess: () => void
+}
+
+export function useMysteryActions({ onSuccess }: UseMysteryActionsOptions) {
+  const feedback = useActionFeedback()
+
+  // リビルド失敗は approve/archive の成否に影響しない（fire-and-forget）
+  const triggerRebuild = async () => {
+    try {
+      await fetch("/api/deployments/rebuild", { method: "POST" })
+    } catch (error) {
+      console.error("Failed to trigger rebuild:", error)
+    }
+  }
+
+  const handleApprove = useCallback(async (id: string) => {
+    try {
+      await approveMystery(id)
+      feedback.showSuccess(`Case ${id} approved and published`)
+      onSuccess()
+      triggerRebuild()
+    } catch (error) {
+      console.error("Failed to approve:", error)
+      const message = error instanceof Error ? error.message : "不明なエラー"
+      feedback.showError(`承認に失敗しました: ${message}`)
+    }
+  }, [feedback, onSuccess])
+
+  const handleArchive = useCallback(async (id: string) => {
+    try {
+      await archiveMystery(id)
+      feedback.showSuccess(`Case ${id} archived`)
+      onSuccess()
+      triggerRebuild()
+    } catch (error) {
+      console.error("Failed to archive:", error)
+      const message = error instanceof Error ? error.message : "不明なエラー"
+      feedback.showError(`アーカイブに失敗しました: ${message}`)
+    }
+  }, [feedback, onSuccess])
+
+  const handleUnpublish = useCallback(async (id: string) => {
+    if (!window.confirm("この記事を非公開に戻しますか？公開サイトから削除されます。")) return
+    try {
+      await unpublishMystery(id)
+      feedback.showSuccess(`Case ${id} unpublished`)
+      onSuccess()
+      triggerRebuild()
+    } catch (error) {
+      console.error("Failed to unpublish:", error)
+      const message = error instanceof Error ? error.message : "不明なエラー"
+      feedback.showError(`非公開への変更に失敗しました: ${message}`)
+    }
+  }, [feedback, onSuccess])
+
+  return {
+    actions: { handleApprove, handleArchive, handleUnpublish },
+    feedback,
+  }
+}


### PR DESCRIPTION
## Summary

- AdminPage（572行 → 255行）をコンポーネント分割し、useState 12個 → 5個に削減
- 3ページで完全重複していたトースト通知パターンを `useActionFeedback` + `ActionToast` に共通化
- `useMysteryActions` / `useInvestigation` フックで関連ロジックを集約

## 変更ファイル

| ファイル | 操作 | 行数 |
|---|---|---|
| `hooks/use-action-feedback.ts` | 新規 | 46行 |
| `hooks/use-mystery-actions.ts` | 新規 | 67行 |
| `hooks/use-investigation.ts` | 新規 | 91行 |
| `components/action-toast.tsx` | 新規 | 26行 |
| `components/admin-mystery-card.tsx` | 新規 | 145行 |
| `components/investigation-form.tsx` | 新規 | 97行 |
| `app/(main)/page.tsx` | 変更 | 572→255行 |
| `app/(main)/podcasts/page.tsx` | 変更 | 微修正 |
| `app/(main)/podcasts/[id]/podcast-detail.tsx` | 変更 | 微修正 |

## Test plan

- [x] `npx tsc --noEmit` — 型チェック通過
- [x] `npx next build` — ビルド成功（全11ルート正常）
- [ ] 管理画面で記事一覧の表示・フィルタ切り替え確認
- [ ] 記事の Approve / Archive / Unpublish → トースト表示確認
- [ ] 新規調査フォームの入力・テーマ提案・パイプライン開始確認
- [ ] Podcast ページの脚本生成 → トースト表示確認
- [ ] Podcast 詳細ページの脚本保存・音声生成 → トースト表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)