### PR TITLE
fix: TOC 動的見出し対応 + React key 警告修正

### DIFF
--- a/web-public/src/app/[lang]/mystery/[id]/page.tsx
+++ b/web-public/src/app/[lang]/mystery/[id]/page.tsx
@@ -23,6 +23,8 @@ import { getDictionary } from "@/lib/i18n/dictionaries"
 import { findRelatedArticles } from "@/lib/related-articles"
 import { getSiteUrl } from "@/lib/site-url"
 import { buildOgpMetadata, buildAlternates } from "@/lib/seo"
+import { extractHeadings } from "@/lib/markdown-headings"
+import { stripLeadingH1 } from "@ghost/shared/src/lib/utils"
 import type { TocSection } from "@/components/table-of-contents"
 
 // SSG: ビルド時に生成されたページ以外は 404
@@ -113,20 +115,19 @@ export default async function MysteryDetailPage({
   const evidenceAExcerpt = getTranslatedExcerpt(mystery, "a", lang)
   const evidenceBExcerpt = getTranslatedExcerpt(mystery, "b", lang)
 
-  // 目次セクションの動的構築（存在するセクションのみ含める）
+  // 本文見出しから TOC セクションを動的構築
+  const narrativeHeadings = extractHeadings(stripLeadingH1(narrativeContent || ""))
   const tocSections: TocSection[] = [
-    { id: SECTION_IDS.narrative, label: dict.detail.tocNarrative },
+    // 見出しが抽出できた場合は記事固有の見出しを使用、なければ固定ラベル
+    ...(narrativeHeadings.length > 0
+      ? narrativeHeadings.map(h => ({ id: h.id, label: h.text }))
+      : [{ id: SECTION_IDS.narrative, label: dict.detail.tocNarrative }]),
+    // 固定セクション（条件付き）
+    ...(discrepancyDetected ? [{ id: SECTION_IDS.discrepancy, label: dict.detail.tocDiscrepancy }] : []),
+    { id: SECTION_IDS.evidence, label: dict.detail.tocEvidence },
+    ...(hypothesis ? [{ id: SECTION_IDS.hypothesis, label: dict.detail.tocHypothesis }] : []),
+    ...(mystery.historical_context ? [{ id: SECTION_IDS.historicalContext, label: dict.detail.tocHistoricalContext }] : []),
   ]
-  if (discrepancyDetected) {
-    tocSections.push({ id: SECTION_IDS.discrepancy, label: dict.detail.tocDiscrepancy })
-  }
-  tocSections.push({ id: SECTION_IDS.evidence, label: dict.detail.tocEvidence })
-  if (hypothesis) {
-    tocSections.push({ id: SECTION_IDS.hypothesis, label: dict.detail.tocHypothesis })
-  }
-  if (mystery.historical_context) {
-    tocSections.push({ id: SECTION_IDS.historicalContext, label: dict.detail.tocHistoricalContext })
-  }
 
   // シェアボタン用の URL
   const shareUrl = `${getSiteUrl()}/${lang}/mystery/${id}`

--- a/web-public/src/components/mystery/narrative-section.tsx
+++ b/web-public/src/components/mystery/narrative-section.tsx
@@ -2,6 +2,8 @@ import Markdown, { type Components } from "react-markdown"
 import remarkGfm from "remark-gfm"
 import { FileText } from "lucide-react"
 import { stripLeadingH1 } from "@ghost/shared/src/lib/utils"
+import { slugify } from "@/lib/markdown-headings"
+import type { ReactNode } from "react"
 
 // 7言語のアーカイブ引用ラベル
 const ARCHIVE_LABEL: Record<string, string> = {
@@ -28,6 +30,20 @@ function ArchiveBlockquote({ children, lang }: { children?: React.ReactNode; lan
   )
 }
 
+/**
+ * React children からプレーンテキストを再帰的に抽出する。
+ * h2 要素の children はネストした要素（bold, em 等）を含むため再帰処理が必要。
+ */
+function getTextContent(children: ReactNode): string {
+  if (typeof children === "string") return children
+  if (typeof children === "number") return String(children)
+  if (Array.isArray(children)) return children.map(getTextContent).join("")
+  if (children && typeof children === "object" && "props" in children) {
+    return getTextContent((children as { props: { children?: ReactNode } }).props.children)
+  }
+  return ""
+}
+
 interface NarrativeSectionProps {
   narrativeContent?: string
   summary: string
@@ -36,14 +52,25 @@ interface NarrativeSectionProps {
 
 export function NarrativeSection({ narrativeContent, summary, lang = "en" }: NarrativeSectionProps) {
   if (narrativeContent) {
+    // 重複スラグを追跡するクロージャ（レンダーごとにリセット）
+    const slugCounts = new Map<string, number>()
+
     const markdownComponents: Components = {
       blockquote: ({ children }) => (
         <ArchiveBlockquote lang={lang}>{children}</ArchiveBlockquote>
       ),
+      h2: ({ children }) => {
+        const text = getTextContent(children)
+        const baseSlug = slugify(text)
+        const count = slugCounts.get(baseSlug) || 0
+        const id = count > 0 ? `${baseSlug}-${count}` : baseSlug
+        slugCounts.set(baseSlug, count + 1)
+        return <h2 id={id} className="scroll-mt-24">{children}</h2>
+      },
     }
 
     return (
-      <section id="section-narrative" className="scroll-mt-24 prose prose-lg prose-invert max-w-none prose-headings:font-serif prose-headings:text-parchment prose-headings:mt-12 prose-headings:mb-4 prose-p:text-foreground/90 prose-p:leading-loose prose-p:mb-6 prose-a:text-gold prose-strong:text-parchment prose-hr:border-border">
+      <section className="prose prose-lg prose-invert max-w-none prose-headings:font-serif prose-headings:text-parchment prose-headings:mt-12 prose-headings:mb-4 prose-p:text-foreground/90 prose-p:leading-loose prose-p:mb-6 prose-a:text-gold prose-strong:text-parchment prose-hr:border-border">
         <Markdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
           {stripLeadingH1(narrativeContent).replace(/\*\*(.+?)\*\*/g, ' **$1** ')}
         </Markdown>

--- a/web-public/src/components/table-of-contents.tsx
+++ b/web-public/src/components/table-of-contents.tsx
@@ -33,8 +33,8 @@ function TocLinks({
 }) {
   return (
     <ul className="space-y-1">
-      {sections.map((section) => (
-        <li key={section.id}>
+      {sections.map((section, index) => (
+        <li key={`${section.id}-${index}`}>
           <button
             onClick={() => onClick(section.id)}
             className={`w-full text-left text-sm font-mono py-1.5 pl-3 border-l-2 transition-colors ${

--- a/web-public/src/lib/markdown-headings.ts
+++ b/web-public/src/lib/markdown-headings.ts
@@ -1,0 +1,64 @@
+/**
+ * Markdown から見出しを抽出し、slug ID を生成するユーティリティ。
+ * TOC（目次）の動的構築と、見出し要素への id 付与に使用する。
+ */
+
+export interface MarkdownHeading {
+  id: string
+  text: string
+  level: 2 | 3
+}
+
+/**
+ * テキストを URL フレンドリーなスラグに変換する。
+ * - 小文字化、空白をハイフン化、英数字とハイフンのみ残す
+ */
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+}
+
+/**
+ * インライン Markdown 書式を除去してプレーンテキストにする。
+ * **bold**, *italic*, `code`, [link](url) を処理する。
+ */
+function stripInlineMarkdown(text: string): string {
+  return text
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1") // [link](url) → link
+    .replace(/`([^`]+)`/g, "$1")              // `code` → code
+    .replace(/\*\*(.+?)\*\*/g, "$1")          // **bold** → bold
+    .replace(/\*(.+?)\*/g, "$1")              // *italic* → italic
+    .replace(/__(.+?)__/g, "$1")              // __bold__ → bold
+    .replace(/_(.+?)_/g, "$1")                // _italic_ → italic
+}
+
+/**
+ * Markdown テキストから h2 見出しを抽出する。
+ * stripLeadingH1() 適用後の markdown を渡すことを想定。
+ * 重複スラグにはサフィックス -1, -2 を付与する。
+ */
+export function extractHeadings(markdown: string): MarkdownHeading[] {
+  const headings: MarkdownHeading[] = []
+  const slugCounts = new Map<string, number>()
+
+  const regex = /^##\s+(.+)$/gm
+  let match: RegExpExecArray | null
+  while ((match = regex.exec(markdown)) !== null) {
+    const rawText = match[1].trim()
+    const text = stripInlineMarkdown(rawText)
+    const baseSlug = slugify(text)
+
+    const count = slugCounts.get(baseSlug) || 0
+    const id = count > 0 ? `${baseSlug}-${count}` : baseSlug
+    slugCounts.set(baseSlug, count + 1)
+
+    headings.push({ id, text, level: 2 })
+  }
+
+  return headings
+}


### PR DESCRIPTION
## Summary

- 記事詳細ページの目次（TOC）を、固定 "Narrative" ラベルから記事本文の実際の h2 見出しに動的生成するよう改修
- Markdown 見出しに `id` 属性を付与し、クリックスクロール・現在位置ハイライトが正常に動作するよう修正
- React key 警告を防止するため、key に index を含める安全策を追加

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `web-public/src/lib/markdown-headings.ts` | 新規: `slugify()` + `extractHeadings()` ユーティリティ |
| `web-public/src/components/mystery/narrative-section.tsx` | h2 カスタムコンポーネント追加（`id` + `scroll-mt-24`）|
| `web-public/src/app/[lang]/mystery/[id]/page.tsx` | TOC を `extractHeadings()` で動的構築、見出し 0 件時はフォールバック |
| `web-public/src/components/table-of-contents.tsx` | key を `${section.id}-${index}` に変更 |

## Test plan

- [ ] 記事詳細ページで TOC に記事固有の h2 見出しが表示される
- [ ] 見出しクリックで該当セクションへスムーズスクロールする
- [ ] スクロール時に TOC の現在位置が gold 色でハイライトされる
- [ ] React key 警告がコンソールに表示されない
- [ ] 見出しのない記事（summary フォールバック）で従来の "Narrative" ラベルが表示される
- [ ] モバイル折りたたみ TOC が正常に動作する
- [ ] `npm run build` が成功する

🤖 Generated with [Claude Code](https://claude.com/claude-code)