### PR TITLE
fix: product_designs コレクションの Firestore セキュリティルール追加

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -16,6 +16,12 @@ service cloud.firestore {
       allow write: if true;
     }
 
+    // product_designs: web-admin からの読み書き許可
+    match /product_designs/{designId} {
+      allow read: if true;
+      allow write: if true;
+    }
+
     // pipeline_runs: web-admin から読み取りのみ（進捗表示用）
     match /pipeline_runs/{runId} {
       allow read: if true;


### PR DESCRIPTION
## Summary

- PR #275（Alchemist プロダクトデザイン機能）で新設した `product_designs` コレクションに Firestore セキュリティルールが未定義だった
- キャッチオールの deny ルール（L32: `allow read, write: if false`）に引っかかり、web-admin の `/designs` ページで `FirebaseError: false for 'list' @ L32` が発生していた
- `podcasts` ルールの後に `product_designs` の読み書き許可ルールを追加

## Test plan

- [ ] Firebase Emulator でルール再読み込み後、web-admin `/designs` ページでエラーが解消されることを確認
- [ ] `product_designs` コレクションへの読み書きが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)