### PR TITLE
fix: Claude Sonnet (Vertex AI) 429 リトライ強化（max_retries=10）

### DIFF
--- a/shared/model_config.py
+++ b/shared/model_config.py
@@ -12,12 +12,57 @@ ADK はデフォルトで retry_options=None（リトライ0回）のため、
 from google.adk.models.google_llm import Gemini
 from google.genai.types import HttpRetryOptions
 
+# === 日本語訳 ===
+# Claude (Vertex AI) のリトライ回数上限。
+# Anthropic SDK のデフォルトは 2回だが、Vertex AI の 429 レート制限に対応するため
+# 10回に引き上げる。指数バックオフは SDK が自動適用する。
+# === End 日本語訳 ===
+_CLAUDE_MAX_RETRIES = 10
+
 # Claude モデルの LLMRegistry 登録（Vertex AI 経由）
 # anthropic パッケージが未インストールの場合はスキップ（テスト環境等）
 try:
+    import os
+    from functools import cached_property
+
+    from anthropic import AsyncAnthropicVertex
     from google.adk.models.anthropic_llm import Claude
     from google.adk.models.registry import LLMRegistry
-    LLMRegistry.register(Claude)
+
+    class _ClaudeWithRetry(Claude):
+        """Vertex AI 429 レート制限に対応するリトライ強化版 Claude。
+
+        ADK の Claude クラスは AsyncAnthropicVertex に max_retries を渡さないため、
+        Anthropic SDK のデフォルト（2回）しかリトライされない。
+        このサブクラスで max_retries=_CLAUDE_MAX_RETRIES を明示的に設定する。
+        """
+
+        @cached_property
+        def _anthropic_client(self) -> AsyncAnthropicVertex:
+            if (
+                "GOOGLE_CLOUD_PROJECT" not in os.environ
+                or "GOOGLE_CLOUD_LOCATION" not in os.environ
+            ):
+                raise ValueError(
+                    "GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION "
+                    "environment variables must be set."
+                )
+            try:
+                from google.adk.utils._google_client_headers import (
+                    get_tracking_headers,
+                )
+
+                headers = get_tracking_headers()
+            except ImportError:
+                headers = {}
+            return AsyncAnthropicVertex(
+                project_id=os.environ["GOOGLE_CLOUD_PROJECT"],
+                region=os.environ["GOOGLE_CLOUD_LOCATION"],
+                default_headers=headers,
+                max_retries=_CLAUDE_MAX_RETRIES,
+            )
+
+    LLMRegistry.register(_ClaudeWithRetry)
 except ImportError:
     pass
 
@@ -72,8 +117,8 @@ def create_flash_model() -> Gemini:
 def create_claude_sonnet_model() -> str:
     """Claude Sonnet 4.5 (Vertex AI) のモデル文字列を返す。
 
-    Claude は ADK の LLMRegistry 経由で解決されるため、
+    Claude は ADK の LLMRegistry 経由で _ClaudeWithRetry に解決されるため、
     Gemini のようなアダプタオブジェクトではなくモデル文字列を返す。
-    リトライは anthropic SDK 側で自動処理される。
+    リトライは _ClaudeWithRetry が max_retries=10 で Anthropic SDK に委譲する。
     """
     return MODEL_CLAUDE_SONNET

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,13 @@ mock_adk.utils.context_utils = MagicMock()
 mock_adk.models = MagicMock()
 mock_adk.models.google_llm = MagicMock()
 mock_adk.models.llm_response = MagicMock()
+# _ClaudeWithRetry のサブクラス化に必要な実クラス
+class _MockClaude:
+    """テスト用 Claude スタブ。model_config._ClaudeWithRetry の親クラスとして使用。"""
+    pass
+
 mock_adk.models.anthropic_llm = MagicMock()
+mock_adk.models.anthropic_llm.Claude = _MockClaude
 mock_adk.models.registry = MagicMock()
 mock_adk.runners = MagicMock()
 mock_adk.sessions = MagicMock()
@@ -52,6 +58,10 @@ sys.modules["google.adk.models.registry"] = mock_adk.models.registry
 sys.modules["google.adk.tools"] = mock_adk.tools
 sys.modules["google.adk.tools.base_tool"] = mock_adk.tools.base_tool
 sys.modules["google.adk.tools.tool_context"] = mock_adk.tools.tool_context
+
+# Mock anthropic (used by shared/model_config.py for _ClaudeWithRetry)
+mock_anthropic = MagicMock()
+sys.modules["anthropic"] = mock_anthropic
 
 mock_genai = MagicMock()
 mock_genai.Client = MagicMock

--- a/tests/unit/test_model_config.py
+++ b/tests/unit/test_model_config.py
@@ -12,6 +12,7 @@ from shared.model_config import (
     MODEL_CLAUDE_SONNET,
     MODEL_FLASH,
     MODEL_PRO,
+    _CLAUDE_MAX_RETRIES,
     _FLASH_RETRY_OPTIONS,
     _PRO_RETRY_OPTIONS,
     create_claude_sonnet_model,
@@ -75,3 +76,17 @@ class TestCreateClaudeSonnetModel:
         result = create_claude_sonnet_model()
         assert result.startswith("claude-")
         assert "@" in result
+
+    def test_claude_with_retry_registered(self):
+        """_ClaudeWithRetry が LLMRegistry に登録されていること。"""
+        from google.adk.models.registry import LLMRegistry
+
+        # LLMRegistry.register() が呼び出されたこと
+        assert LLMRegistry.register.called
+        # 最後の register 呼び出しの引数が _ClaudeWithRetry クラスであること
+        registered_cls = LLMRegistry.register.call_args_list[-1][0][0]
+        assert registered_cls.__name__ == "_ClaudeWithRetry"
+
+    def test_claude_max_retries_value(self):
+        """_CLAUDE_MAX_RETRIES が 10 であること。"""
+        assert _CLAUDE_MAX_RETRIES == 10


### PR DESCRIPTION
## Summary

- ADK の `Claude` クラスは `AsyncAnthropicVertex` に `max_retries` を渡さないため、Anthropic SDK のデフォルト（2回）しかリトライされず、Vertex AI の 429 RESOURCE_EXHAUSTED で即クラッシュしていた
- `_ClaudeWithRetry` サブクラスを定義し `max_retries=10` を明示的に設定、`LLMRegistry` に登録
- `create_claude_sonnet_model()` のインターフェースは変更なし（文字列を返す → LLMRegistry 経由で `_ClaudeWithRetry` に解決）

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `shared/model_config.py` | `_ClaudeWithRetry` サブクラス定義 + `LLMRegistry` 登録 |
| `tests/conftest.py` | `anthropic` モジュールモック + `_MockClaude` スタブ追加 |
| `tests/unit/test_model_config.py` | `_ClaudeWithRetry` 登録検証 + `_CLAUDE_MAX_RETRIES` 値検証 |

## Test plan

- [x] `python -m pytest tests/unit/test_model_config.py -v` — 8 passed
- [x] `python -m pytest tests/unit/ -v` — 904 passed（既存テスト回帰なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)