### PR TITLE
fix: TOC 目次の Unicode スラグ対応 + スクロールスパイ改善

### DIFF
--- a/web-public/src/components/mystery/narrative-section.tsx
+++ b/web-public/src/components/mystery/narrative-section.tsx
@@ -54,6 +54,7 @@ export function NarrativeSection({ narrativeContent, summary, lang = "en" }: Nar
   if (narrativeContent) {
     // 重複スラグを追跡するクロージャ（レンダーごとにリセット）
     const slugCounts = new Map<string, number>()
+    let headingIndex = 0
 
     const markdownComponents: Components = {
       blockquote: ({ children }) => (
@@ -61,10 +62,12 @@ export function NarrativeSection({ narrativeContent, summary, lang = "en" }: Nar
       ),
       h2: ({ children }) => {
         const text = getTextContent(children)
-        const baseSlug = slugify(text)
+        // 空スラグのフォールバック（Unicode 対応で解消済みだが安全策）
+        const baseSlug = slugify(text) || `heading-${headingIndex}`
         const count = slugCounts.get(baseSlug) || 0
         const id = count > 0 ? `${baseSlug}-${count}` : baseSlug
         slugCounts.set(baseSlug, count + 1)
+        headingIndex++
         return <h2 id={id} className="scroll-mt-24">{children}</h2>
       },
     }

--- a/web-public/src/components/table-of-contents.tsx
+++ b/web-public/src/components/table-of-contents.tsx
@@ -54,6 +54,21 @@ function TocLinks({
 export function TableOfContents({ sections, heading, variant }: TableOfContentsProps) {
   const [activeId, setActiveId] = useState<string | null>(null)
 
+  // 初期表示時: 現在スクロール位置に基づいて activeId を設定
+  useEffect(() => {
+    const findActiveSection = () => {
+      for (let i = sections.length - 1; i >= 0; i--) {
+        const el = document.getElementById(sections[i].id)
+        if (el && el.getBoundingClientRect().top <= window.innerHeight * 0.3) {
+          setActiveId(sections[i].id)
+          return
+        }
+      }
+      if (sections.length > 0) setActiveId(sections[0].id)
+    }
+    findActiveSection()
+  }, [sections])
+
   useEffect(() => {
     const observer = new IntersectionObserver(
       (entries) => {
@@ -63,7 +78,7 @@ export function TableOfContents({ sections, heading, variant }: TableOfContentsP
           }
         }
       },
-      { rootMargin: "-20% 0px -70% 0px" }
+      { rootMargin: "-10% 0px -60% 0px", threshold: 0 }
     )
 
     for (const section of sections) {
@@ -76,7 +91,10 @@ export function TableOfContents({ sections, heading, variant }: TableOfContentsP
 
   const scrollTo = (id: string) => {
     const el = document.getElementById(id)
-    if (el) el.scrollIntoView({ behavior: "smooth" })
+    if (el) {
+      setActiveId(id)
+      el.scrollIntoView({ behavior: "smooth", block: "start" })
+    }
   }
 
   if (variant === "desktop") {

--- a/web-public/src/lib/markdown-headings.ts
+++ b/web-public/src/lib/markdown-headings.ts
@@ -11,13 +11,14 @@ export interface MarkdownHeading {
 
 /**
  * テキストを URL フレンドリーなスラグに変換する。
- * - 小文字化、空白をハイフン化、英数字とハイフンのみ残す
+ * - 小文字化、空白をハイフン化、Unicode 文字・数字・ハイフンを保持
+ * - \p{L}（全 Unicode 文字）対応で日本語・アクセント付き文字も保持
  */
 export function slugify(text: string): string {
   return text
     .toLowerCase()
     .trim()
-    .replace(/[^\w\s-]/g, "")
+    .replace(/[^\p{L}\p{N}\s-]/gu, "")
     .replace(/\s+/g, "-")
     .replace(/-+/g, "-")
     .replace(/^-|-$/g, "")
@@ -48,16 +49,19 @@ export function extractHeadings(markdown: string): MarkdownHeading[] {
 
   const regex = /^##\s+(.+)$/gm
   let match: RegExpExecArray | null
+  let index = 0
   while ((match = regex.exec(markdown)) !== null) {
     const rawText = match[1].trim()
     const text = stripInlineMarkdown(rawText)
-    const baseSlug = slugify(text)
+    // 空スラグのフォールバック（日本語等で slugify が空になるケースは Unicode 対応で解消済みだが安全策）
+    const baseSlug = slugify(text) || `heading-${index}`
 
     const count = slugCounts.get(baseSlug) || 0
     const id = count > 0 ? `${baseSlug}-${count}` : baseSlug
     slugCounts.set(baseSlug, count + 1)
 
     headings.push({ id, text, level: 2 })
+    index++
   }
 
   return headings

--- a/web-public/tsconfig.json
+++ b/web-public/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "ES2018",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary

- `slugify()` が `\w`（ASCII のみ）を使用していたため、日本語等の非ラテン文字を全て除去し空スラグが生成される問題を修正
- `\p{L}\p{N}`（Unicode 文字・数字）に変更し、全7言語（en/ja/es/de/fr/nl/pt）でスラグが正しく生成されるように
- IntersectionObserver の rootMargin が狭すぎて後半セクションがハイライトされない問題を修正
- scrollTo クリック時のアクティブハイライト即時化 + 初期表示時のアクティブセクション設定追加

## 修正内容

| ファイル | 変更内容 |
|----------|----------|
| `web-public/src/lib/markdown-headings.ts` | `slugify()` Unicode 対応（`\w` → `\p{L}\p{N}`）+ 空スラグフォールバック |
| `web-public/src/components/mystery/narrative-section.tsx` | h2 コンポーネントに空スラグフォールバック追加 |
| `web-public/src/components/table-of-contents.tsx` | rootMargin 調整 + 初期 activeId 設定 + scrollTo 改善 |
| `web-public/tsconfig.json` | target ES2017 → ES2018（Unicode property escapes 対応） |

## 影響範囲（全7言語での slugify 修正効果）

| 言語 | 見出し例 | 修正前 | 修正後 |
|------|----------|--------|--------|
| ja | `消えた記録の謎` | `""` (空) | `消えた記録の謎` |
| de | `Die Große Flamme` | `die-groe-flamme` | `die-große-flamme` |
| fr | `L'Énigme du Château` | `lnigme-du-chteau` | `lénigme-du-château` |
| es | `El Niño Desaparecido` | `el-nio-desaparecido` | `el-niño-desaparecido` |
| pt | `A Aparição Misteriosa` | `a-apario-misteriosa` | `a-aparição-misteriosa` |
| nl | `Het Verdwenen Café` | `het-verdwenen-caf` | `het-verdwenen-café` |
| en | `The Great Fire` | `the-great-fire` ✅ | `the-great-fire` ✅ |

## Test plan

- [ ] TypeScript 型チェック通過（`tsc --noEmit`）✅
- [ ] 日本語ページで全ての目次項目がクリックでスクロール、最初の見出しのハイライト動作
- [ ] 英語ページで証拠資料・仮説・歴史的背景がハイライト＆スクロール
- [ ] de/fr/es/pt/nl ページでアクセント付き見出しの ID が正しく生成
- [ ] DevTools で h2 要素の id が空でないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)