### PR TITLE
fix: ParallelAgent 内の一時的接続エラーにリトライを適用

### DIFF
--- a/shared/orchestrator.py
+++ b/shared/orchestrator.py
@@ -56,13 +56,39 @@ def _is_rate_limit_error(exc: BaseException) -> bool:
     return "429" in error_str or "RESOURCE_EXHAUSTED" in error_str
 
 
+# 一時的接続エラーの判定マーカー（httpx を import せず文字列ベースで判定）
+_TRANSIENT_ERROR_MARKERS = (
+    "RemoteProtocolError",
+    "Server disconnected",
+    "NetworkError",
+    "ConnectError",
+    "ReadError",
+    "WriteError",
+    "ReadTimeout",
+    "ConnectTimeout",
+    "PoolTimeout",
+    "ConnectionReset",
+    "ConnectionRefused",
+)
+
+
+def _is_transient_connection_error(exc: BaseException) -> bool:
+    """一時的な接続エラーか判定する。ExceptionGroup も再帰的にチェック。"""
+    if isinstance(exc, ExceptionGroup):
+        return any(_is_transient_connection_error(sub) for sub in exc.exceptions)
+    exc_info = f"{type(exc).__name__} {exc}"
+    return any(marker in exc_info for marker in _TRANSIENT_ERROR_MARKERS)
+
+
 # === 日本語訳 ===
-# レートリミットリトライ設定
+# リトライ設定
 # SDK のリトライで解決しない長時間レート制限に対応するため、
 # オーケストレーターレベルで 1分待ってパイプラインを再実行する（最大1回リトライ）。
+# 接続エラーはより短い間隔（15秒）でリトライする。
 # === End 日本語訳 ===
 _RATE_LIMIT_RETRY_DELAY = 60   # 1分
 _RATE_LIMIT_MAX_RETRIES = 1    # 最大1回リトライ（計2回試行）
+_CONNECTION_ERROR_RETRY_DELAY = 15  # 接続エラー: 15秒
 
 # スキップされたエージェント判定の閾値（秒）
 _SKIP_DURATION_THRESHOLD = 0.5
@@ -249,17 +275,24 @@ async def run_pipeline(
     user_id = "pipeline_user"
     session_id = "pipeline_session"
 
-    # レートリミットリトライループ
-    # SDK の 10回リトライで解決しない長時間レート制限に対応
+    # リトライループ（レートリミット + 一時的接続エラー対応）
+    # SDK の 10回リトライで解決しない長時間レート制限、および
+    # トランスポート層の一時的接続エラー（RemoteProtocolError 等）に対応
     last_error: Exception | None = None
+    last_error_is_rate_limit: bool = False
     for attempt in range(_RATE_LIMIT_MAX_RETRIES + 1):
         if attempt > 0:
+            retry_delay = (
+                _RATE_LIMIT_RETRY_DELAY if last_error_is_rate_limit
+                else _CONNECTION_ERROR_RETRY_DELAY
+            )
+            error_label = "レートリミット" if last_error_is_rate_limit else "接続エラー"
             logger.warning(
-                "レートリミットエラー: %d秒後にパイプラインをリトライ (試行 %d/%d)",
-                _RATE_LIMIT_RETRY_DELAY, attempt + 1, _RATE_LIMIT_MAX_RETRIES + 1,
+                "%s: %d秒後にパイプラインをリトライ (試行 %d/%d)",
+                error_label, retry_delay, attempt + 1, _RATE_LIMIT_MAX_RETRIES + 1,
                 extra={"status": "retrying", "attempt": attempt + 1},
             )
-            await asyncio.sleep(_RATE_LIMIT_RETRY_DELAY)
+            await asyncio.sleep(retry_delay)
 
         # 各試行で Session/Runner を再作成
         session_service = InMemorySessionService()
@@ -441,9 +474,20 @@ async def run_pipeline(
             # 429 レートリミットエラーの場合はリトライ
             if _is_rate_limit_error(e) and attempt < _RATE_LIMIT_MAX_RETRIES:
                 last_error = e
+                last_error_is_rate_limit = True
                 logger.warning(
                     "レートリミットエラー検出: %s", _format_exception_group(e),
                     extra={"status": "rate_limited", "attempt": attempt + 1},
+                )
+                continue
+
+            # 一時的な接続エラーの場合はリトライ
+            if _is_transient_connection_error(e) and attempt < _RATE_LIMIT_MAX_RETRIES:
+                last_error = e
+                last_error_is_rate_limit = False
+                logger.warning(
+                    "一時的な接続エラー検出: %s", _format_exception_group(e),
+                    extra={"status": "connection_error", "attempt": attempt + 1},
                 )
                 continue
 
@@ -461,8 +505,9 @@ async def run_pipeline(
     # リトライ上限到達（通常ここには到達しない — 最後の try で raise されるため）
     assert last_error is not None
     error_message = _format_exception_group(last_error)
+    error_type = "rate_limit_exhausted" if last_error_is_rate_limit else "connection_error_exhausted"
     error_pipeline_run(run_id, error_message, error_detail={
-        "error_type": "rate_limit_exhausted",
+        "error_type": error_type,
         "exception_class": type(last_error).__name__,
         "retry_attempts": _RATE_LIMIT_MAX_RETRIES + 1,
     })

--- a/tests/unit/test_orchestrator_retry.py
+++ b/tests/unit/test_orchestrator_retry.py
@@ -1,7 +1,7 @@
-"""shared/orchestrator のレートリミットリトライのユニットテスト。
+"""shared/orchestrator のリトライのユニットテスト。
 
-_is_rate_limit_error() の判定ロジックと、
-run_pipeline() が 429 エラー時にリトライすることを検証する。
+_is_rate_limit_error() / _is_transient_connection_error() の判定ロジックと、
+run_pipeline() が 429 エラーおよび一時的接続エラー時にリトライすることを検証する。
 """
 
 import asyncio
@@ -10,9 +10,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from shared.orchestrator import (
+    _CONNECTION_ERROR_RETRY_DELAY,
     _RATE_LIMIT_MAX_RETRIES,
     _RATE_LIMIT_RETRY_DELAY,
     _is_rate_limit_error,
+    _is_transient_connection_error,
     run_pipeline,
 )
 
@@ -55,6 +57,57 @@ class TestIsRateLimitError:
         assert _is_rate_limit_error(outer_group) is True
 
 
+class TestIsTransientConnectionError:
+    """_is_transient_connection_error() のテスト。"""
+
+    def test_with_remote_protocol_error_class_name(self):
+        """クラス名に 'RemoteProtocolError' を含む例外を検出すること。"""
+        # httpx.RemoteProtocolError を模擬（httpx を import せずクラス名で判定）
+        class RemoteProtocolError(Exception):
+            pass
+        exc = RemoteProtocolError("Server disconnected without sending a response")
+        assert _is_transient_connection_error(exc) is True
+
+    def test_with_server_disconnected_message(self):
+        """メッセージに 'Server disconnected' を含む例外を検出すること。"""
+        exc = Exception("Server disconnected without sending a response")
+        assert _is_transient_connection_error(exc) is True
+
+    def test_with_connect_error(self):
+        """クラス名に 'ConnectError' を含む例外を検出すること。"""
+        class ConnectError(Exception):
+            pass
+        exc = ConnectError("Connection refused")
+        assert _is_transient_connection_error(exc) is True
+
+    def test_with_read_timeout(self):
+        """クラス名に 'ReadTimeout' を含む例外を検出すること。"""
+        class ReadTimeout(Exception):
+            pass
+        exc = ReadTimeout("Read timed out")
+        assert _is_transient_connection_error(exc) is True
+
+    def test_with_unrelated_error(self):
+        """無関係なエラーは False を返すこと。"""
+        exc = Exception("Invalid argument: bad request")
+        assert _is_transient_connection_error(exc) is False
+
+    def test_with_exception_group(self):
+        """ExceptionGroup 内の接続エラーを検出すること。"""
+        class RemoteProtocolError(Exception):
+            pass
+        inner = RemoteProtocolError("Server disconnected")
+        group = ExceptionGroup("pipeline errors", [inner])
+        assert _is_transient_connection_error(group) is True
+
+    def test_with_nested_exception_group(self):
+        """ネストした ExceptionGroup 内の接続エラーも検出すること。"""
+        inner = Exception("Server disconnected without sending a response")
+        inner_group = ExceptionGroup("inner", [inner])
+        outer_group = ExceptionGroup("outer", [inner_group])
+        assert _is_transient_connection_error(outer_group) is True
+
+
 class TestRateLimitConstants:
     """レートリミットリトライ定数のテスト。"""
 
@@ -65,6 +118,14 @@ class TestRateLimitConstants:
     def test_max_retries_is_1(self):
         """最大リトライ回数が 1回であること（計2回試行）。"""
         assert _RATE_LIMIT_MAX_RETRIES == 1
+
+
+class TestConnectionErrorConstants:
+    """接続エラーリトライ定数のテスト。"""
+
+    def test_connection_error_retry_delay_is_15_seconds(self):
+        """接続エラーのリトライ間隔が 15秒であること。"""
+        assert _CONNECTION_ERROR_RETRY_DELAY == 15
 
 
 class TestRunPipelineRetry:
@@ -206,3 +267,146 @@ class TestRunPipelineRetry:
                 )
 
         assert call_count == 1  # リトライなし
+
+    @pytest.mark.asyncio
+    async def test_retries_on_connection_error(self):
+        """接続エラー時にリトライされ、2回目で成功すること。"""
+        mock_agent = MagicMock()
+        call_count = 0
+
+        class RemoteProtocolError(Exception):
+            pass
+
+        async def mock_run_async(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RemoteProtocolError("Server disconnected without sending a response")
+            return
+            yield
+
+        mock_runner_cls = MagicMock()
+        mock_runner_instance = MagicMock()
+        mock_runner_instance.run_async = mock_run_async
+        mock_runner_cls.return_value = mock_runner_instance
+
+        mock_session_service_cls = MagicMock()
+        mock_session_service = AsyncMock()
+        mock_session = MagicMock()
+        mock_session.state = {"pipeline_log": []}
+        mock_session_service.create_session = AsyncMock()
+        mock_session_service.get_session = AsyncMock(return_value=mock_session)
+        mock_session_service_cls.return_value = mock_session_service
+
+        with (
+            patch("shared.orchestrator.Runner", mock_runner_cls),
+            patch("shared.orchestrator.InMemorySessionService", mock_session_service_cls),
+            patch("shared.orchestrator.create_pipeline_run", return_value="test-run-id"),
+            patch("shared.orchestrator.set_pipeline_context"),
+            patch("shared.orchestrator.update_agent_started"),
+            patch("shared.orchestrator.update_agent_completed"),
+            patch("shared.orchestrator.complete_pipeline_run"),
+            patch("shared.orchestrator.error_pipeline_run"),
+            patch("shared.orchestrator._CONNECTION_ERROR_RETRY_DELAY", 0),
+        ):
+            result = await run_pipeline(
+                agent=mock_agent,
+                app_name="test_app",
+                user_message="test query",
+                initial_state={},
+                run_type="podcast",
+            )
+
+        assert result.run_id == "test-run-id"
+        assert call_count == 2  # 1回目失敗 + 2回目成功
+
+    @pytest.mark.asyncio
+    async def test_connection_error_uses_shorter_delay(self):
+        """接続エラーのリトライが 15秒の遅延を使用すること。"""
+        mock_agent = MagicMock()
+        call_count = 0
+
+        async def mock_run_async(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise Exception("Server disconnected without sending a response")
+            return
+            yield
+
+        mock_runner_cls = MagicMock()
+        mock_runner_instance = MagicMock()
+        mock_runner_instance.run_async = mock_run_async
+        mock_runner_cls.return_value = mock_runner_instance
+
+        mock_session_service_cls = MagicMock()
+        mock_session_service = AsyncMock()
+        mock_session = MagicMock()
+        mock_session.state = {"pipeline_log": []}
+        mock_session_service.create_session = AsyncMock()
+        mock_session_service.get_session = AsyncMock(return_value=mock_session)
+        mock_session_service_cls.return_value = mock_session_service
+
+        with (
+            patch("shared.orchestrator.Runner", mock_runner_cls),
+            patch("shared.orchestrator.InMemorySessionService", mock_session_service_cls),
+            patch("shared.orchestrator.create_pipeline_run", return_value="test-run-id"),
+            patch("shared.orchestrator.set_pipeline_context"),
+            patch("shared.orchestrator.update_agent_started"),
+            patch("shared.orchestrator.update_agent_completed"),
+            patch("shared.orchestrator.complete_pipeline_run"),
+            patch("shared.orchestrator.error_pipeline_run"),
+            patch("shared.orchestrator.asyncio") as mock_asyncio,
+        ):
+            # asyncio.sleep をモック化して呼び出し引数を検証
+            mock_asyncio.sleep = AsyncMock()
+            mock_asyncio.timeout = asyncio.timeout
+            result = await run_pipeline(
+                agent=mock_agent,
+                app_name="test_app",
+                user_message="test query",
+                initial_state={},
+                run_type="podcast",
+            )
+
+        # 接続エラーのリトライ遅延は 15秒
+        mock_asyncio.sleep.assert_called_once_with(15)
+
+    @pytest.mark.asyncio
+    async def test_connection_error_raises_after_max_retries(self):
+        """接続エラーが最大リトライ回数を超えた場合に例外が送出されること。"""
+        mock_agent = MagicMock()
+
+        async def mock_run_async(**kwargs):
+            raise Exception("Server disconnected without sending a response")
+            yield
+
+        mock_runner_cls = MagicMock()
+        mock_runner_instance = MagicMock()
+        mock_runner_instance.run_async = mock_run_async
+        mock_runner_cls.return_value = mock_runner_instance
+
+        mock_session_service_cls = MagicMock()
+        mock_session_service = AsyncMock()
+        mock_session_service.create_session = AsyncMock()
+        mock_session_service_cls.return_value = mock_session_service
+
+        with (
+            patch("shared.orchestrator.Runner", mock_runner_cls),
+            patch("shared.orchestrator.InMemorySessionService", mock_session_service_cls),
+            patch("shared.orchestrator.create_pipeline_run", return_value="test-run-id"),
+            patch("shared.orchestrator.set_pipeline_context"),
+            patch("shared.orchestrator.update_agent_started"),
+            patch("shared.orchestrator.update_agent_completed"),
+            patch("shared.orchestrator.complete_pipeline_run"),
+            patch("shared.orchestrator.error_pipeline_run") as mock_error,
+            patch("shared.orchestrator._CONNECTION_ERROR_RETRY_DELAY", 0),
+        ):
+            with pytest.raises(Exception, match="Server disconnected"):
+                await run_pipeline(
+                    agent=mock_agent,
+                    app_name="test_app",
+                    user_message="test query",
+                    initial_state={},
+                    run_type="podcast",
+                )


### PR DESCRIPTION
## Summary

- オーケストレーター（`shared/orchestrator.py`）のリトライ対象を一時的接続エラーに拡張
- `RemoteProtocolError`、`Server disconnected`、`ConnectError`、`ReadTimeout` 等のトランスポート層エラーを検出・リトライ
- 接続エラーは15秒間隔でリトライ（レートリミットの60秒より短い）

## 背景

パイプラインをローカル実行すると `httpx.RemoteProtocolError: Server disconnected without sending a response` で即死する問題が発生。

**根本原因**: `google.genai` SDK の tenacity リトライは `APIError` + HTTP ステータスコードのみ対象。`RemoteProtocolError` はトランスポート層の例外で `APIError` ではないため、SDK レベルで一切リトライされない。ADK の `ParallelAgent` は `asyncio.TaskGroup` を使い、1つのサブタスクの例外が `ExceptionGroup` として伝播してパイプライン全体が落ちる。

## 変更内容

### `shared/orchestrator.py`
- `_TRANSIENT_ERROR_MARKERS` タプル追加（11種の接続エラーマーカー）
- `_is_transient_connection_error()` 関数追加（文字列ベース判定、ExceptionGroup 再帰対応）
- `_CONNECTION_ERROR_RETRY_DELAY = 15` 定数追加
- リトライループをエラー種別に応じた遅延に改修（レートリミット: 60秒、接続エラー: 15秒）
- リトライ上限到達時の `error_type` をエラー種別で分岐

### `tests/unit/test_orchestrator_retry.py`
- `TestIsTransientConnectionError`: 7テスト（クラス名/メッセージ判定、ExceptionGroup ラッピング、ネスト）
- `TestConnectionErrorConstants`: 1テスト（15秒定数）
- `TestRunPipelineRetry` に3テスト追加（接続エラーリトライ成功、15秒遅延検証、リトライ上限超過）

## Test plan

- [x] `python -m pytest tests/unit/test_orchestrator_retry.py -v` — 22テスト全通過
- [x] `python -m pytest tests/unit/test_orchestrator.py -v` — 既存39テスト回帰なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)