### PR TITLE
fix: Curator instruction にアーカイブ API カバレッジを明記（テーマ精度向上）

### DIFF
--- a/curator_agents/agents/curator.py
+++ b/curator_agents/agents/curator.py
@@ -33,27 +33,56 @@ _CATEGORY_SECTION = build_category_prompt_section()
 #
 # 過小表現のカテゴリを優先してください。
 #
-# ## 地理的多様性（文化圏ベース）
-# 以下の文化圏から幅広くテーマを選択すること:
-# - **西欧**: 英国、フランス、ドイツ、オランダ、スペイン、ポルトガル、イタリア
-# - **東欧**: ロシア、ポーランド、チェコ、ハンガリー、ルーマニア、バルカン諸国
-# - **南北アメリカ**: 米国、カナダ、メキシコ、カリブ海、南米
-# - **アジア太平洋**: 日本、中国、インド、東南アジア、オセアニア
-# - **中東・北アフリカ**: エジプト、トルコ、ペルシア、レヴァント
-# - **サブサハラアフリカ**: 西アフリカ、東アフリカ、南部アフリカ
-# 全5件を単一の文化圏に集中させない。少なくとも3つの異なる文化圏をカバーすること。
+# ## 利用可能なアーカイブ API（全12件）
+# Librarian エージェントが実際に検索できる API は以下の通りです。
+# テーマ提案時は、これらの API で一次資料がヒットするテーマのみ提案してください。
+#
+# | API | 言語 | カバレッジ |
+# |-----|------|-----------|
+# | Library of Congress Digital Collections | en | 米国・英語圏全般（書籍・写真・地図・手稿） |
+# | Chronicling America (LOC Newspapers) | en | 米国の歴史的新聞（1789-1963） |
+# | Digital Public Library of America (DPLA) | en, es | 全米3,100万点（図書館・博物館の統合検索） |
+# | NYPL Digital Collections | en | ニューヨーク公共図書館120万点（手稿・地図・写真・稀覯本） |
+# | Internet Archive | en, de, es, fr, nl, pt, ja | グローバル7,000万点超（書籍・雑誌・音声・映像・ウェブ） |
+# | Deutsche Digitale Bibliothek (DDB) | de | ドイツ語圏1,200万点超（ドイツ・オーストリア・スイスの文化遺産機関） |
+# | Europeana | de, es, fr, nl, pt | 欧州50カ国・6,000機関から6,000万点超 |
+# | KB/Delpher (オランダ国立図書館) | nl | オランダ5億点超（新聞1618年〜、書籍、雑誌） |
+# | Trove (オーストラリア国立図書館) | en | オーストラリア2,000万点超（新聞1803年〜、書籍、画像） |
+# | NDL Search (国立国会図書館) | ja | 日本2,000万点超（書籍・雑誌・手稿・地図、江戸〜昭和期） |
+# | Wellcome Collection | en | 英国600万点超（医療史・民俗・迷信・手稿に特化） |
+# | DigitalNZ | en | ニュージーランド3,000万点超（新聞・書籍・画像・手稿） |
+#
+# ## 利用不可のアーカイブ（テーマ禁止）
+# 以下のアーカイブ API は未実装です。これらでしか資料が見つからないテーマは提案しないでください：
+# - BnF Gallica（フランス国立図書館）— 未実装。フランス関連テーマは Europeana/Internet Archive でカバーできる場合のみ可
+# - 中国のアーカイブ（中国国家図書館等）— 未実装。中国固有のテーマは不可
+# - ロシアのアーカイブ（ロシア国立図書館等）— 未実装。ロシア固有のテーマは不可
+# - 韓国のアーカイブ（韓国国立図書館等）— 未実装。韓国固有のテーマは不可
+# - アラビア語圏のアーカイブ — 未実装。中東・北アフリカ固有のテーマは不可
+# - サブサハラアフリカのアーカイブ — 未実装。アフリカ固有のテーマは不可
+# - インド・南アジアのアーカイブ — 未実装。インド固有のテーマは不可
+#
+# ## 地理的多様性（API カバレッジベース）
+# 以下の言語圏から幅広くテーマを選択すること。各言語圏の後のカッコ内は利用可能な API：
+# - **英語圏**（米国・英国・オーストラリア・NZ）— LOC, DPLA, NYPL, Chronicling America, Trove, Wellcome, DigitalNZ
+# - **ドイツ語圏**（ドイツ・オーストリア・スイス）— DDB, Europeana
+# - **スペイン語圏**（スペイン・中南米）— DPLA, Europeana, Internet Archive
+# - **フランス語圏**（フランス・ベルギー・旧植民地）— Europeana, Internet Archive
+# - **オランダ語圏**（オランダ・フランドル・旧植民地）— Delpher, Europeana
+# - **ポルトガル語圏**（ポルトガル・ブラジル）— Europeana, Internet Archive
+# - **日本語圏**（日本）— NDL Search, Internet Archive
+# 全5件を単一の言語圏に集中させない。少なくとも3つの異なる言語圏をカバーすること。
 #
 # ## テーマの条件
-# - 世界中のあらゆる時代が対象（デジタルアーカイブに一次資料が存在することが唯一の制約）
-# - デジタルアーカイブ（Library of Congress, DPLA, Europeana, Deutsche Digitale Bibliothek,
-#   BnF Gallica, Internet Archive 等）で資料が見つかりそうなテーマ
+# - 世界中のあらゆる時代が対象（ただし上記 API で一次資料が見つかることが必須条件）
+# - 上記12の API のいずれかで具体的に資料がヒットしそうなテーマのみ提案すること
 # - 複数の学術領域から分析可能な、記録の隙間に潜む謎
 # - 具体的な年代、地名、キーワードを含む調査クエリとして使えるもの
 #
 # ## 多様性要件
 # 5件のテーマ全体で以下を満たすこと：
 # - 少なくとも4つの異なるカテゴリ（HIS/FLK/ANT/OCC/URB/CRM/REL/LOC）を使用
-# - 少なくとも3つの異なる文化圏をカバー
+# - 少なくとも3つの異なる言語圏をカバー
 # - 少なくとも2世紀以上の時代幅をカバー（例: 中世と近代の両方）
 # - 有名すぎるテーマは避け、あまり知られていないが十分な資料がある事例を探す
 #   （回避例: Salem Witch Trials, Roanoke Colony, Bell Witch, Jack the Ripper,
@@ -76,7 +105,7 @@ _CATEGORY_SECTION = build_category_prompt_section()
 # [
 #   {
 #     "theme": "調査クエリとしてそのまま使える英語のテーマ文",
-#     "description": "このテーマが面白い理由の簡潔な英語説明（2-3文）",
+#     "description": "このテーマが面白い理由の簡潔な英語説明（2-3文）。どの API で資料がヒットしそうかにも言及すること",
 #     "category": "分類コード（HIS/FLK/ANT/OCC/URB/CRM/REL/LOC）"
 #   }
 # ]
@@ -105,27 +134,56 @@ Current category distribution:
 
 Prioritize underrepresented categories.
 
-## Geographic Diversity (Cultural Sphere-Based)
-Select themes from a broad range of cultural spheres:
-- **Western Europe**: Britain, France, Germany, Netherlands, Spain, Portugal, Italy
-- **Eastern Europe**: Russia, Poland, Czech Republic, Hungary, Romania, Balkans
-- **Americas**: United States, Canada, Mexico, Caribbean, South America
-- **Asia-Pacific**: Japan, China, India, Southeast Asia, Oceania
-- **Middle East & North Africa**: Egypt, Turkey, Persia, Levant
-- **Sub-Saharan Africa**: West Africa, East Africa, Southern Africa
-Do NOT concentrate all 5 themes on a single cultural sphere. Cover at least 3 distinct cultural spheres.
+## Available Archive APIs (12 total)
+The Librarian agent can ONLY search the following 12 APIs. Suggest themes for which primary sources \
+are likely to be found in at least one of these APIs:
+
+| API | Languages | Coverage |
+|-----|-----------|----------|
+| Library of Congress Digital Collections | en | US & English-language materials (books, photos, maps, manuscripts) |
+| Chronicling America (LOC Newspapers) | en | US historical newspapers (1789-1963) |
+| Digital Public Library of America (DPLA) | en, es | 31M+ items from US libraries & museums |
+| NYPL Digital Collections | en | 1.2M items (manuscripts, maps, photos, rare books) |
+| Internet Archive | en, de, es, fr, nl, pt, ja | 70M+ items globally (books, periodicals, audio, video, web) |
+| Deutsche Digitale Bibliothek (DDB) | de | 12M+ items from German-speaking cultural heritage institutions |
+| Europeana | de, es, fr, nl, pt | 60M+ items from 6,000+ institutions across 50+ European countries |
+| KB/Delpher (Dutch National Library) | nl | 500M+ digitized items (newspapers from 1618, books, periodicals) |
+| Trove (National Library of Australia) | en | 20M+ items (newspapers from 1803, books, images) |
+| NDL Search (National Diet Library, Japan) | ja | 20M+ items (books, periodicals, manuscripts, maps; Edo-Showa eras) |
+| Wellcome Collection | en | 6M+ items specializing in medical history, folklore, superstition |
+| DigitalNZ (Digital New Zealand) | en | 30M+ items (newspapers, books, images, manuscripts) |
+
+## Archives NOT Available (Do NOT Suggest Themes Requiring These)
+The following archives are NOT implemented. Do NOT suggest themes that can only be researched through these:
+- BnF Gallica (French National Library) — NOT implemented. French themes are OK only if Europeana/Internet Archive can cover them
+- Chinese archives (National Library of China, etc.) — NOT implemented. China-specific themes are NOT allowed
+- Russian archives (Russian State Library, etc.) — NOT implemented. Russia-specific themes are NOT allowed
+- Korean archives (National Library of Korea, etc.) — NOT implemented. Korea-specific themes are NOT allowed
+- Arabic-language archives — NOT implemented. Middle East / North Africa-specific themes are NOT allowed
+- Sub-Saharan African archives — NOT implemented. Africa-specific themes are NOT allowed
+- Indian / South Asian archives — NOT implemented. India-specific themes are NOT allowed
+
+## Geographic Diversity (API Coverage-Based)
+Select themes from a broad range of language spheres. APIs available for each sphere are shown in parentheses:
+- **English sphere** (US, UK, Australia, NZ) — LOC, DPLA, NYPL, Chronicling America, Trove, Wellcome, DigitalNZ
+- **German sphere** (Germany, Austria, Switzerland) — DDB, Europeana
+- **Spanish sphere** (Spain, Latin America) — DPLA, Europeana, Internet Archive
+- **French sphere** (France, Belgium, former colonies) — Europeana, Internet Archive
+- **Dutch sphere** (Netherlands, Flanders, former colonies) — Delpher, Europeana
+- **Portuguese sphere** (Portugal, Brazil) — Europeana, Internet Archive
+- **Japanese sphere** (Japan) — NDL Search, Internet Archive
+Do NOT concentrate all 5 themes on a single language sphere. Cover at least 3 distinct language spheres.
 
 ## Theme Requirements
-- Any era or region worldwide is fair game (the only constraint: primary sources must exist in digital archives)
-- Themes likely to yield results in digital archives (Library of Congress, DPLA, Europeana,
-  Deutsche Digitale Bibliothek, BnF Gallica, Internet Archive, etc.)
+- Any era worldwide is fair game (the constraint: primary sources must be findable via the 12 APIs above)
+- ONLY suggest themes for which at least one of the 12 APIs above is likely to return relevant primary sources
 - Amenable to interdisciplinary analysis (history, folklore, anthropology, linguistics, archival science)
 - Include specific dates, place names, and keywords usable as research queries
 
 ## Diversity Requirements
 Across all 5 themes, ensure:
 - At least 4 distinct categories (from HIS/FLK/ANT/OCC/URB/CRM/REL/LOC)
-- At least 3 distinct cultural spheres
+- At least 3 distinct language spheres
 - At least a 2-century span covered (e.g., both medieval and modern themes)
 - Avoid overly famous topics (Salem Witch Trials, Roanoke Colony, Bell Witch, Jack the Ripper, \
 Bermuda Triangle, Amityville, Loch Ness Monster, Roswell, etc.); \
@@ -148,7 +206,7 @@ Output the following JSON array. Do NOT output any text other than the JSON.
 [
   {{
     "theme": "A theme statement in English, usable directly as a research query",
-    "description": "A concise explanation (2-3 sentences) of why this theme is interesting",
+    "description": "A concise explanation (2-3 sentences) of why this theme is interesting. Mention which APIs are likely to yield relevant primary sources.",
     "category": "Classification code (HIS/FLK/ANT/OCC/URB/CRM/REL/LOC)"
   }}
 ]


### PR DESCRIPTION
## Summary

Curator の instruction が曖昧で、Librarian が実際に使える12 API のカバレッジ情報を伝えていなかった。結果として：
- 未実装の BnF Gallica が記載されている → フランス関連テーマを誤提案
- API が存在しない地域（中国、ロシア、中東、アフリカ等）のテーマを提案 → パイプライン失敗

### 変更内容
- **Geographic Diversity** を6文化圏から7言語圏（API カバレッジベース）に変更
- **全12 API の表**（API名・言語・カバレッジ概要）を追加し「これらのみ検索可能」と明記
- **利用不可アーカイブ一覧**を新設（BnF Gallica, 中国, ロシア, 韓国, アラビア語圏, アフリカ, インド）
- **description フィールド**にどの API でヒットしそうか言及させるよう指示追加
- 日本語コメントブロックを Prompt Language Policy に従い同期更新

## Test plan

- [x] `python -c "from curator_agents.agents.curator import curator_agent"` — import 成功
- [x] `pytest tests/unit/test_curator_schemas.py tests/unit/test_curator_server.py -v` — 全38テスト PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)