### PR TITLE
fix: Dockerfile に GOOGLE_CLOUD_LOCATION=global を追加（Vertex AI Claude エラー解消）

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ COPY services/ ./services/
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH=/app
 ENV GOOGLE_CLOUD_PROJECT=ghostinthearchive
+ENV GOOGLE_CLOUD_LOCATION=global
 ENV GOOGLE_GENAI_USE_VERTEXAI=TRUE
 
 # Default entrypoint (overridden by Cloud Run configuration)


### PR DESCRIPTION
## Summary

- Dockerfile に `ENV GOOGLE_CLOUD_LOCATION=global` を追加
- Cloud Run 上の Storyteller（Claude Sonnet 4.5 on Vertex AI）が `GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION must be set` エラーで失敗していた問題を修正

## 原因

ADK の `Claude` クラスは `os.environ` に `GOOGLE_CLOUD_LOCATION` が存在するかをチェックし、未設定なら `ValueError` を投げる。`.env` には `global` が設定済みだったが、Cloud Run では Dockerfile の `ENV` しか参照されないため、Dockerfile に未設定だったことが原因。

## 変更内容

| ファイル | 変更 |
|---|---|
| `Dockerfile` | `ENV GOOGLE_CLOUD_LOCATION=global` を追加（1行） |

## Test plan

- [x] Dockerfile に `GOOGLE_CLOUD_LOCATION=global` が含まれることを確認
- [ ] Cloud Run に再デプロイ後、ブログパイプラインの Storyteller ステップが正常に Claude を呼べることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)