### PR TITLE
feat: 分類索引フィルタリング（ビルド時 JSON インデックス + クライアントサイドフィルタ）

### DIFF
--- a/web-public/package.json
+++ b/web-public/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "postbuild": "npx tsx scripts/generate-sitemap.ts && npx tsx scripts/generate-feed.ts",
+    "postbuild": "npx tsx scripts/generate-sitemap.ts && npx tsx scripts/generate-feed.ts && npx tsx scripts/generate-search-index.ts",
     "start": "npx serve out",
     "preview": "next build && npx serve out -l 3000",
     "lint": "eslint"

--- a/web-public/scripts/generate-search-index.ts
+++ b/web-public/scripts/generate-search-index.ts
@@ -1,0 +1,138 @@
+/**
+ * 検索インデックス (search-index.json) 生成スクリプト
+ * next build (output: "export") 後に out/ ディレクトリから記事情報を抽出して生成
+ *
+ * 分類フィルタリング等のクライアントサイド機能で使用
+ *
+ * 使用方法: npx tsx scripts/generate-search-index.ts
+ */
+
+import fs from "fs"
+import path from "path"
+
+const OUT_DIR = path.resolve(__dirname, "../out")
+const SUPPORTED_LANGS = ["en", "ja", "es", "de", "fr", "nl", "pt"]
+
+interface MysteryI18n {
+  title: string
+  summary: string
+}
+
+interface MysteryEntry {
+  id: string
+  classification: string
+  thumbnail: string | null
+  publishedAt: string
+  i18n: Record<string, MysteryI18n>
+}
+
+interface SearchIndex {
+  mysteries: MysteryEntry[]
+}
+
+/**
+ * out/en/mystery/ から mystery_id 一覧を取得
+ */
+function collectMysteryIds(): string[] {
+  const mysteryDir = path.join(OUT_DIR, "en", "mystery")
+  if (!fs.existsSync(mysteryDir)) {
+    console.warn(`[search-index] ${mysteryDir} が見つかりません。記事がない可能性があります。`)
+    return []
+  }
+
+  return fs
+    .readdirSync(mysteryDir, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name)
+}
+
+/**
+ * HTML ファイルからメタデータを抽出
+ */
+function extractMetadata(htmlPath: string): {
+  title: string
+  summary: string
+  publishedAt: string
+  thumbnail: string | null
+} {
+  const html = fs.readFileSync(htmlPath, "utf-8")
+
+  // <title> からタイトルを抽出（" | Ghost in the Archive" サフィックス除去）
+  const titleMatch = html.match(/<title>([^<]+)<\/title>/)
+  const rawTitle = titleMatch?.[1] || ""
+  const title = rawTitle.replace(/\s*\|\s*Ghost in the Archive$/, "")
+
+  // meta description から summary を抽出
+  const descMatch = html.match(/<meta name="description" content="([^"]*)"/)
+  const summary = descMatch?.[1] || ""
+
+  // JSON-LD から datePublished を抽出
+  const publishedMatch = html.match(/"datePublished"\s*:\s*"([^"]+)"/)
+  const publishedAt = publishedMatch?.[1] || ""
+
+  // og:image からサムネイル URL を抽出
+  const ogImageMatch = html.match(/<meta property="og:image" content="([^"]*)"/)
+  const ogImage = ogImageMatch?.[1] || null
+
+  return { title, summary, publishedAt, thumbnail: ogImage }
+}
+
+/**
+ * 全言語の記事データを収集し、検索インデックスを生成
+ */
+function generateIndex(): SearchIndex {
+  const mysteryIds = collectMysteryIds()
+  const mysteries: MysteryEntry[] = []
+
+  for (const id of mysteryIds) {
+    const classification = id.slice(0, 3).toUpperCase()
+    let publishedAt = ""
+    let thumbnail: string | null = null
+    const i18n: Record<string, MysteryI18n> = {}
+
+    for (const lang of SUPPORTED_LANGS) {
+      const htmlPath = path.join(OUT_DIR, lang, "mystery", id, "index.html")
+      if (!fs.existsSync(htmlPath)) continue
+
+      const meta = extractMetadata(htmlPath)
+
+      // 英語版から publishedAt と thumbnail を取得
+      if (lang === "en") {
+        publishedAt = meta.publishedAt
+        thumbnail = meta.thumbnail
+      }
+
+      i18n[lang] = {
+        title: meta.title,
+        summary: meta.summary,
+      }
+    }
+
+    // 少なくとも英語版が存在する場合のみ追加
+    if (i18n["en"]) {
+      mysteries.push({ id, classification, thumbnail, publishedAt, i18n })
+    }
+  }
+
+  // 新しい記事を先頭にソート
+  mysteries.sort(
+    (a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime()
+  )
+
+  return { mysteries }
+}
+
+// メイン処理
+const index = generateIndex()
+
+// out/api/ ディレクトリを作成
+const apiDir = path.join(OUT_DIR, "api")
+if (!fs.existsSync(apiDir)) {
+  fs.mkdirSync(apiDir, { recursive: true })
+}
+
+const outputPath = path.join(apiDir, "search-index.json")
+fs.writeFileSync(outputPath, JSON.stringify(index), "utf-8")
+console.log(
+  `[search-index] ${outputPath} を生成しました（${index.mysteries.length} エントリ）`
+)

--- a/web-public/src/app/[lang]/archive/[[...page]]/page.tsx
+++ b/web-public/src/app/[lang]/archive/[[...page]]/page.tsx
@@ -1,8 +1,10 @@
+import { Suspense } from "react"
 import { notFound } from "next/navigation"
 import { Header } from "@/components/header"
 import { PublicFooter } from "@/components/public-footer"
 import { MysteryCard } from "@/components/mystery-card"
 import { Pagination } from "@/components/pagination"
+import { ArchiveFilter } from "@/components/archive-filter"
 import { getPublishedMysteries, getAllPublishedMysteriesMap } from "@ghost/shared/src/lib/firestore/queries"
 import { ARCHIVE_PAGE_SIZE } from "@/lib/constants"
 import { FileStack, Search } from "lucide-react"
@@ -99,35 +101,42 @@ export default async function ArchivePage({
               <div className="mt-4 h-px bg-gradient-to-r from-border to-transparent" />
             </div>
 
-            {/* 記事グリッド or 空状態 */}
-            {pageMysteries.length === 0 ? (
-              <div className="text-center py-16">
-                <Search className="h-12 w-12 text-muted-foreground mx-auto mb-4" aria-hidden="true" />
-                <h2 className="font-serif text-xl text-parchment mb-2">
-                  {dict.archive.noArticles}
-                </h2>
-              </div>
-            ) : (
-              <>
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                  {pageMysteries.map((mystery) => (
-                    <MysteryCard
-                      key={mystery.mystery_id}
-                      mystery={mystery}
-                      lang={lang as SupportedLang}
-                      classificationLabels={dict.classification}
-                    />
-                  ))}
-                </div>
+            {/* 分類フィルタ（?c= パラメータ使用時） */}
+            <Suspense fallback={null}>
+              <ArchiveFilter lang={lang as SupportedLang} dict={dict} />
+            </Suspense>
 
-                <Pagination
-                  currentPage={currentPage}
-                  totalPages={totalPages}
-                  basePath={`/${lang}/archive`}
-                  labels={dict.archive}
-                />
-              </>
-            )}
+            {/* SSG 記事グリッド（フィルタ未使用時に表示） */}
+            <div className="archive-default-content">
+              {pageMysteries.length === 0 ? (
+                <div className="text-center py-16">
+                  <Search className="h-12 w-12 text-muted-foreground mx-auto mb-4" aria-hidden="true" />
+                  <h2 className="font-serif text-xl text-parchment mb-2">
+                    {dict.archive.noArticles}
+                  </h2>
+                </div>
+              ) : (
+                <>
+                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                    {pageMysteries.map((mystery) => (
+                      <MysteryCard
+                        key={mystery.mystery_id}
+                        mystery={mystery}
+                        lang={lang as SupportedLang}
+                        classificationLabels={dict.classification}
+                      />
+                    ))}
+                  </div>
+
+                  <Pagination
+                    currentPage={currentPage}
+                    totalPages={totalPages}
+                    basePath={`/${lang}/archive`}
+                    labels={dict.archive}
+                  />
+                </>
+              )}
+            </div>
           </div>
         </section>
       </main>

--- a/web-public/src/components/archive-filter.tsx
+++ b/web-public/src/components/archive-filter.tsx
@@ -1,0 +1,225 @@
+"use client"
+
+import { useSearchParams, useRouter } from "next/navigation"
+import { useEffect, useState } from "react"
+import Image from "next/image"
+import Link from "next/link"
+import { FileText, X, Filter } from "lucide-react"
+import { cn } from "@ghost/shared/src/lib/utils"
+import type { SupportedLang } from "@/lib/i18n/config"
+import type { Dictionary } from "@/lib/i18n/dictionaries"
+
+type ClassificationCode = "HIS" | "FLK" | "ANT" | "OCC" | "URB" | "CRM" | "REL" | "LOC"
+
+const VALID_CODES = new Set<string>(["HIS", "FLK", "ANT", "OCC", "URB", "CRM", "REL", "LOC"])
+
+const badgeColorMap: Record<ClassificationCode, string> = {
+  HIS: "bg-amber-900/30 text-amber-400",
+  FLK: "bg-teal-900/30 text-teal-400",
+  ANT: "bg-orange-900/30 text-orange-400",
+  OCC: "bg-purple-900/30 text-purple-400",
+  URB: "bg-slate-700/30 text-slate-400",
+  CRM: "bg-red-900/30 text-red-400",
+  REL: "bg-indigo-900/30 text-indigo-400",
+  LOC: "bg-emerald-900/30 text-emerald-400",
+}
+
+interface MysteryI18n {
+  title: string
+  summary: string
+}
+
+interface MysteryEntry {
+  id: string
+  classification: string
+  thumbnail: string | null
+  publishedAt: string
+  i18n: Record<string, MysteryI18n>
+}
+
+interface ArchiveFilterProps {
+  lang: SupportedLang
+  dict: Dictionary
+}
+
+/**
+ * クライアントサイドの分類フィルタコンポーネント
+ * ?c=HIS 等のクエリパラメータを読み取り、search-index.json からフィルタ結果を表示
+ */
+export function ArchiveFilter({ lang, dict }: ArchiveFilterProps) {
+  const searchParams = useSearchParams()
+  const router = useRouter()
+  const filterCode = searchParams.get("c")?.toUpperCase() || null
+  const [mysteries, setMysteries] = useState<MysteryEntry[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(false)
+
+  // 有効な分類コードかチェック
+  const isValidFilter = filterCode && VALID_CODES.has(filterCode)
+
+  useEffect(() => {
+    if (!isValidFilter) return
+
+    setLoading(true)
+    setError(false)
+
+    fetch("/api/search-index.json")
+      .then((res) => {
+        if (!res.ok) throw new Error("Failed to fetch")
+        return res.json()
+      })
+      .then((data: { mysteries: MysteryEntry[] }) => {
+        const filtered = data.mysteries.filter(
+          (m) => m.classification === filterCode
+        )
+        setMysteries(filtered)
+      })
+      .catch(() => setError(true))
+      .finally(() => setLoading(false))
+  }, [filterCode, isValidFilter])
+
+  // フィルタが無効または未指定の場合は何も表示しない（SSG コンテンツが表示される）
+  if (!isValidFilter) return null
+
+  const classificationLabel = dict.classification[filterCode as ClassificationCode]
+
+  return (
+    <>
+      {/* フィルタ有効時に SSG コンテンツを非表示にする */}
+      <style>{`.archive-default-content { display: none; }`}</style>
+
+      {/* フィルタアクティブバー */}
+      <div className="mb-8 flex items-center gap-3 rounded-lg border border-border/50 bg-card px-4 py-3">
+        <Filter className="w-4 h-4 text-gold shrink-0" />
+        <span className="text-sm text-parchment">
+          {dict.archive.filterActive.replace("{classification}", classificationLabel)}
+        </span>
+        <span
+          className={cn(
+            "inline-flex items-center px-2 py-0.5 rounded text-[10px] font-mono uppercase tracking-wider",
+            badgeColorMap[filterCode as ClassificationCode]
+          )}
+        >
+          {filterCode}
+        </span>
+        <button
+          onClick={() => router.push(`/${lang}/archive`)}
+          className="ml-auto flex items-center gap-1.5 text-xs text-muted-foreground hover:text-parchment transition-colors"
+        >
+          <X className="w-3.5 h-3.5" />
+          {dict.archive.clearFilter}
+        </button>
+      </div>
+
+      {/* フィルタ結果 */}
+      {loading ? (
+        <div className="text-center py-16">
+          <div className="inline-block w-6 h-6 border-2 border-gold/30 border-t-gold rounded-full animate-spin" />
+        </div>
+      ) : error ? (
+        <div className="text-center py-16 text-muted-foreground">
+          Failed to load data.
+        </div>
+      ) : mysteries.length === 0 ? (
+        <div className="text-center py-16">
+          <h2 className="font-serif text-xl text-parchment mb-2">
+            {dict.archive.noArticles}
+          </h2>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {mysteries.map((mystery) => (
+            <FilteredMysteryCard
+              key={mystery.id}
+              mystery={mystery}
+              lang={lang}
+              classificationLabels={dict.classification}
+            />
+          ))}
+        </div>
+      )}
+    </>
+  )
+}
+
+/**
+ * JSON データから直接描画する軽量カードコンポーネント
+ * 見た目は MysteryCard と統一
+ */
+function FilteredMysteryCard({
+  mystery,
+  lang,
+  classificationLabels,
+}: {
+  mystery: MysteryEntry
+  lang: SupportedLang
+  classificationLabels: Dictionary["classification"]
+}) {
+  const i18n = mystery.i18n[lang] || mystery.i18n["en"]
+  if (!i18n) return null
+
+  const code = mystery.classification as ClassificationCode
+  const publishedDate = mystery.publishedAt
+    ? new Date(mystery.publishedAt).toLocaleDateString()
+    : ""
+
+  return (
+    <Link href={`/${lang}/mystery/${mystery.id}`} className="block group no-underline">
+      <article className="aged-card letterpress-border rounded-sm p-5 h-full transition-all duration-300 hover:bg-paper-light hover:border-parchment-dark/30 hover:shadow-lg hover:shadow-black/20">
+        <div className={cn(mystery.thumbnail && "grid grid-cols-[96px_1fr] gap-4")}>
+          {/* サムネイル */}
+          {mystery.thumbnail && (
+            <div className="w-24 h-24 rounded-sm overflow-hidden flex-shrink-0 border border-border/30">
+              <Image
+                src={mystery.thumbnail}
+                alt=""
+                width={96}
+                height={96}
+                className="w-full h-full object-cover opacity-90 group-hover:opacity-100 transition-opacity"
+              />
+            </div>
+          )}
+
+          <div className="min-w-0">
+            {/* ID + 日付 */}
+            <div className="flex items-start justify-between gap-3 mb-2">
+              <div className="flex items-center gap-2 text-xs text-muted-foreground font-mono uppercase tracking-wider">
+                <FileText className="w-3.5 h-3.5 text-gold" />
+                <span>{mystery.id}</span>
+              </div>
+              {publishedDate && (
+                <time className="text-xs text-muted-foreground font-mono shrink-0">
+                  {publishedDate}
+                </time>
+              )}
+            </div>
+
+            {/* 分類バッジ */}
+            {VALID_CODES.has(code) && (
+              <div className="mb-3">
+                <span
+                  className={cn(
+                    "inline-flex items-center px-2 py-0.5 rounded text-[10px] font-mono uppercase tracking-wider",
+                    badgeColorMap[code]
+                  )}
+                >
+                  {classificationLabels[code]}
+                </span>
+              </div>
+            )}
+
+            {/* タイトル */}
+            <h3 className="font-serif text-lg text-parchment mb-1 leading-tight group-hover:text-gold transition-colors text-balance">
+              {i18n.title}
+            </h3>
+
+            {/* サマリー */}
+            <p className="text-sm text-foreground/80 leading-relaxed mb-4 line-clamp-3">
+              {i18n.summary}
+            </p>
+          </div>
+        </div>
+      </article>
+    </Link>
+  )
+}

--- a/web-public/src/components/classification-guide.tsx
+++ b/web-public/src/components/classification-guide.tsx
@@ -58,7 +58,7 @@ export function ClassificationGuide({ lang, dict }: ClassificationGuideProps) {
             return (
               <Link
                 key={code}
-                href={`/${lang}/archive`}
+                href={`/${lang}/archive?c=${code}`}
                 className={`group block rounded-lg border ${colors.border} bg-card p-4 transition-transform hover:scale-[1.02] no-underline`}
               >
                 <Icon className={`w-6 h-6 ${colors.icon} mb-2`} aria-hidden="true" />

--- a/web-public/src/lib/i18n/dictionaries/de.ts
+++ b/web-public/src/lib/i18n/dictionaries/de.ts
@@ -42,6 +42,8 @@ const dict: Dictionary = {
     heading: "Fallarchiv",
     description: "Vollständiges Verzeichnis aller untersuchten Anomalien, Diskrepanzen und unerklärlichen Phänomene aus den öffentlichen Aufzeichnungen der Welt.",
     noArticles: "Es wurden noch keine Fallakten veröffentlicht.",
+    filterActive: "Anzeige: {classification}",
+    clearFilter: "Alle anzeigen",
     page: "Seite",
     previous: "Zurück",
     next: "Weiter",

--- a/web-public/src/lib/i18n/dictionaries/en.ts
+++ b/web-public/src/lib/i18n/dictionaries/en.ts
@@ -41,6 +41,8 @@ const dict: Dictionary = {
     heading: "Case Archive",
     description: "Complete index of all investigated anomalies, discrepancies, and unexplained phenomena unearthed from the world's public records.",
     noArticles: "No case files have been published yet.",
+    filterActive: "Showing: {classification}",
+    clearFilter: "Show all",
     page: "Page",
     previous: "Previous",
     next: "Next",

--- a/web-public/src/lib/i18n/dictionaries/es.ts
+++ b/web-public/src/lib/i18n/dictionaries/es.ts
@@ -42,6 +42,8 @@ const dict: Dictionary = {
     heading: "Archivo de casos",
     description: "Índice completo de todas las anomalías, discrepancias y fenómenos inexplicables desenterrados de los registros públicos del mundo.",
     noArticles: "Aún no se han publicado expedientes.",
+    filterActive: "Mostrando: {classification}",
+    clearFilter: "Mostrar todo",
     page: "Página",
     previous: "Anterior",
     next: "Siguiente",

--- a/web-public/src/lib/i18n/dictionaries/fr.ts
+++ b/web-public/src/lib/i18n/dictionaries/fr.ts
@@ -42,6 +42,8 @@ const dict: Dictionary = {
     heading: "Archives des dossiers",
     description: "Index complet de toutes les anomalies, divergences et phénomènes inexpliqués exhumés des archives publiques du monde.",
     noArticles: "Aucun dossier n'a encore été publié.",
+    filterActive: "Affichage : {classification}",
+    clearFilter: "Tout afficher",
     page: "Page",
     previous: "Précédent",
     next: "Suivant",

--- a/web-public/src/lib/i18n/dictionaries/ja.ts
+++ b/web-public/src/lib/i18n/dictionaries/ja.ts
@@ -41,6 +41,8 @@ const dict: Dictionary = {
     heading: "ケースアーカイブ",
     description: "世界の公開記録から発掘された、すべての異常・矛盾・説明不能な現象の完全索引。",
     noArticles: "まだケースファイルは公開されていません。",
+    filterActive: "表示中: {classification}",
+    clearFilter: "すべて表示",
     page: "ページ",
     previous: "前へ",
     next: "次へ",

--- a/web-public/src/lib/i18n/dictionaries/nl.ts
+++ b/web-public/src/lib/i18n/dictionaries/nl.ts
@@ -42,6 +42,8 @@ const dict: Dictionary = {
     heading: "Zaakarchief",
     description: "Volledige index van alle onderzochte anomalieën, discrepanties en onverklaarde verschijnselen uit de openbare archieven van de wereld.",
     noArticles: "Er zijn nog geen dossiers gepubliceerd.",
+    filterActive: "Weergave: {classification}",
+    clearFilter: "Alles tonen",
     page: "Pagina",
     previous: "Vorige",
     next: "Volgende",

--- a/web-public/src/lib/i18n/dictionaries/pt.ts
+++ b/web-public/src/lib/i18n/dictionaries/pt.ts
@@ -42,6 +42,8 @@ const dict: Dictionary = {
     heading: "Arquivo de casos",
     description: "Índice completo de todas as anomalias, discrepâncias e fenômenos inexplicáveis desenterrados dos registros públicos do mundo.",
     noArticles: "Nenhum dossiê foi publicado ainda.",
+    filterActive: "Exibindo: {classification}",
+    clearFilter: "Mostrar tudo",
     page: "Página",
     previous: "Anterior",
     next: "Próximo",

--- a/web-public/src/lib/i18n/dictionaries/types.ts
+++ b/web-public/src/lib/i18n/dictionaries/types.ts
@@ -34,6 +34,8 @@ export interface Dictionary {
     heading: string;
     description: string;
     noArticles: string;
+    filterActive: string;
+    clearFilter: string;
     page: string;
     previous: string;
     next: string;


### PR DESCRIPTION
## Summary

- ClassificationGuide（トップページの分類索引カード）クリック時に、該当分類の記事のみフィルタ表示する機能を追加
- SSG サイトのため、ビルド時に JSON インデックスを生成し、クライアントサイド JS でフィルタリングする方式を採用

## 変更内容

- **`scripts/generate-search-index.ts`** (新規): postbuild スクリプト。`out/` ディレクトリの HTML からメタデータ（タイトル・サマリー・分類コード・サムネイル・公開日）を7言語分抽出し、`out/api/search-index.json` を生成
- **`classification-guide.tsx`**: 各分類カードのリンクに `?c={code}` クエリパラメータ追加
- **`archive-filter.tsx`** (新規): `"use client"` コンポーネント。`useSearchParams()` で `?c=` を読み取り、`search-index.json` を fetch してフィルタ結果をカード表示。フィルタ有効時は SSG コンテンツを非表示
- **`archive/[[...page]]/page.tsx`**: `<Suspense>` + `<ArchiveFilter>` 統合、SSG コンテンツを `.archive-default-content` で囲む
- **i18n 辞書** (7言語): `filterActive` / `clearFilter` エントリ追加

## Test plan

- [ ] `npm run build && npm run postbuild` でビルド成功
- [ ] `out/api/search-index.json` が正しく生成される
- [ ] トップページの分類カードクリック → `/{lang}/archive?c=HIS` 等に遷移
- [ ] フィルタされた記事のみ表示される
- [ ] 「全件表示」ボタンで `?c=` パラメータ解除、全記事表示に戻る
- [ ] パラメータなしの `/archive` は従来通り全件表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)