### PR TITLE
fix: Claude Sonnet 429 リトライ修正第2弾（LLMRegistry バイパス + オーケストレーターリトライ）

### DIFF
--- a/shared/model_config.py
+++ b/shared/model_config.py
@@ -9,8 +9,12 @@ ADK はデフォルトで retry_options=None（リトライ0回）のため、
 参照: https://google.github.io/adk-docs/agents/models/google-gemini/
 """
 
+import logging
+
 from google.adk.models.google_llm import Gemini
 from google.genai.types import HttpRetryOptions
+
+logger = logging.getLogger(__name__)
 
 # === 日本語訳 ===
 # Claude (Vertex AI) のリトライ回数上限。
@@ -18,6 +22,10 @@ from google.genai.types import HttpRetryOptions
 # 10回に引き上げる。指数バックオフは SDK が自動適用する。
 # === End 日本語訳 ===
 _CLAUDE_MAX_RETRIES = 10
+
+# _ClaudeWithRetry クラスの参照（try ブロック外に sentinel 定義）
+# anthropic パッケージが未インストールの場合は None のまま
+_claude_with_retry_cls = None
 
 # Claude モデルの LLMRegistry 登録（Vertex AI 経由）
 # anthropic パッケージが未インストールの場合はスキップ（テスト環境等）
@@ -55,6 +63,10 @@ try:
                 headers = get_tracking_headers()
             except ImportError:
                 headers = {}
+            logger.info(
+                "AsyncAnthropicVertex 初期化: max_retries=%d",
+                _CLAUDE_MAX_RETRIES,
+            )
             return AsyncAnthropicVertex(
                 project_id=os.environ["GOOGLE_CLOUD_PROJECT"],
                 region=os.environ["GOOGLE_CLOUD_LOCATION"],
@@ -62,7 +74,11 @@ try:
                 max_retries=_CLAUDE_MAX_RETRIES,
             )
 
+    _claude_with_retry_cls = _ClaudeWithRetry
     LLMRegistry.register(_ClaudeWithRetry)
+    # ADK が自動登録した Claude の LRU キャッシュを無効化し、
+    # _ClaudeWithRetry が resolve() で返されるようにする
+    LLMRegistry.resolve.cache_clear()
 except ImportError:
     pass
 
@@ -114,11 +130,14 @@ def create_flash_model() -> Gemini:
     return Gemini(model=MODEL_FLASH, retry_options=_FLASH_RETRY_OPTIONS)
 
 
-def create_claude_sonnet_model() -> str:
-    """Claude Sonnet 4.5 (Vertex AI) のモデル文字列を返す。
+def create_claude_sonnet_model():
+    """Claude Sonnet 4.5 (Vertex AI) のモデルを返す。
 
-    Claude は ADK の LLMRegistry 経由で _ClaudeWithRetry に解決されるため、
-    Gemini のようなアダプタオブジェクトではなくモデル文字列を返す。
-    リトライは _ClaudeWithRetry が max_retries=10 で Anthropic SDK に委譲する。
+    _ClaudeWithRetry が利用可能な場合はインスタンスを直接返す。
+    LlmAgent(model=BaseLlm_instance) は LLMRegistry.resolve() を完全にバイパスするため、
+    ADK 自動登録 Claude の LRU キャッシュ問題を根本解決する。
+    利用不可能な場合はモデル文字列にフォールバック。
     """
+    if _claude_with_retry_cls is not None:
+        return _claude_with_retry_cls(model=MODEL_CLAUDE_SONNET)
     return MODEL_CLAUDE_SONNET

--- a/shared/orchestrator.py
+++ b/shared/orchestrator.py
@@ -48,6 +48,22 @@ def _format_exception_group(exc: BaseException) -> str:
     return " | ".join(parts)
 
 
+def _is_rate_limit_error(exc: BaseException) -> bool:
+    """429 レート制限エラーか判定する。ExceptionGroup も再帰的にチェック。"""
+    if isinstance(exc, ExceptionGroup):
+        return any(_is_rate_limit_error(sub) for sub in exc.exceptions)
+    error_str = str(exc)
+    return "429" in error_str or "RESOURCE_EXHAUSTED" in error_str
+
+
+# === 日本語訳 ===
+# レートリミットリトライ設定
+# SDK の 10回リトライ（~70秒）で解決しない長時間レート制限に対応するため、
+# オーケストレーターレベルで 3分待ってパイプラインを再実行する（最大2回リトライ）。
+# === End 日本語訳 ===
+_RATE_LIMIT_RETRY_DELAY = 180  # 3分
+_RATE_LIMIT_MAX_RETRIES = 2    # 最大2回リトライ（計3回試行）
+
 # スキップされたエージェント判定の閾値（秒）
 _SKIP_DURATION_THRESHOLD = 0.5
 
@@ -230,193 +246,224 @@ async def run_pipeline(
     pipeline_start_time = time.monotonic()
     logger.info("パイプライン開始: %s", run_type, extra={"status": "started"})
 
-    # Runner + Session セットアップ
-    session_service = InMemorySessionService()
-    runner = Runner(
-        agent=agent,
-        app_name=app_name,
-        session_service=session_service,
-    )
-
     user_id = "pipeline_user"
     session_id = "pipeline_session"
 
-    state = {
-        "pipeline_log": [],
-        "pipeline_run_id": run_id,
-        **initial_state,
-    }
-
-    await session_service.create_session(
-        app_name=app_name,
-        user_id=user_id,
-        session_id=session_id,
-        state=state,
-    )
-
-    # 進捗追跡（並列対応: エージェントごとの dict で管理）
-    pipeline_logger = PipelineLogger()
-    agent_texts: dict[str, list[str]] = {}  # {agent_name: [text_chunks]}
-    agent_log_indices: dict[str, int | None] = {}  # {agent_name: firestore_index}
-
-    run_config = RunConfig(max_llm_calls=max_llm_calls)
-
-    try:
-        async with asyncio.timeout(timeout_seconds):
-            async for event in runner.run_async(
-                user_id=user_id,
-                session_id=session_id,
-                new_message=types.Content(
-                    role="user",
-                    parts=[types.Part(text=user_message)],
-                ),
-                run_config=run_config,
-            ):
-                # エージェント遷移検出
-                author = getattr(event, "author", None)
-                if not author or author in skip_authors:
-                    # skip_authors のイベントはステージ境界として検出
-                    # 前ステージの全 active エージェントを一括完了
-                    if author and author in skip_authors and agent_texts:
-                        for name in list(agent_texts.keys()):
-                            _complete_agent(
-                                pipeline_logger,
-                                run_id,
-                                name,
-                                agent_texts.pop(name),
-                                agent_log_indices.pop(name, None),
-                            )
-                    continue
-
-                # 順次実行エージェントの直列完了:
-                # 同セット内の既存 active エージェントを自動完了する
-                if sequential_agents and author in sequential_agents:
-                    for name in list(agent_texts.keys()):
-                        if name in sequential_agents and name != author:
-                            _complete_agent(
-                                pipeline_logger,
-                                run_id,
-                                name,
-                                agent_texts.pop(name),
-                                agent_log_indices.pop(name, None),
-                            )
-
-                # 新規エージェントの場合のみエントリ作成
-                if author not in agent_texts:
-                    agent_texts[author] = []
-                    pipeline_logger.start_agent(author)
-                    logger.info(
-                        "エージェント開始: %s", author,
-                        extra={"agent_name": author, "status": "started"},
-                    )
-                    agent_log_indices[author] = update_agent_started(
-                        run_id, author, pipeline_logger.get_logs()[-1]
-                    )
-
-                # テキスト出力処理
-                if event.content and event.content.parts:
-                    for part in event.content.parts:
-                        if hasattr(part, "text") and part.text:
-                            if on_text:
-                                on_text(part.text)
-                            agent_texts[author].append(part.text[:100])
-
-        # 残存エージェントを完了マーク
-        for name in list(agent_texts.keys()):
-            _complete_agent(
-                pipeline_logger,
-                run_id,
-                name,
-                agent_texts.pop(name),
-                agent_log_indices.pop(name, None),
+    # レートリミットリトライループ
+    # SDK の 10回リトライで解決しない長時間レート制限に対応
+    last_error: Exception | None = None
+    for attempt in range(_RATE_LIMIT_MAX_RETRIES + 1):
+        if attempt > 0:
+            logger.warning(
+                "レートリミットエラー: %d秒後にパイプラインをリトライ (試行 %d/%d)",
+                _RATE_LIMIT_RETRY_DELAY, attempt + 1, _RATE_LIMIT_MAX_RETRIES + 1,
+                extra={"status": "retrying", "attempt": attempt + 1},
             )
+            await asyncio.sleep(_RATE_LIMIT_RETRY_DELAY)
 
-        # セッション状態を取得
-        session = await session_service.get_session(
+        # 各試行で Session/Runner を再作成
+        session_service = InMemorySessionService()
+        runner = Runner(
+            agent=agent,
+            app_name=app_name,
+            session_service=session_service,
+        )
+
+        state = {
+            "pipeline_log": [],
+            "pipeline_run_id": run_id,
+            **initial_state,
+        }
+
+        await session_service.create_session(
             app_name=app_name,
             user_id=user_id,
             session_id=session_id,
+            state=state,
         )
-        session_state = dict(session.state) if session else {}
 
-        # pipeline_log をセッション状態に保存
-        if session:
-            session.state["pipeline_log"] = pipeline_logger.get_logs()
+        # 進捗追跡（並列対応: エージェントごとの dict で管理）
+        pipeline_logger = PipelineLogger()
+        agent_texts: dict[str, list[str]] = {}  # {agent_name: [text_chunks]}
+        agent_log_indices: dict[str, int | None] = {}  # {agent_name: firestore_index}
 
-        # mystery_id 抽出（blog パイプラインのみ）
-        mystery_id = None
-        if run_type == "blog" and session_state:
-            # 優先: ツールがセッション状態に直接書き込んだ mystery_id
-            mystery_id = session_state.get("published_mystery_id")
+        run_config = RunConfig(max_llm_calls=max_llm_calls)
 
-            # フォールバック: published_episode テキストから抽出
-            if not mystery_id:
-                published = session_state.get("published_episode", "")
-                if isinstance(published, str):
-                    text = published.strip()
-                    if text.startswith("{"):
-                        try:
-                            published_data = json.loads(text)
-                            mystery_id = published_data.get("mystery_id")
-                        except (json.JSONDecodeError, AttributeError):
-                            pass
-                elif isinstance(published, dict):
-                    mystery_id = published.get("mystery_id")
+        try:
+            async with asyncio.timeout(timeout_seconds):
+                async for event in runner.run_async(
+                    user_id=user_id,
+                    session_id=session_id,
+                    new_message=types.Content(
+                        role="user",
+                        parts=[types.Part(text=user_message)],
+                    ),
+                    run_config=run_config,
+                ):
+                    # エージェント遷移検出
+                    author = getattr(event, "author", None)
+                    if not author or author in skip_authors:
+                        # skip_authors のイベントはステージ境界として検出
+                        # 前ステージの全 active エージェントを一括完了
+                        if author and author in skip_authors and agent_texts:
+                            for name in list(agent_texts.keys()):
+                                _complete_agent(
+                                    pipeline_logger,
+                                    run_id,
+                                    name,
+                                    agent_texts.pop(name),
+                                    agent_log_indices.pop(name, None),
+                                )
+                        continue
 
-        # mystery_id をコンテキストに追加
-        if mystery_id:
-            set_pipeline_context(PipelineContext(
-                run_id=run_id, pipeline_type=run_type, mystery_id=mystery_id,
-            ))
+                    # 順次実行エージェントの直列完了:
+                    # 同セット内の既存 active エージェントを自動完了する
+                    if sequential_agents and author in sequential_agents:
+                        for name in list(agent_texts.keys()):
+                            if name in sequential_agents and name != author:
+                                _complete_agent(
+                                    pipeline_logger,
+                                    run_id,
+                                    name,
+                                    agent_texts.pop(name),
+                                    agent_log_indices.pop(name, None),
+                                )
 
-        # blog パイプラインで記事未生成の場合、ゲート失敗を検出してエラーマーク
-        if run_type == "blog" and mystery_id is None:
-            failure_reason, detail = _detect_gate_failure(session_state)
+                    # 新規エージェントの場合のみエントリ作成
+                    if author not in agent_texts:
+                        agent_texts[author] = []
+                        pipeline_logger.start_agent(author)
+                        logger.info(
+                            "エージェント開始: %s", author,
+                            extra={"agent_name": author, "status": "started"},
+                        )
+                        agent_log_indices[author] = update_agent_started(
+                            run_id, author, pipeline_logger.get_logs()[-1]
+                        )
+
+                    # テキスト出力処理
+                    if event.content and event.content.parts:
+                        for part in event.content.parts:
+                            if hasattr(part, "text") and part.text:
+                                if on_text:
+                                    on_text(part.text)
+                                agent_texts[author].append(part.text[:100])
+
+            # 残存エージェントを完了マーク
+            for name in list(agent_texts.keys()):
+                _complete_agent(
+                    pipeline_logger,
+                    run_id,
+                    name,
+                    agent_texts.pop(name),
+                    agent_log_indices.pop(name, None),
+                )
+
+            # セッション状態を取得
+            session = await session_service.get_session(
+                app_name=app_name,
+                user_id=user_id,
+                session_id=session_id,
+            )
+            session_state = dict(session.state) if session else {}
+
+            # pipeline_log をセッション状態に保存
+            if session:
+                session.state["pipeline_log"] = pipeline_logger.get_logs()
+
+            # mystery_id 抽出（blog パイプラインのみ）
+            mystery_id = None
+            if run_type == "blog" and session_state:
+                # 優先: ツールがセッション状態に直接書き込んだ mystery_id
+                mystery_id = session_state.get("published_mystery_id")
+
+                # フォールバック: published_episode テキストから抽出
+                if not mystery_id:
+                    published = session_state.get("published_episode", "")
+                    if isinstance(published, str):
+                        text = published.strip()
+                        if text.startswith("{"):
+                            try:
+                                published_data = json.loads(text)
+                                mystery_id = published_data.get("mystery_id")
+                            except (json.JSONDecodeError, AttributeError):
+                                pass
+                    elif isinstance(published, dict):
+                        mystery_id = published.get("mystery_id")
+
+            # mystery_id をコンテキストに追加
+            if mystery_id:
+                set_pipeline_context(PipelineContext(
+                    run_id=run_id, pipeline_type=run_type, mystery_id=mystery_id,
+                ))
+
+            # blog パイプラインで記事未生成の場合、ゲート失敗を検出してエラーマーク
+            if run_type == "blog" and mystery_id is None:
+                failure_reason, detail = _detect_gate_failure(session_state)
+                logger.error(
+                    "ゲート失敗: %s (stage=%s)",
+                    failure_reason,
+                    detail.get("failed_stage", "unknown"),
+                    extra={"status": "error", **detail},
+                )
+                error_pipeline_run(run_id, failure_reason, error_detail=detail)
+            else:
+                # パイプライン正常完了サマリ
+                completed_logs = pipeline_logger.get_logs()
+                total_agents = len(completed_logs)
+                total_duration = round(time.monotonic() - pipeline_start_time, 1)
+                logger.info(
+                    "パイプライン完了: %s (エージェント数=%d, 合計%.1fs)",
+                    run_type, total_agents, total_duration,
+                    extra={
+                        "status": "completed",
+                        "agent_count": total_agents,
+                        "total_duration_seconds": total_duration,
+                        "mystery_id": mystery_id or "",
+                    },
+                )
+                complete_pipeline_run(run_id, mystery_id=mystery_id)
+
+            return PipelineResult(
+                run_id=run_id,
+                mystery_id=mystery_id,
+                logs=pipeline_logger.get_logs(),
+                session_state=session_state,
+            )
+
+        except TimeoutError:
+            error_pipeline_run(run_id, f"Pipeline timed out after {timeout_seconds}s", error_detail={
+                "error_type": "timeout",
+                "timeout_seconds": timeout_seconds,
+            })
+            raise
+        except Exception as e:
+            # 429 レートリミットエラーの場合はリトライ
+            if _is_rate_limit_error(e) and attempt < _RATE_LIMIT_MAX_RETRIES:
+                last_error = e
+                logger.warning(
+                    "レートリミットエラー検出: %s", _format_exception_group(e),
+                    extra={"status": "rate_limited", "attempt": attempt + 1},
+                )
+                continue
+
+            error_message = _format_exception_group(e)
             logger.error(
-                "ゲート失敗: %s (stage=%s)",
-                failure_reason,
-                detail.get("failed_stage", "unknown"),
-                extra={"status": "error", **detail},
+                "Pipeline failed: %s", error_message, exc_info=True,
+                extra={"status": "error", "exception_class": type(e).__name__},
             )
-            error_pipeline_run(run_id, failure_reason, error_detail=detail)
-        else:
-            # パイプライン正常完了サマリ
-            completed_logs = pipeline_logger.get_logs()
-            total_agents = len(completed_logs)
-            total_duration = round(time.monotonic() - pipeline_start_time, 1)
-            logger.info(
-                "パイプライン完了: %s (エージェント数=%d, 合計%.1fs)",
-                run_type, total_agents, total_duration,
-                extra={
-                    "status": "completed",
-                    "agent_count": total_agents,
-                    "total_duration_seconds": total_duration,
-                    "mystery_id": mystery_id or "",
-                },
-            )
-            complete_pipeline_run(run_id, mystery_id=mystery_id)
+            error_pipeline_run(run_id, error_message, error_detail={
+                "error_type": "exception",
+                "exception_class": type(e).__name__,
+            })
+            raise
 
-        return PipelineResult(
-            run_id=run_id,
-            mystery_id=mystery_id,
-            logs=pipeline_logger.get_logs(),
-            session_state=session_state,
-        )
-
-    except TimeoutError:
-        error_pipeline_run(run_id, f"Pipeline timed out after {timeout_seconds}s", error_detail={
-            "error_type": "timeout",
-            "timeout_seconds": timeout_seconds,
-        })
-        raise
-    except Exception as e:
-        error_message = _format_exception_group(e)
-        logger.error(
-            "Pipeline failed: %s", error_message, exc_info=True,
-            extra={"status": "error", "exception_class": type(e).__name__},
-        )
-        error_pipeline_run(run_id, error_message, error_detail={
-            "error_type": "exception",
-            "exception_class": type(e).__name__,
-        })
-        raise
+    # リトライ上限到達（通常ここには到達しない — 最後の try で raise されるため）
+    assert last_error is not None
+    error_message = _format_exception_group(last_error)
+    error_pipeline_run(run_id, error_message, error_detail={
+        "error_type": "rate_limit_exhausted",
+        "exception_class": type(last_error).__name__,
+        "retry_attempts": _RATE_LIMIT_MAX_RETRIES + 1,
+    })
+    raise last_error

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,10 +29,11 @@ mock_adk.utils.context_utils = MagicMock()
 mock_adk.models = MagicMock()
 mock_adk.models.google_llm = MagicMock()
 mock_adk.models.llm_response = MagicMock()
-# _ClaudeWithRetry のサブクラス化に必要な実クラス
+# _ClaudeWithRetry のサブクラス化 + インスタンス化に必要な実クラス
 class _MockClaude:
     """テスト用 Claude スタブ。model_config._ClaudeWithRetry の親クラスとして使用。"""
-    pass
+    def __init__(self, *, model=None, **kwargs):
+        self.model = model
 
 mock_adk.models.anthropic_llm = MagicMock()
 mock_adk.models.anthropic_llm.Claude = _MockClaude

--- a/tests/unit/test_model_config.py
+++ b/tests/unit/test_model_config.py
@@ -66,19 +66,20 @@ class TestCreateFlashModel:
 class TestCreateClaudeSonnetModel:
     """create_claude_sonnet_model() のテスト。"""
 
-    def test_returns_model_string(self):
-        """戻り値が MODEL_CLAUDE_SONNET と一致すること。"""
-        result = create_claude_sonnet_model()
-        assert result == MODEL_CLAUDE_SONNET
+    def test_returns_instance(self):
+        """_ClaudeWithRetry インスタンスが返されること（LLMRegistry バイパス）。"""
+        from shared.model_config import _claude_with_retry_cls
 
-    def test_model_string_format(self):
-        """モデル文字列が Vertex AI 形式（claude- プレフィックス + @ セパレータ）であること。"""
         result = create_claude_sonnet_model()
-        assert result.startswith("claude-")
-        assert "@" in result
+        # _claude_with_retry_cls が None でない場合はインスタンスが返される
+        if _claude_with_retry_cls is not None:
+            assert isinstance(result, _claude_with_retry_cls)
+        else:
+            # anthropic が未インストールの場合はモデル文字列にフォールバック
+            assert result == MODEL_CLAUDE_SONNET
 
     def test_claude_with_retry_registered(self):
-        """_ClaudeWithRetry が LLMRegistry に登録されていること。"""
+        """_ClaudeWithRetry が LLMRegistry に登録され、cache_clear が呼ばれていること。"""
         from google.adk.models.registry import LLMRegistry
 
         # LLMRegistry.register() が呼び出されたこと
@@ -86,6 +87,8 @@ class TestCreateClaudeSonnetModel:
         # 最後の register 呼び出しの引数が _ClaudeWithRetry クラスであること
         registered_cls = LLMRegistry.register.call_args_list[-1][0][0]
         assert registered_cls.__name__ == "_ClaudeWithRetry"
+        # ADK 自動登録 Claude の LRU キャッシュ無効化が呼ばれていること
+        assert LLMRegistry.resolve.cache_clear.called
 
     def test_claude_max_retries_value(self):
         """_CLAUDE_MAX_RETRIES が 10 であること。"""

--- a/tests/unit/test_orchestrator_retry.py
+++ b/tests/unit/test_orchestrator_retry.py
@@ -1,0 +1,208 @@
+"""shared/orchestrator のレートリミットリトライのユニットテスト。
+
+_is_rate_limit_error() の判定ロジックと、
+run_pipeline() が 429 エラー時にリトライすることを検証する。
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from shared.orchestrator import (
+    _RATE_LIMIT_MAX_RETRIES,
+    _RATE_LIMIT_RETRY_DELAY,
+    _is_rate_limit_error,
+    run_pipeline,
+)
+
+
+class TestIsRateLimitError:
+    """_is_rate_limit_error() のテスト。"""
+
+    def test_with_429_in_message(self):
+        """エラーメッセージに '429' が含まれる場合に True を返すこと。"""
+        exc = Exception("Error code: 429 Too Many Requests")
+        assert _is_rate_limit_error(exc) is True
+
+    def test_with_resource_exhausted(self):
+        """エラーメッセージに 'RESOURCE_EXHAUSTED' が含まれる場合に True を返すこと。"""
+        exc = Exception("RESOURCE_EXHAUSTED: Quota exceeded")
+        assert _is_rate_limit_error(exc) is True
+
+    def test_with_other_error(self):
+        """429 でも RESOURCE_EXHAUSTED でもないエラーは False を返すこと。"""
+        exc = Exception("Internal server error 500")
+        assert _is_rate_limit_error(exc) is False
+
+    def test_with_exception_group_containing_429(self):
+        """ExceptionGroup 内に 429 エラーがある場合に True を返すこと。"""
+        inner = Exception("429 rate limited")
+        group = ExceptionGroup("pipeline errors", [inner])
+        assert _is_rate_limit_error(group) is True
+
+    def test_with_exception_group_no_rate_limit(self):
+        """ExceptionGroup 内にレートリミットエラーがない場合に False を返すこと。"""
+        inner = Exception("Some other error")
+        group = ExceptionGroup("pipeline errors", [inner])
+        assert _is_rate_limit_error(group) is False
+
+    def test_with_nested_exception_group(self):
+        """ネストした ExceptionGroup 内の 429 エラーも検出すること。"""
+        inner = Exception("RESOURCE_EXHAUSTED")
+        inner_group = ExceptionGroup("inner", [inner])
+        outer_group = ExceptionGroup("outer", [inner_group])
+        assert _is_rate_limit_error(outer_group) is True
+
+
+class TestRateLimitConstants:
+    """レートリミットリトライ定数のテスト。"""
+
+    def test_retry_delay_is_180_seconds(self):
+        """リトライ間隔が 180秒（3分）であること。"""
+        assert _RATE_LIMIT_RETRY_DELAY == 180
+
+    def test_max_retries_is_2(self):
+        """最大リトライ回数が 2回であること（計3回試行）。"""
+        assert _RATE_LIMIT_MAX_RETRIES == 2
+
+
+class TestRunPipelineRetry:
+    """run_pipeline() のレートリミットリトライのテスト。"""
+
+    @pytest.mark.asyncio
+    async def test_retries_on_rate_limit(self):
+        """429 エラー時にリトライされ、2回目で成功すること。"""
+        mock_agent = MagicMock()
+
+        # Runner.run_async のモック:
+        # 1回目: 429 例外を送出
+        # 2回目: 正常終了（空のイベントストリーム）
+        call_count = 0
+
+        async def mock_run_async(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise Exception("429 Too Many Requests")
+            # 2回目: 空のイベントストリーム（正常終了）
+            return
+            yield  # async generator にする
+
+        mock_runner_cls = MagicMock()
+        mock_runner_instance = MagicMock()
+        mock_runner_instance.run_async = mock_run_async
+        mock_runner_cls.return_value = mock_runner_instance
+
+        mock_session_service_cls = MagicMock()
+        mock_session_service = AsyncMock()
+        mock_session = MagicMock()
+        mock_session.state = {"pipeline_log": []}
+        mock_session_service.create_session = AsyncMock()
+        mock_session_service.get_session = AsyncMock(return_value=mock_session)
+        mock_session_service_cls.return_value = mock_session_service
+
+        with (
+            patch("shared.orchestrator.Runner", mock_runner_cls),
+            patch("shared.orchestrator.InMemorySessionService", mock_session_service_cls),
+            patch("shared.orchestrator.create_pipeline_run", return_value="test-run-id"),
+            patch("shared.orchestrator.set_pipeline_context"),
+            patch("shared.orchestrator.update_agent_started"),
+            patch("shared.orchestrator.update_agent_completed"),
+            patch("shared.orchestrator.complete_pipeline_run"),
+            patch("shared.orchestrator.error_pipeline_run"),
+            patch("shared.orchestrator._RATE_LIMIT_RETRY_DELAY", 0),  # テストではスリープしない
+        ):
+            result = await run_pipeline(
+                agent=mock_agent,
+                app_name="test_app",
+                user_message="test query",
+                initial_state={},
+                run_type="podcast",  # blog だとゲート失敗判定が必要
+            )
+
+        assert result.run_id == "test-run-id"
+        assert call_count == 2  # 1回目失敗 + 2回目成功
+
+    @pytest.mark.asyncio
+    async def test_raises_after_max_retries(self):
+        """最大リトライ回数を超えた場合に例外が送出されること。"""
+        mock_agent = MagicMock()
+
+        async def mock_run_async(**kwargs):
+            raise Exception("429 Too Many Requests")
+            yield  # async generator にする
+
+        mock_runner_cls = MagicMock()
+        mock_runner_instance = MagicMock()
+        mock_runner_instance.run_async = mock_run_async
+        mock_runner_cls.return_value = mock_runner_instance
+
+        mock_session_service_cls = MagicMock()
+        mock_session_service = AsyncMock()
+        mock_session_service.create_session = AsyncMock()
+        mock_session_service_cls.return_value = mock_session_service
+
+        with (
+            patch("shared.orchestrator.Runner", mock_runner_cls),
+            patch("shared.orchestrator.InMemorySessionService", mock_session_service_cls),
+            patch("shared.orchestrator.create_pipeline_run", return_value="test-run-id"),
+            patch("shared.orchestrator.set_pipeline_context"),
+            patch("shared.orchestrator.update_agent_started"),
+            patch("shared.orchestrator.update_agent_completed"),
+            patch("shared.orchestrator.complete_pipeline_run"),
+            patch("shared.orchestrator.error_pipeline_run") as mock_error,
+            patch("shared.orchestrator._RATE_LIMIT_RETRY_DELAY", 0),
+        ):
+            with pytest.raises(Exception, match="429"):
+                await run_pipeline(
+                    agent=mock_agent,
+                    app_name="test_app",
+                    user_message="test query",
+                    initial_state={},
+                    run_type="podcast",
+                )
+
+    @pytest.mark.asyncio
+    async def test_non_rate_limit_error_not_retried(self):
+        """429 以外のエラーはリトライせずに即座に送出されること。"""
+        mock_agent = MagicMock()
+        call_count = 0
+
+        async def mock_run_async(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise Exception("Internal server error 500")
+            yield
+
+        mock_runner_cls = MagicMock()
+        mock_runner_instance = MagicMock()
+        mock_runner_instance.run_async = mock_run_async
+        mock_runner_cls.return_value = mock_runner_instance
+
+        mock_session_service_cls = MagicMock()
+        mock_session_service = AsyncMock()
+        mock_session_service.create_session = AsyncMock()
+        mock_session_service_cls.return_value = mock_session_service
+
+        with (
+            patch("shared.orchestrator.Runner", mock_runner_cls),
+            patch("shared.orchestrator.InMemorySessionService", mock_session_service_cls),
+            patch("shared.orchestrator.create_pipeline_run", return_value="test-run-id"),
+            patch("shared.orchestrator.set_pipeline_context"),
+            patch("shared.orchestrator.update_agent_started"),
+            patch("shared.orchestrator.update_agent_completed"),
+            patch("shared.orchestrator.complete_pipeline_run"),
+            patch("shared.orchestrator.error_pipeline_run"),
+            patch("shared.orchestrator._RATE_LIMIT_RETRY_DELAY", 0),
+        ):
+            with pytest.raises(Exception, match="500"):
+                await run_pipeline(
+                    agent=mock_agent,
+                    app_name="test_app",
+                    user_message="test query",
+                    initial_state={},
+                    run_type="podcast",
+                )
+
+        assert call_count == 1  # リトライなし


### PR DESCRIPTION
## Summary

PR #265 で `_ClaudeWithRetry`（`max_retries=10`）を `LLMRegistry` に登録したが、デプロイ後も 429 エラーが再発していた。

### 根本原因
ADK の `LLMRegistry.resolve()` に **`@lru_cache(maxsize=32)`** がかかっており、ADK が自動登録した `Claude` クラスがキャッシュされ続けるため、後から登録した `_ClaudeWithRetry` が無視されていた。

### 修正内容

**SDK レベル（model_config.py）:**
- `create_claude_sonnet_model()` が `_ClaudeWithRetry` **インスタンス** を直接返却
- `LlmAgent(model=BaseLlm_instance)` は `LLMRegistry.resolve()` を**完全にバイパス**するため、LRU cache 問題を根本解決
- `LLMRegistry.resolve.cache_clear()` も追加（他コードが LLMRegistry を使う場合のセーフティネット）
- `AsyncAnthropicVertex` 初期化時にログ出力（`max_retries` 値の確認用）

**オーケストレーターレベル（orchestrator.py）:**
- `_is_rate_limit_error()` ヘルパー追加（ExceptionGroup 再帰対応）
- `run_pipeline()` に 429 エラー時のリトライループ追加（180秒待機 × 最大2回リトライ、計3回試行）
- Session/Runner を各試行で再作成（前回の状態を引き継がない）

## Test plan
- [x] `test_model_config.py`: `create_claude_sonnet_model()` がインスタンスを返すこと、`cache_clear` が呼ばれていること
- [x] `test_orchestrator_retry.py`: 429 判定、ExceptionGroup 対応、リトライ成功、最大リトライ到達時の例外送出、非429エラーはリトライなし
- [x] 全ユニットテスト回帰確認（914 passed, 1 failed — 失敗は既存の Storyteller プロンプト変更テストで本 PR とは無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)