### PR TITLE
フッター Primary Sources を全11件に網羅化 + 申請中バッジ追加

### DIFF
--- a/packages/shared/src/components/footer.tsx
+++ b/packages/shared/src/components/footer.tsx
@@ -12,6 +12,28 @@ const TECH_STACK = [
 ] as const
 
 /**
+ * 一次資料提供元一覧（固有名詞のため翻訳不要）
+ * pending: true の項目は API 利用申請中
+ */
+const PRIMARY_SOURCES = [
+  // 米国
+  { label: "Library of Congress", href: "https://www.loc.gov/" },
+  { label: "Digital Public Library of America", href: "https://dp.la/" },
+  { label: "NYPL Digital Collections", href: "https://digitalcollections.nypl.org/" },
+  // 欧州
+  { label: "Europeana", href: "https://www.europeana.eu/", pending: true },
+  { label: "Deutsche Digitale Bibliothek", href: "https://www.deutsche-digitale-bibliothek.de/" },
+  { label: "Delpher (KB)", href: "https://www.delpher.nl/" },
+  { label: "Wellcome Collection", href: "https://wellcomecollection.org/" },
+  // アジア太平洋
+  { label: "NDL Search（国立国会図書館）", href: "https://ndlsearch.ndl.go.jp/" },
+  { label: "Trove", href: "https://trove.nla.gov.au/", pending: true },
+  { label: "DigitalNZ", href: "https://digitalnz.org/" },
+  // グローバル
+  { label: "Internet Archive", href: "https://archive.org/" },
+] as const
+
+/**
  * Footer ラベル（web-public から辞書を渡す用）
  * 未指定時は英語デフォルト
  */
@@ -20,6 +42,7 @@ interface FooterLabels {
   primarySources?: string
   technical?: string
   classification?: string
+  pendingApplication?: string
 }
 
 interface FooterProps {
@@ -32,6 +55,7 @@ export function Footer({ labels, siteLinks }: FooterProps) {
   const primarySources = labels?.primarySources ?? "Primary Sources"
   const technical = labels?.technical ?? "Technical"
   const classification = labels?.classification ?? "Document Classification: PUBLIC RELEASE"
+  const pendingApplication = labels?.pendingApplication ?? "Application Pending"
 
   return (
     <footer className="border-t border-border/50 bg-card/50 mt-auto">
@@ -64,51 +88,23 @@ export function Footer({ labels, siteLinks }: FooterProps) {
           {/* Sources */}
           <div className="space-y-4">
             <h3 className="text-sm font-mono uppercase tracking-wider text-parchment">{primarySources}</h3>
-            <ul className="space-y-2">
-              <li>
-                <a
-                  href="https://www.loc.gov/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-sm text-muted-foreground hover:text-gold transition-colors inline-flex items-center gap-1.5 no-underline"
-                >
-                  Library of Congress
-                  <ExternalLink className="w-3 h-3" />
-                </a>
-              </li>
-              <li>
-                <a
-                  href="https://dp.la/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-sm text-muted-foreground hover:text-gold transition-colors inline-flex items-center gap-1.5 no-underline"
-                >
-                  Digital Public Library of America
-                  <ExternalLink className="w-3 h-3" />
-                </a>
-              </li>
-              <li>
-                <a
-                  href="https://www.europeana.eu/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-sm text-muted-foreground hover:text-gold transition-colors inline-flex items-center gap-1.5 no-underline"
-                >
-                  Europeana
-                  <ExternalLink className="w-3 h-3" />
-                </a>
-              </li>
-              <li>
-                <a
-                  href="https://archive.org/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-sm text-muted-foreground hover:text-gold transition-colors inline-flex items-center gap-1.5 no-underline"
-                >
-                  Internet Archive
-                  <ExternalLink className="w-3 h-3" />
-                </a>
-              </li>
+            <ul className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-2">
+              {PRIMARY_SOURCES.map(({ label, href, ...rest }) => (
+                <li key={href}>
+                  <a
+                    href={href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm text-muted-foreground hover:text-gold transition-colors inline-flex items-center gap-1.5 no-underline"
+                  >
+                    {label}
+                    <ExternalLink className="w-3 h-3 shrink-0" />
+                  </a>
+                  {"pending" in rest && rest.pending && (
+                    <span className="ml-1 text-xs text-muted-foreground/60">({pendingApplication})</span>
+                  )}
+                </li>
+              ))}
             </ul>
           </div>
 

--- a/web-public/src/lib/i18n/dictionaries/de.ts
+++ b/web-public/src/lib/i18n/dictionaries/de.ts
@@ -175,6 +175,7 @@ const dict: Dictionary = {
     primarySources: "Primärquellen",
     technical: "Technik",
     classification: "Klassifikation:",
+    pendingApplication: "Antrag ausstehend",
     home: "Startseite",
     archive: "Archiv",
     about: "Über uns",

--- a/web-public/src/lib/i18n/dictionaries/en.ts
+++ b/web-public/src/lib/i18n/dictionaries/en.ts
@@ -174,6 +174,7 @@ const dict: Dictionary = {
     primarySources: "Primary Sources",
     technical: "Technical",
     classification: "Classification:",
+    pendingApplication: "Application Pending",
     home: "Home",
     archive: "Archive",
     about: "About",

--- a/web-public/src/lib/i18n/dictionaries/es.ts
+++ b/web-public/src/lib/i18n/dictionaries/es.ts
@@ -175,6 +175,7 @@ const dict: Dictionary = {
     primarySources: "Fuentes primarias",
     technical: "Técnico",
     classification: "Clasificación:",
+    pendingApplication: "Solicitud pendiente",
     home: "Inicio",
     archive: "Archivo",
     about: "Acerca de",

--- a/web-public/src/lib/i18n/dictionaries/fr.ts
+++ b/web-public/src/lib/i18n/dictionaries/fr.ts
@@ -175,6 +175,7 @@ const dict: Dictionary = {
     primarySources: "Sources primaires",
     technical: "Technique",
     classification: "Classification :",
+    pendingApplication: "Demande en cours",
     home: "Accueil",
     archive: "Archives",
     about: "À propos",

--- a/web-public/src/lib/i18n/dictionaries/ja.ts
+++ b/web-public/src/lib/i18n/dictionaries/ja.ts
@@ -174,6 +174,7 @@ const dict: Dictionary = {
     primarySources: "一次資料",
     technical: "技術情報",
     classification: "分類：",
+    pendingApplication: "申請中",
     home: "ホーム",
     archive: "アーカイブ",
     about: "このサイトについて",

--- a/web-public/src/lib/i18n/dictionaries/nl.ts
+++ b/web-public/src/lib/i18n/dictionaries/nl.ts
@@ -175,6 +175,7 @@ const dict: Dictionary = {
     primarySources: "Primaire bronnen",
     technical: "Technisch",
     classification: "Classificatie:",
+    pendingApplication: "Aanvraag in behandeling",
     home: "Home",
     archive: "Archief",
     about: "Over ons",

--- a/web-public/src/lib/i18n/dictionaries/pt.ts
+++ b/web-public/src/lib/i18n/dictionaries/pt.ts
@@ -175,6 +175,7 @@ const dict: Dictionary = {
     primarySources: "Fontes primárias",
     technical: "Técnico",
     classification: "Classificação:",
+    pendingApplication: "Solicitação pendente",
     home: "Início",
     archive: "Arquivo",
     about: "Sobre",

--- a/web-public/src/lib/i18n/dictionaries/types.ts
+++ b/web-public/src/lib/i18n/dictionaries/types.ts
@@ -155,6 +155,7 @@ export interface Dictionary {
     primarySources: string;
     technical: string;
     classification: string;
+    pendingApplication: string;
     home: string;
     archive: string;
     about: string;


### PR DESCRIPTION
## Summary
- フッターの Primary Sources を4件→11件に網羅化（実際に利用中の全外部アーカイブAPIを表示）
- Trove（オーストラリア）と Europeana にAPI利用申請中であることを示す `pendingApplication` ラベルを追加（7言語 i18n 対応）
- ソースリストを2カラム grid サブレイアウトに変更（11件表示時の高さバランス改善）

## 変更内容
- `packages/shared/src/components/footer.tsx` — `PRIMARY_SOURCES` 定数配列によるデータ駆動化 + `pending` フラグ + 2カラム grid
- `web-public/src/lib/i18n/dictionaries/types.ts` — `pendingApplication` フィールド追加
- 7言語辞書（en/ja/es/de/fr/nl/pt）に `pendingApplication` ラベル追加

## Test plan
- [ ] `npx tsc --noEmit` 型チェック通過 ✅
- [ ] 全11ソースがフッターに表示されること
- [ ] Trove と Europeana に「申請中」ラベルが表示されること
- [ ] 7言語全てで申請中ラベルが正しく翻訳されていること
- [ ] レスポンシブ確認（モバイル: 1列、PC: 2列）

🤖 Generated with [Claude Code](https://claude.com/claude-code)