### PR TITLE
fix: Firebase Emulator データ永続化（--import / --export-on-exit）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ out/
 *.tsbuildinfo
 
 # Firebase Emulator data
+.firebase-emulator-data/
 firebase-debug.log
 firestore-debug.log
 ui-debug.log

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -115,7 +115,10 @@ start_emulator() {
     fi
 
     log_info "Firebase エミュレータを起動中..."
-    firebase emulators:start --project ghostinthearchive &
+    EMULATOR_DATA_DIR="$PROJECT_ROOT/.firebase-emulator-data"
+    firebase emulators:start --project ghostinthearchive \
+        --import="$EMULATOR_DATA_DIR" \
+        --export-on-exit="$EMULATOR_DATA_DIR" &
     EMULATOR_PID=$!
 
     # エミュレータ起動を待つ


### PR DESCRIPTION
## Summary

- Emulator 終了時に `.firebase-emulator-data/` へデータを自動エクスポート（`--export-on-exit`）
- Emulator 起動時に `.firebase-emulator-data/` からデータを自動インポート（`--import`）
- `.gitignore` にエクスポートディレクトリを追加

## 変更ファイル

- `scripts/dev.sh` — `start_emulator()` に `--import` / `--export-on-exit` オプション追加
- `.gitignore` — `.firebase-emulator-data/` を除外

## Test plan

- [ ] `./scripts/dev.sh emulator` で Emulator 起動
- [ ] Emulator UI (`http://localhost:4000`) から Firestore にテストデータを追加
- [ ] `Ctrl+C` で停止 → `.firebase-emulator-data/` ディレクトリが作成されることを確認
- [ ] 再度 `./scripts/dev.sh emulator` で起動 → テストデータが残っていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)