### PR TITLE
feat: 分野ラベル + ゴーストレベルバッジを全ページで統一表示

### DIFF
--- a/web-public/src/app/[lang]/archive/[[...page]]/page.tsx
+++ b/web-public/src/app/[lang]/archive/[[...page]]/page.tsx
@@ -92,6 +92,7 @@ export default async function ArchivePage({
     return {
       id: m.mystery_id,
       classification: m.mystery_id.slice(0, 3).toUpperCase(),
+      confidenceLevel: m.confidence_level,
       thumbnail: m.images?.thumbnail ?? null,
       publishedAt: m.publishedAt?.toISOString() ?? "",
       i18n,
@@ -142,6 +143,7 @@ export default async function ArchivePage({
                         mystery={mystery}
                         lang={lang as SupportedLang}
                         classificationLabels={dict.classification}
+                        confidenceLabels={dict.confidence}
                       />
                     ))}
                   </div>

--- a/web-public/src/app/[lang]/mystery/[id]/page.tsx
+++ b/web-public/src/app/[lang]/mystery/[id]/page.tsx
@@ -174,6 +174,7 @@ export default async function MysteryDetailPage({
             publishedLabel={dict.detail.published}
             confidenceLevel={mystery.confidence_level}
             confidenceLabels={dict.confidence}
+            classificationLabels={dict.classification}
             storyteller={mystery.storyteller}
             storytellerBylineLabel={dict.detail.storytoldBy}
           />
@@ -306,6 +307,7 @@ export default async function MysteryDetailPage({
             lang={lang as SupportedLang}
             heading={dict.detail.relatedArticles}
             classificationLabels={dict.classification}
+            confidenceLabels={dict.confidence}
           />
         </div>
       </main>

--- a/web-public/src/app/[lang]/page.tsx
+++ b/web-public/src/app/[lang]/page.tsx
@@ -54,6 +54,7 @@ async function MysteryList({ lang, dict }: { lang: SupportedLang; dict: Dictiona
           lang={lang}
           label={dict.home.featuredStory}
           classificationLabels={dict.classification}
+          confidenceLabels={dict.confidence}
         />
       </div>
 
@@ -72,7 +73,7 @@ async function MysteryList({ lang, dict }: { lang: SupportedLang; dict: Dictiona
 
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {rest.map((mystery) => (
-              <MysteryCard key={mystery.mystery_id} mystery={mystery} lang={lang} classificationLabels={dict.classification} />
+              <MysteryCard key={mystery.mystery_id} mystery={mystery} lang={lang} classificationLabels={dict.classification} confidenceLabels={dict.confidence} />
             ))}
           </div>
         </>

--- a/web-public/src/components/archive-filter.tsx
+++ b/web-public/src/components/archive-filter.tsx
@@ -4,8 +4,9 @@ import { useSearchParams, useRouter } from "next/navigation"
 import { useMemo } from "react"
 import Image from "next/image"
 import Link from "next/link"
-import { FileText, X, Filter } from "lucide-react"
+import { FileText, X, Filter, Ghost } from "lucide-react"
 import { cn } from "@ghost/shared/src/lib/utils"
+import type { ConfidenceLevel } from "@ghost/shared/src/types/mystery"
 import type { SupportedLang } from "@/lib/i18n/config"
 import type { Dictionary } from "@/lib/i18n/dictionaries"
 
@@ -24,6 +25,18 @@ const badgeColorMap: Record<ClassificationCode, string> = {
   LOC: "bg-emerald-900/30 text-emerald-400",
 }
 
+const confidenceColorMap: Record<ConfidenceLevel, string> = {
+  high: "bg-emerald-900/30 text-emerald-400",
+  medium: "bg-amber-900/30 text-amber-400",
+  low: "bg-zinc-700/30 text-zinc-400",
+}
+
+const confidenceLabelMap: Record<ConfidenceLevel, keyof Dictionary["confidence"]> = {
+  high: "confirmedGhost",
+  medium: "suspectedGhost",
+  low: "archivalEcho",
+}
+
 export interface MysteryI18n {
   title: string
   summary: string
@@ -32,6 +45,7 @@ export interface MysteryI18n {
 export interface MysteryEntry {
   id: string
   classification: string
+  confidenceLevel?: ConfidenceLevel
   thumbnail: string | null
   publishedAt: string
   i18n: Record<string, MysteryI18n>
@@ -110,6 +124,7 @@ export function ArchiveFilter({ lang, dict, mysteries }: ArchiveFilterProps) {
               mystery={mystery}
               lang={lang}
               classificationLabels={dict.classification}
+              confidenceLabels={dict.confidence}
             />
           ))}
         </div>
@@ -126,10 +141,12 @@ function FilteredMysteryCard({
   mystery,
   lang,
   classificationLabels,
+  confidenceLabels,
 }: {
   mystery: MysteryEntry
   lang: SupportedLang
   classificationLabels: Dictionary["classification"]
+  confidenceLabels: Dictionary["confidence"]
 }) {
   const i18n = mystery.i18n[lang] || mystery.i18n["en"]
   if (!i18n) return null
@@ -170,9 +187,9 @@ function FilteredMysteryCard({
               )}
             </div>
 
-            {/* 分類バッジ */}
-            {VALID_CODES.has(code) && (
-              <div className="mb-3">
+            {/* 分類バッジ + ゴーストレベル */}
+            <div className="flex flex-wrap items-center gap-2 mb-3">
+              {VALID_CODES.has(code) && (
                 <span
                   className={cn(
                     "inline-flex items-center px-2 py-0.5 rounded text-[10px] font-mono uppercase tracking-wider",
@@ -181,8 +198,19 @@ function FilteredMysteryCard({
                 >
                   {classificationLabels[code]}
                 </span>
-              </div>
-            )}
+              )}
+              {mystery.confidenceLevel && (
+                <span
+                  className={cn(
+                    "inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-[10px] font-mono uppercase tracking-wider",
+                    confidenceColorMap[mystery.confidenceLevel]
+                  )}
+                >
+                  <Ghost className="w-3 h-3" />
+                  {confidenceLabels[confidenceLabelMap[mystery.confidenceLevel]]}
+                </span>
+              )}
+            </div>
 
             {/* タイトル */}
             <h3 className="font-serif text-lg text-parchment mb-1 leading-tight group-hover:text-gold transition-colors text-balance">

--- a/web-public/src/components/featured-mystery-card.tsx
+++ b/web-public/src/components/featured-mystery-card.tsx
@@ -5,6 +5,7 @@ import type { FirestoreMystery } from "@ghost/shared/src/types/mystery"
 import { localizeMystery } from "@ghost/shared/src/lib/localize"
 import { cn } from "@ghost/shared/src/lib/utils"
 import { ClassificationBadge } from "@/components/classification-badge"
+import { GhostConfidenceBadge } from "@/components/ghost-confidence-badge"
 import type { SupportedLang } from "@/lib/i18n/config"
 import type { Dictionary } from "@/lib/i18n/dictionaries"
 
@@ -13,9 +14,10 @@ interface FeaturedMysteryCardProps {
   lang: SupportedLang
   label: string
   classificationLabels: Dictionary["classification"]
+  confidenceLabels: Dictionary["confidence"]
 }
 
-export function FeaturedMysteryCard({ mystery, lang, label, classificationLabels }: FeaturedMysteryCardProps) {
+export function FeaturedMysteryCard({ mystery, lang, label, classificationLabels, confidenceLabels }: FeaturedMysteryCardProps) {
   const { title, summary } = localizeMystery(mystery, lang)
 
   const locations = mystery.historical_context?.geographic_scope || []
@@ -49,8 +51,8 @@ export function FeaturedMysteryCard({ mystery, lang, label, classificationLabels
           "p-6 md:p-8",
           hasImage && "lg:flex lg:flex-col lg:justify-center lg:py-10 lg:px-10"
         )}>
-          {/* フィーチャーバッジ + 分類バッジ */}
-          <div className="flex items-center gap-3 mb-4">
+          {/* フィーチャーバッジ + 分類バッジ + ゴーストレベル */}
+          <div className="flex flex-wrap items-center gap-3 mb-4">
             <div className="flex items-center gap-2">
               <Star className="w-4 h-4 text-gold" />
               <span className="text-xs font-mono uppercase tracking-widest text-gold">
@@ -58,6 +60,9 @@ export function FeaturedMysteryCard({ mystery, lang, label, classificationLabels
               </span>
             </div>
             <ClassificationBadge mysteryId={mystery.mystery_id} labels={classificationLabels} />
+            {mystery.confidence_level && (
+              <GhostConfidenceBadge level={mystery.confidence_level} labels={confidenceLabels} />
+            )}
           </div>
 
           {/* メタデータ */}

--- a/web-public/src/components/mystery-card.tsx
+++ b/web-public/src/components/mystery-card.tsx
@@ -5,6 +5,7 @@ import type { FirestoreMystery } from "@ghost/shared/src/types/mystery"
 import { cn } from "@ghost/shared/src/lib/utils"
 import { localizeMystery } from "@ghost/shared/src/lib/localize"
 import { ClassificationBadge } from "@/components/classification-badge"
+import { GhostConfidenceBadge } from "@/components/ghost-confidence-badge"
 import type { SupportedLang } from "@/lib/i18n/config"
 import type { Dictionary } from "@/lib/i18n/dictionaries"
 
@@ -12,10 +13,11 @@ interface MysteryCardProps {
   mystery: FirestoreMystery
   lang?: SupportedLang
   classificationLabels: Dictionary["classification"]
+  confidenceLabels: Dictionary["confidence"]
   className?: string
 }
 
-export function MysteryCard({ mystery, lang = "en", classificationLabels, className }: MysteryCardProps) {
+export function MysteryCard({ mystery, lang = "en", classificationLabels, confidenceLabels, className }: MysteryCardProps) {
   const { title, summary } = localizeMystery(mystery, lang)
 
   const locations = mystery.historical_context?.geographic_scope || []
@@ -53,9 +55,12 @@ export function MysteryCard({ mystery, lang = "en", classificationLabels, classN
               </time>
             </div>
 
-            {/* 分類バッジ */}
-            <div className="mb-3">
+            {/* 分類バッジ + ゴーストレベル */}
+            <div className="flex flex-wrap items-center gap-2 mb-3">
               <ClassificationBadge mysteryId={mystery.mystery_id} labels={classificationLabels} />
+              {mystery.confidence_level && (
+                <GhostConfidenceBadge level={mystery.confidence_level} labels={confidenceLabels} />
+              )}
             </div>
 
             {/* Title */}

--- a/web-public/src/components/mystery/case-file-header.tsx
+++ b/web-public/src/components/mystery/case-file-header.tsx
@@ -2,6 +2,7 @@ import { MapPin, Clock, Calendar, FileText, Pen } from "lucide-react"
 import type { ConfidenceLevel } from "@ghost/shared/src/types/mystery"
 import { STORYTELLER_DISPLAY_NAMES } from "@ghost/shared/src/types/mystery"
 import type { Dictionary } from "@/lib/i18n/dictionaries"
+import { ClassificationBadge } from "@/components/classification-badge"
 import { GhostConfidenceBadge } from "@/components/ghost-confidence-badge"
 
 interface CaseFileHeaderProps {
@@ -13,6 +14,7 @@ interface CaseFileHeaderProps {
   publishedLabel?: string
   confidenceLevel?: ConfidenceLevel
   confidenceLabels?: Dictionary["confidence"]
+  classificationLabels?: Dictionary["classification"]
   storyteller?: string
   storytellerBylineLabel?: string
 }
@@ -26,6 +28,7 @@ export function CaseFileHeader({
   publishedLabel = "Published:",
   confidenceLevel,
   confidenceLabels,
+  classificationLabels,
   storyteller,
   storytellerBylineLabel = "Storytold by",
 }: CaseFileHeaderProps) {
@@ -71,6 +74,9 @@ export function CaseFileHeader({
             <Pen className="w-4 h-4 text-gold" />
             {storytellerBylineLabel} {storytellerDisplayName}
           </span>
+        )}
+        {classificationLabels && (
+          <ClassificationBadge mysteryId={mysteryId} labels={classificationLabels} />
         )}
         {confidenceLevel && confidenceLabels && (
           <GhostConfidenceBadge level={confidenceLevel} labels={confidenceLabels} />

--- a/web-public/src/components/related-articles.tsx
+++ b/web-public/src/components/related-articles.tsx
@@ -8,9 +8,10 @@ interface RelatedArticlesProps {
   lang: SupportedLang
   heading: string
   classificationLabels: Dictionary["classification"]
+  confidenceLabels: Dictionary["confidence"]
 }
 
-export function RelatedArticles({ articles, lang, heading, classificationLabels }: RelatedArticlesProps) {
+export function RelatedArticles({ articles, lang, heading, classificationLabels, confidenceLabels }: RelatedArticlesProps) {
   if (articles.length === 0) return null
 
   return (
@@ -23,6 +24,7 @@ export function RelatedArticles({ articles, lang, heading, classificationLabels 
             mystery={article}
             lang={lang}
             classificationLabels={classificationLabels}
+            confidenceLabels={confidenceLabels}
           />
         ))}
       </div>


### PR DESCRIPTION
## Summary

- カード系コンポーネント（MysteryCard, FeaturedMysteryCard, FilteredMysteryCard）に `GhostConfidenceBadge` を追加
- 記事詳細ページの `CaseFileHeader` に `ClassificationBadge` を追加
- トップページ・アーカイブ・詳細ページ・関連記事すべてで分野ラベルとゴーストレベルが統一表示される

## 変更ファイル（8件）

| ファイル | 変更内容 |
|---------|---------|
| `mystery-card.tsx` | `confidenceLabels` props + `GhostConfidenceBadge` 追加 |
| `featured-mystery-card.tsx` | `confidenceLabels` props + `GhostConfidenceBadge` 追加 |
| `archive-filter.tsx` | `MysteryEntry.confidenceLevel` 追加 + `FilteredMysteryCard` にゴーストレベルバッジ |
| `case-file-header.tsx` | `classificationLabels` props + `ClassificationBadge` 追加 |
| `related-articles.tsx` | `confidenceLabels` props をスルーパス |
| `[lang]/page.tsx` | `confidenceLabels={dict.confidence}` を各カードに渡す |
| `[lang]/mystery/[id]/page.tsx` | `classificationLabels` + `confidenceLabels` を渡す |
| `[lang]/archive/[[...page]]/page.tsx` | `confidenceLevel` をフィルタデータに追加 + `confidenceLabels` を渡す |

## Test plan

- [ ] `tsc --noEmit` 型チェック通過 ✅
- [ ] トップページでフィーチャーカード・通常カードに両バッジ表示を確認
- [ ] アーカイブページで両バッジ表示を確認（SSG + フィルタ結果）
- [ ] 記事詳細ページのヘッダーに分類バッジ + ゴーストレベル表示を確認
- [ ] 関連記事カードに両バッジ表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)