### PR TITLE
fix: Storyteller テストのアサーションを実際の instruction に合わせて修正

### DIFF
--- a/tests/unit/test_storyteller.py
+++ b/tests/unit/test_storyteller.py
@@ -157,7 +157,7 @@ class TestStorytellerInstruction:
         assert "gaps, silences, and omissions" in STORYTELLER_INSTRUCTION
 
     def test_has_abstract_concrete_alternation(self):
-        """抽象⇄具体の交互配置指示が Creative Guidelines 内にある。"""
-        assert "Abstract" in STORYTELLER_INSTRUCTION
-        assert "Concrete Alternation" in STORYTELLER_INSTRUCTION
-        assert "three consecutive paragraphs" in STORYTELLER_INSTRUCTION
+        """抽象⇄具体の交互配置指示が Sensory Writing 内にある。"""
+        assert "abstract analysis" in STORYTELLER_INSTRUCTION
+        assert "concrete sensory details" in STORYTELLER_INSTRUCTION
+        assert "rhythm and contrast" in STORYTELLER_INSTRUCTION


### PR DESCRIPTION
## Summary

- `test_has_abstract_concrete_alternation` が失敗していた原因を修正
- テストが期待していた「Abstract ⇄ Concrete Alternation」セクション見出しは、Storyteller instruction のリファクタで Sensory Writing セクションに統合済みだったが、テスト側が追従していなかった
- テストのアサーションを実際の instruction 内容（`abstract analysis`, `concrete sensory details`, `rhythm and contrast`）に合わせて更新

## Test plan

- [x] `pytest tests/unit/test_storyteller.py -v` — 13件全パス確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)