### PR TITLE
fix: docker-compose に ANTHROPIC_API_KEY を追加（Storyteller 用）

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,5 +33,6 @@ services:
       - FIRESTORE_EMULATOR_HOST=host.docker.internal:8080
       - STORAGE_EMULATOR_HOST=http://host.docker.internal:9199
       - STORAGE_EMULATOR_PUBLIC_HOST=http://localhost:9199
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
     volumes:
       - ${HOME}/.config/gcloud/application_default_credentials.json:/tmp/keys/adc.json:ro


### PR DESCRIPTION
## Summary

- pipeline-server の環境変数に `ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}` を追加
- `.env` から値を読み込んでコンテナに注入する（ローカル開発用）

## Test plan

- [x] `docker compose config` で環境変数が展開されることを確認
- [x] 既存サービス（curator）に影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)