### PR TITLE
fix: アーカイブ分類フィルタの "Failed to load data" エラーを修正

### DIFF
--- a/web-public/src/app/[lang]/archive/[[...page]]/page.tsx
+++ b/web-public/src/app/[lang]/archive/[[...page]]/page.tsx
@@ -5,7 +5,9 @@ import { PublicFooter } from "@/components/public-footer"
 import { MysteryCard } from "@/components/mystery-card"
 import { Pagination } from "@/components/pagination"
 import { ArchiveFilter } from "@/components/archive-filter"
+import type { MysteryEntry } from "@/components/archive-filter"
 import { getPublishedMysteries, getAllPublishedMysteriesMap } from "@ghost/shared/src/lib/firestore/queries"
+import { localizeMystery } from "@ghost/shared/src/lib/localize"
 import { ARCHIVE_PAGE_SIZE } from "@/lib/constants"
 import { FileStack, Search } from "lucide-react"
 import { isValidLang, SUPPORTED_LANGS } from "@/lib/i18n/config"
@@ -80,6 +82,22 @@ export default async function ArchivePage({
   const startIndex = (currentPage - 1) * ARCHIVE_PAGE_SIZE
   const pageMysteries = allMysteries.slice(startIndex, startIndex + ARCHIVE_PAGE_SIZE)
 
+  // フィルタ用の軽量データを構築（全記事・全言語の title/summary）
+  const filterEntries: MysteryEntry[] = allMysteries.map((m) => {
+    const i18n: Record<string, { title: string; summary: string }> = {}
+    for (const l of SUPPORTED_LANGS) {
+      const localized = localizeMystery(m, l)
+      i18n[l] = { title: localized.title, summary: localized.summary }
+    }
+    return {
+      id: m.mystery_id,
+      classification: m.mystery_id.slice(0, 3).toUpperCase(),
+      thumbnail: m.images?.thumbnail ?? null,
+      publishedAt: m.publishedAt?.toISOString() ?? "",
+      i18n,
+    }
+  })
+
   return (
     <div className="min-h-screen flex flex-col film-grain">
       <Header lang={lang as SupportedLang} nav={dict.nav} />
@@ -103,7 +121,7 @@ export default async function ArchivePage({
 
             {/* 分類フィルタ（?c= パラメータ使用時） */}
             <Suspense fallback={null}>
-              <ArchiveFilter lang={lang as SupportedLang} dict={dict} />
+              <ArchiveFilter lang={lang as SupportedLang} dict={dict} mysteries={filterEntries} />
             </Suspense>
 
             {/* SSG 記事グリッド（フィルタ未使用時に表示） */}

--- a/web-public/src/components/archive-filter.tsx
+++ b/web-public/src/components/archive-filter.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useSearchParams, useRouter } from "next/navigation"
-import { useEffect, useState } from "react"
+import { useMemo } from "react"
 import Image from "next/image"
 import Link from "next/link"
 import { FileText, X, Filter } from "lucide-react"
@@ -24,12 +24,12 @@ const badgeColorMap: Record<ClassificationCode, string> = {
   LOC: "bg-emerald-900/30 text-emerald-400",
 }
 
-interface MysteryI18n {
+export interface MysteryI18n {
   title: string
   summary: string
 }
 
-interface MysteryEntry {
+export interface MysteryEntry {
   id: string
   classification: string
   thumbnail: string | null
@@ -40,43 +40,27 @@ interface MysteryEntry {
 interface ArchiveFilterProps {
   lang: SupportedLang
   dict: Dictionary
+  /** サーバーコンポーネントから渡される全記事データ */
+  mysteries: MysteryEntry[]
 }
 
 /**
  * クライアントサイドの分類フィルタコンポーネント
- * ?c=HIS 等のクエリパラメータを読み取り、search-index.json からフィルタ結果を表示
+ * ?c=HIS 等のクエリパラメータを読み取り、props のデータからフィルタ結果を表示
  */
-export function ArchiveFilter({ lang, dict }: ArchiveFilterProps) {
+export function ArchiveFilter({ lang, dict, mysteries }: ArchiveFilterProps) {
   const searchParams = useSearchParams()
   const router = useRouter()
   const filterCode = searchParams.get("c")?.toUpperCase() || null
-  const [mysteries, setMysteries] = useState<MysteryEntry[]>([])
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState(false)
 
   // 有効な分類コードかチェック
   const isValidFilter = filterCode && VALID_CODES.has(filterCode)
 
-  useEffect(() => {
-    if (!isValidFilter) return
-
-    setLoading(true)
-    setError(false)
-
-    fetch("/api/search-index.json")
-      .then((res) => {
-        if (!res.ok) throw new Error("Failed to fetch")
-        return res.json()
-      })
-      .then((data: { mysteries: MysteryEntry[] }) => {
-        const filtered = data.mysteries.filter(
-          (m) => m.classification === filterCode
-        )
-        setMysteries(filtered)
-      })
-      .catch(() => setError(true))
-      .finally(() => setLoading(false))
-  }, [filterCode, isValidFilter])
+  // フィルタ結果をメモ化
+  const filtered = useMemo(() => {
+    if (!isValidFilter) return []
+    return mysteries.filter((m) => m.classification === filterCode)
+  }, [mysteries, filterCode, isValidFilter])
 
   // フィルタが無効または未指定の場合は何も表示しない（SSG コンテンツが表示される）
   if (!isValidFilter) return null
@@ -112,15 +96,7 @@ export function ArchiveFilter({ lang, dict }: ArchiveFilterProps) {
       </div>
 
       {/* フィルタ結果 */}
-      {loading ? (
-        <div className="text-center py-16">
-          <div className="inline-block w-6 h-6 border-2 border-gold/30 border-t-gold rounded-full animate-spin" />
-        </div>
-      ) : error ? (
-        <div className="text-center py-16 text-muted-foreground">
-          Failed to load data.
-        </div>
-      ) : mysteries.length === 0 ? (
+      {filtered.length === 0 ? (
         <div className="text-center py-16">
           <h2 className="font-serif text-xl text-parchment mb-2">
             {dict.archive.noArticles}
@@ -128,7 +104,7 @@ export function ArchiveFilter({ lang, dict }: ArchiveFilterProps) {
         </div>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {mysteries.map((mystery) => (
+          {filtered.map((mystery) => (
             <FilteredMysteryCard
               key={mystery.id}
               mystery={mystery}


### PR DESCRIPTION
## Summary

- アーカイブページの分類フィルタ（`?c=FLK` 等）で「Failed to load data.」エラーが発生していたバグを修正
- **原因**: `search-index.json` は `postbuild` でのみ生成されるため、開発モード（`next dev`）では存在せず `fetch` が失敗していた
- **修正**: サーバーコンポーネントが既に Firestore から全記事データを取得しているため、フィルタ用の軽量データを props として `ArchiveFilter` に渡す方式に変更。`fetch` を排除し、`useMemo` によるクライアントサイドフィルタリングに統一

## Test plan

- [ ] `localhost:3000/ja/archive/?c=FLK` で FLK 分類の記事のみが表示されること
- [ ] `localhost:3000/ja/archive/?c=HIS` 等、他の分類コードでも正常にフィルタされること
- [ ] `localhost:3000/ja/archive`（フィルタなし）で通常の SSG 記事一覧が表示されること
- [ ] 「すべて表示」ボタンでフィルタが解除されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)