### PR TITLE
fix: alchemist_agents の get_storage_client ImportError 修正

### DIFF
--- a/alchemist_agents/tools/firestore_tools.py
+++ b/alchemist_agents/tools/firestore_tools.py
@@ -177,10 +177,10 @@ def upload_design_assets(
         アップロード結果のリスト
             各要素: {"product_type", "layer", "gcs_path", "public_url", "aspect_ratio"}
     """
-    from shared.firestore import get_storage_client
+    from shared.firestore import get_storage_bucket
     from pathlib import Path
 
-    bucket = get_storage_client()
+    bucket = get_storage_bucket()
     results = []
 
     for asset in asset_paths:


### PR DESCRIPTION
## Summary
- `alchemist_agents/tools/firestore_tools.py` で `shared.firestore` から存在しない `get_storage_client` をインポートしていた ImportError を修正
- 正しい関数名 `get_storage_bucket` に変更（`mystery_agents` / `podcast_agents` と同じ）

## 修正内容
- L180: `from shared.firestore import get_storage_client` → `get_storage_bucket`
- L183: `bucket = get_storage_client()` → `get_storage_bucket()`

## Test plan
- [x] `python -c "from alchemist_agents.tools.firestore_tools import upload_design_assets"` — import 成功確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)