### PR TITLE
fix: 目次の重複表示 + React key 警告を修正

### DIFF
--- a/web-public/src/app/[lang]/mystery/[id]/page.tsx
+++ b/web-public/src/app/[lang]/mystery/[id]/page.tsx
@@ -195,7 +195,7 @@ export default async function MysteryDetailPage({
           )}
 
           {/* モバイル目次（Hero 画像下、Grid の前） */}
-          <TableOfContents sections={tocSections} heading={dict.detail.tableOfContents} />
+          <TableOfContents sections={tocSections} heading={dict.detail.tableOfContents} variant="mobile" />
 
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 lg:gap-12">
             {/* Main content */}
@@ -293,7 +293,7 @@ export default async function MysteryDetailPage({
               sourceCoverageLabels={dict.sourceCoverage}
             >
               {/* デスクトップ目次（サイドバー内） */}
-              <TableOfContents sections={tocSections} heading={dict.detail.tableOfContents} />
+              <TableOfContents sections={tocSections} heading={dict.detail.tableOfContents} variant="desktop" />
             </DetailSidebar>
           </div>
 

--- a/web-public/src/components/table-of-contents.tsx
+++ b/web-public/src/components/table-of-contents.tsx
@@ -19,6 +19,7 @@ export interface TocSection {
 interface TableOfContentsProps {
   sections: TocSection[]
   heading: string
+  variant: "mobile" | "desktop"
 }
 
 function TocLinks({
@@ -50,7 +51,7 @@ function TocLinks({
   )
 }
 
-export function TableOfContents({ sections, heading }: TableOfContentsProps) {
+export function TableOfContents({ sections, heading, variant }: TableOfContentsProps) {
   const [activeId, setActiveId] = useState<string | null>(null)
 
   useEffect(() => {
@@ -78,31 +79,30 @@ export function TableOfContents({ sections, heading }: TableOfContentsProps) {
     if (el) el.scrollIntoView({ behavior: "smooth" })
   }
 
+  if (variant === "desktop") {
+    return (
+      <div className="aged-card letterpress-border rounded-sm p-5">
+        <h3 className="font-mono text-xs uppercase tracking-wider text-muted-foreground mb-4 flex items-center gap-2">
+          <List className="w-3.5 h-3.5" />
+          {heading}
+        </h3>
+        <TocLinks sections={sections} activeId={activeId} onClick={scrollTo} />
+      </div>
+    )
+  }
+
+  // variant === "mobile"
   return (
-    <>
-      {/* デスクトップ版: サイドバー内で表示 */}
-      <div className="hidden lg:block">
-        <div className="aged-card letterpress-border rounded-sm p-5">
-          <h3 className="font-mono text-xs uppercase tracking-wider text-muted-foreground mb-4 flex items-center gap-2">
-            <List className="w-3.5 h-3.5" />
-            {heading}
-          </h3>
+    <div className="lg:hidden mb-8">
+      <details className="aged-card letterpress-border rounded-sm">
+        <summary className="px-5 py-3 cursor-pointer font-mono text-xs uppercase tracking-wider text-muted-foreground flex items-center gap-2">
+          <List className="w-3.5 h-3.5" />
+          {heading}
+        </summary>
+        <div className="px-5 pb-4">
           <TocLinks sections={sections} activeId={activeId} onClick={scrollTo} />
         </div>
-      </div>
-
-      {/* モバイル版: details/summary トグル */}
-      <div className="lg:hidden mb-8">
-        <details className="aged-card letterpress-border rounded-sm">
-          <summary className="px-5 py-3 cursor-pointer font-mono text-xs uppercase tracking-wider text-muted-foreground flex items-center gap-2">
-            <List className="w-3.5 h-3.5" />
-            {heading}
-          </summary>
-          <div className="px-5 pb-4">
-            <TocLinks sections={sections} activeId={activeId} onClick={scrollTo} />
-          </div>
-        </details>
-      </div>
-    </>
+      </details>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary

- `TableOfContents` に `variant` prop（`"mobile"` | `"desktop"`）を追加し、各配置箇所で1種類のみレンダリングするように変更
- 内部の `hidden lg:block` / `lg:hidden` の両方レンダリングを廃止し、`TocLinks` インスタンスを 4→2 に削減
- デスクトップ: サイドバーにのみ目次表示、モバイル: Hero 画像下にのみ目次（details/summary）表示

## 変更ファイル

- `web-public/src/components/table-of-contents.tsx` — `variant` prop 追加、条件分岐で単一バリアントのみレンダリング
- `web-public/src/app/[lang]/mystery/[id]/page.tsx` — 各配置箇所に `variant="mobile"` / `variant="desktop"` を指定

## Test plan

- [ ] デスクトップ: mystery 詳細ページでサイドバーにのみ目次が表示されること
- [ ] モバイル: Hero 画像下にのみ目次（details/summary）が表示されること
- [ ] ブラウザコンソールに React key 重複警告が出ないこと
- [ ] TypeScript 型チェック成功（✓ 確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)