### PR TITLE
fix: ADK エージェント親重複エラー解消（build_pipeline ファクトリ化）

### DIFF
--- a/mystery_agents/agent.py
+++ b/mystery_agents/agent.py
@@ -14,13 +14,16 @@ PostStoryBlock では Illustrator と6言語翻訳が並列実行される。
 DebateLoop 内部は SequentialAgent(debate_round) で構成:
   parallel_debate_scholars → convergence_checker
 収束判定により新規論点が枯渇した場合、max_iterations 前にループを早期終了する。
+
+build_pipeline() は全エージェントを毎回新規生成するファクトリ関数。
+ADK の単一親制約に違反しないよう、同一インスタンスを複数の親に割り当てない。
 """
 
 from google.adk.agents import LoopAgent, ParallelAgent, SequentialAgent
 
-from .agents.armchair_polymath import armchair_polymath_agent
-from .agents.convergence_checker import convergence_checker_agent
-from .agents.illustrator import illustrator_agent
+from .agents.armchair_polymath import create_armchair_polymath
+from .agents.convergence_checker import create_convergence_checker
+from .agents.illustrator import create_illustrator
 from .agents.language_gate import make_debate_loop_gate
 from .agents.language_librarians import create_all_librarians
 from .agents.language_scholars import create_all_scholars
@@ -30,114 +33,21 @@ from .agents.pipeline_gate import (
     make_scholar_gate,
     make_storyteller_gate,
 )
-from .agents.publisher import publisher_agent
-from .agents.storyteller import create_storyteller, storyteller_agent
-from .agents.theme_analyzer import theme_analyzer_agent
+from .agents.publisher import create_publisher
+from .agents.storyteller import create_storyteller
+from .agents.theme_analyzer import create_theme_analyzer
 from .agents.translator import create_all_translators
 from shared.model_config import DEFAULT_STORYTELLER
 
-# 言語別エージェントを生成
-all_librarians = create_all_librarians()
-all_scholars = create_all_scholars(mode="analysis")
-all_scholars_debate = create_all_scholars(mode="debate")
-
-# 全6言語の翻訳エージェントを生成
-all_translators = create_all_translators()
-
-# 討論ラウンド: 全 Scholar が並列で議論 → 収束判定
-# SequentialAgent でラップし、convergence_checker の escalate で早期終了可能にする
-debate_round = SequentialAgent(
-    name="debate_round",
-    sub_agents=[
-        ParallelAgent(
-            name="parallel_debate_scholars",
-            sub_agents=list(all_scholars_debate.values()),
-        ),
-        convergence_checker_agent,
-    ],
-)
-
-# 討論ループ（LoopAgent: 最大2ラウンド、有意な分析が2言語未満ならスキップ）
-# 収束判定により max_iterations 前に早期終了する場合がある
-debate_loop = LoopAgent(
-    name="debate_loop",
-    sub_agents=[debate_round],
-    max_iterations=2,
-    before_agent_callback=make_debate_loop_gate(),
-)
-
-# Scholar ブロック（全 Librarian 失敗時にスキップ）
-scholar_block = SequentialAgent(
-    name="scholar_block",
-    sub_agents=[
-        ParallelAgent(
-            name="parallel_scholars",
-            sub_agents=list(all_scholars.values()),
-        ),
-    ],
-    before_agent_callback=make_scholar_gate(),
-)
-
-# ArmchairPolymath ブロック（全 Scholar 失敗時にスキップ）
-polymath_block = SequentialAgent(
-    name="polymath_block",
-    sub_agents=[armchair_polymath_agent],
-    before_agent_callback=make_polymath_gate(),
-)
-
-# Storyteller ブロック（mystery_report 空ならスキップ）
-storyteller_block = SequentialAgent(
-    name="storyteller_block",
-    sub_agents=[storyteller_agent],
-    before_agent_callback=make_storyteller_gate(),
-)
-
-# Illustrator と翻訳を並列実行（どちらも creative_content を読むだけで独立）
-post_story_parallel = ParallelAgent(
-    name="post_story_parallel",
-    sub_agents=[
-        illustrator_agent,
-        ParallelAgent(
-            name="parallel_translators",
-            sub_agents=list(all_translators.values()),
-        ),
-    ],
-)
-
-# PostStoryBlock: 並列処理 → Publisher（creative_content 空ならスキップ）
-post_story_block = SequentialAgent(
-    name="post_story_block",
-    sub_agents=[
-        post_story_parallel,
-        publisher_agent,
-    ],
-    before_agent_callback=make_post_story_gate(),
-)
-
-# メインパイプライン
-ghost_commander = SequentialAgent(
-    name="ghost_commander",
-    description=(
-        "Ghost in the Archive multilingual blog creation pipeline. "
-        "Executes ThemeAnalyzer → ParallelLibrarians → ScholarBlock → DebateLoop "
-        "→ PolymathBlock → StorytellerBlock → PostStoryBlock "
-        "to research, analyze, debate, create content, generate images, "
-        "translate to 6 languages (ja/es/de/fr/nl/pt) in parallel, "
-        "and publish historical mysteries and folkloric anomalies. "
-        "Pipeline gates skip downstream agents when upstream stages fail."
-    ),
-    sub_agents=[
-        theme_analyzer_agent,
-        ParallelAgent(
-            name="parallel_librarians",
-            sub_agents=list(all_librarians.values()),
-        ),
-        scholar_block,
-        debate_loop,
-        polymath_block,
-        storyteller_block,
-        post_story_block,
-    ],
+# パイプライン説明文（build_pipeline 内で共有）
+_PIPELINE_DESCRIPTION = (
+    "Ghost in the Archive multilingual blog creation pipeline. "
+    "Executes ThemeAnalyzer → ParallelLibrarians → ScholarBlock → DebateLoop "
+    "→ PolymathBlock → StorytellerBlock → PostStoryBlock "
+    "to research, analyze, debate, create content, generate images, "
+    "translate to 6 languages (ja/es/de/fr/nl/pt) in parallel, "
+    "and publish historical mysteries and folkloric anomalies. "
+    "Pipeline gates skip downstream agents when upstream stages fail."
 )
 
 # オーケストレーター/パラレルエージェントはログ対象外
@@ -157,14 +67,12 @@ SKIP_AUTHORS = {
     "post_story_parallel",
 }
 
-root_agent = ghost_commander
-
 
 def build_pipeline(storyteller: str = DEFAULT_STORYTELLER) -> SequentialAgent:
-    """ストーリーテラー指定でパイプラインを構築する。
+    """パイプラインを新規構築する。毎回新しいエージェントインスタンスを生成。
 
-    デフォルトストーリーテラー以外が指定された場合のみ Storyteller を再生成する。
-    Storyteller 以外のエージェントはステートレスなので共有再利用する。
+    ADK の単一親制約（Agent already has a parent agent）を回避するため、
+    全エージェントを毎回新規生成する。同一インスタンスを複数の親に追加しない。
 
     Args:
         storyteller: ストーリーテラー名（STORYTELLER_MODELS のキー）
@@ -172,36 +80,107 @@ def build_pipeline(storyteller: str = DEFAULT_STORYTELLER) -> SequentialAgent:
     Returns:
         構築済みパイプライン（SequentialAgent）
     """
-    st = create_storyteller(storyteller) if storyteller != DEFAULT_STORYTELLER else storyteller_agent
+    # リーフエージェント（毎回新規生成）
+    ta = create_theme_analyzer()
+    ap = create_armchair_polymath()
+    cc = create_convergence_checker()
+    il = create_illustrator()
+    pub = create_publisher()
+    st = create_storyteller(storyteller)
 
-    custom_storyteller_block = SequentialAgent(
+    # ファクトリエージェント（既に毎回新規生成）
+    libs = create_all_librarians()
+    scholars_analysis = create_all_scholars(mode="analysis")
+    scholars_debate = create_all_scholars(mode="debate")
+    translators = create_all_translators()
+
+    # 討論ラウンド: 全 Scholar が並列で議論 → 収束判定
+    debate_round = SequentialAgent(
+        name="debate_round",
+        sub_agents=[
+            ParallelAgent(
+                name="parallel_debate_scholars",
+                sub_agents=list(scholars_debate.values()),
+            ),
+            cc,
+        ],
+    )
+
+    # 討論ループ（LoopAgent: 最大2ラウンド、有意な分析が2言語未満ならスキップ）
+    debate_loop = LoopAgent(
+        name="debate_loop",
+        sub_agents=[debate_round],
+        max_iterations=2,
+        before_agent_callback=make_debate_loop_gate(),
+    )
+
+    # Scholar ブロック（全 Librarian 失敗時にスキップ）
+    scholar_block = SequentialAgent(
+        name="scholar_block",
+        sub_agents=[
+            ParallelAgent(
+                name="parallel_scholars",
+                sub_agents=list(scholars_analysis.values()),
+            ),
+        ],
+        before_agent_callback=make_scholar_gate(),
+    )
+
+    # ArmchairPolymath ブロック（全 Scholar 失敗時にスキップ）
+    polymath_block = SequentialAgent(
+        name="polymath_block",
+        sub_agents=[ap],
+        before_agent_callback=make_polymath_gate(),
+    )
+
+    # Storyteller ブロック（mystery_report 空ならスキップ）
+    storyteller_block = SequentialAgent(
         name="storyteller_block",
         sub_agents=[st],
         before_agent_callback=make_storyteller_gate(),
     )
 
-    custom_post_story_block = SequentialAgent(
+    # Illustrator と翻訳を並列実行（どちらも creative_content を読むだけで独立）
+    post_story_parallel = ParallelAgent(
+        name="post_story_parallel",
+        sub_agents=[
+            il,
+            ParallelAgent(
+                name="parallel_translators",
+                sub_agents=list(translators.values()),
+            ),
+        ],
+    )
+
+    # PostStoryBlock: 並列処理 → Publisher（creative_content 空ならスキップ）
+    post_story_block = SequentialAgent(
         name="post_story_block",
         sub_agents=[
             post_story_parallel,
-            publisher_agent,
+            pub,
         ],
         before_agent_callback=make_post_story_gate(),
     )
 
+    # メインパイプライン
     return SequentialAgent(
         name="ghost_commander",
-        description=ghost_commander.description,
+        description=_PIPELINE_DESCRIPTION,
         sub_agents=[
-            theme_analyzer_agent,
+            ta,
             ParallelAgent(
                 name="parallel_librarians",
-                sub_agents=list(all_librarians.values()),
+                sub_agents=list(libs.values()),
             ),
             scholar_block,
             debate_loop,
             polymath_block,
-            custom_storyteller_block,
-            custom_post_story_block,
+            storyteller_block,
+            post_story_block,
         ],
     )
+
+
+# モジュールレベル（1回だけ構築 — ADK CLI / adk web 用）
+ghost_commander = build_pipeline()
+root_agent = ghost_commander

--- a/mystery_agents/agents/__init__.py
+++ b/mystery_agents/agents/__init__.py
@@ -4,12 +4,14 @@ This module exports all specialized agents for the blog creation pipeline.
 Scriptwriter and Producer have been moved to podcast_agents package.
 """
 
-from .armchair_polymath import armchair_polymath_agent
-from .illustrator import illustrator_agent
+from .armchair_polymath import armchair_polymath_agent, create_armchair_polymath
+from .convergence_checker import convergence_checker_agent, create_convergence_checker
+from .illustrator import create_illustrator, illustrator_agent
 from .language_librarians import create_all_librarians, create_librarian
 from .language_scholars import create_all_scholars, create_scholar
-from .publisher import publisher_agent
-from .storyteller import storyteller_agent
+from .publisher import create_publisher, publisher_agent
+from .storyteller import create_storyteller, storyteller_agent
+from .theme_analyzer import create_theme_analyzer, theme_analyzer_agent
 from .translator import create_all_translators, create_translator, translator_agent
 
 __all__ = [
@@ -17,10 +19,18 @@ __all__ = [
     "create_all_librarians",
     "create_scholar",
     "create_all_scholars",
+    "create_armchair_polymath",
     "armchair_polymath_agent",
+    "create_storyteller",
     "storyteller_agent",
+    "create_illustrator",
     "illustrator_agent",
+    "create_publisher",
     "publisher_agent",
+    "create_convergence_checker",
+    "convergence_checker_agent",
+    "create_theme_analyzer",
+    "theme_analyzer_agent",
     "create_translator",
     "create_all_translators",
     "translator_agent",

--- a/mystery_agents/agents/armchair_polymath.py
+++ b/mystery_agents/agents/armchair_polymath.py
@@ -384,17 +384,23 @@ If you cannot find a specific verbatim quote, write a brief paraphrase of the so
 NEVER leave `relevant_excerpt` as an empty string — items with empty excerpts will be automatically removed.
 """
 
-armchair_polymath_agent = LlmAgent(
-    name="armchair_polymath",
-    model=create_pro_model(),
-    description=(
-        "The Armchair Polymath: a sardonic, encyclopaedically learned synthesizer "
-        "who integrates analysis results from multiple language-specific Scholars "
-        "and their debate records. Identifies cross-language discrepancies, cultural "
-        "biases, and produces a unified Mystery Report drawing on Fact, Folklore, "
-        "and Anthropology perspectives from all available language sources."
-    ),
-    instruction=ARMCHAIR_POLYMATH_INSTRUCTION,
-    tools=[save_structured_report, get_search_metadata, search_academic_papers],
-    output_key="mystery_report",  # 既存と同じキー → 下流互換性維持
-)
+def create_armchair_polymath() -> LlmAgent:
+    """Armchair Polymath エージェントを新規生成する。"""
+    return LlmAgent(
+        name="armchair_polymath",
+        model=create_pro_model(),
+        description=(
+            "The Armchair Polymath: a sardonic, encyclopaedically learned synthesizer "
+            "who integrates analysis results from multiple language-specific Scholars "
+            "and their debate records. Identifies cross-language discrepancies, cultural "
+            "biases, and produces a unified Mystery Report drawing on Fact, Folklore, "
+            "and Anthropology perspectives from all available language sources."
+        ),
+        instruction=ARMCHAIR_POLYMATH_INSTRUCTION,
+        tools=[save_structured_report, get_search_metadata, search_academic_papers],
+        output_key="mystery_report",  # 既存と同じキー → 下流互換性維持
+    )
+
+
+# 後方互換: デフォルトシングルトン
+armchair_polymath_agent = create_armchair_polymath()

--- a/mystery_agents/agents/convergence_checker.py
+++ b/mystery_agents/agents/convergence_checker.py
@@ -25,14 +25,20 @@ You are a convergence checker agent. Your only job is to call the
 Return the tool's result as your response.
 """
 
-convergence_checker_agent = LlmAgent(
-    name="convergence_checker",
-    model=create_flash_model(),
-    description=(
-        "Checks if the debate has converged by analyzing the whiteboard. "
-        "Calls check_debate_convergence tool and escalates to end the "
-        "debate loop if no significant new arguments are being introduced."
-    ),
-    instruction=_CONVERGENCE_CHECKER_INSTRUCTION,
-    tools=[check_debate_convergence],
-)
+def create_convergence_checker() -> LlmAgent:
+    """収束判定エージェントを新規生成する。"""
+    return LlmAgent(
+        name="convergence_checker",
+        model=create_flash_model(),
+        description=(
+            "Checks if the debate has converged by analyzing the whiteboard. "
+            "Calls check_debate_convergence tool and escalates to end the "
+            "debate loop if no significant new arguments are being introduced."
+        ),
+        instruction=_CONVERGENCE_CHECKER_INSTRUCTION,
+        tools=[check_debate_convergence],
+    )
+
+
+# 後方互換: デフォルトシングルトン
+convergence_checker_agent = create_convergence_checker()

--- a/mystery_agents/agents/illustrator.py
+++ b/mystery_agents/agents/illustrator.py
@@ -277,16 +277,22 @@ Do NOT include any text other than the JSON (no explanations, comments, etc.).
 - If {creative_content} contains "NO_CONTENT", do not generate an image and report accordingly
 """
 
-illustrator_agent = LlmAgent(
-    name="illustrator",
-    model=create_pro_model(),
-    description=(
-        "Reads the Storyteller's blog article and generates a single hero image using Imagen 3. "
-        "Uses region-specific art styles (11 regions × 2 types = 22 styles) based on the article's country. "
-        "Validates generated images against article content for consistency."
-    ),
-    instruction=ILLUSTRATOR_INSTRUCTION,
-    tools=[generate_image, validate_image],
-    output_key="visual_assets",
-    before_tool_callback=_limit_tool_calls,
-)
+def create_illustrator() -> LlmAgent:
+    """Illustrator エージェントを新規生成する。"""
+    return LlmAgent(
+        name="illustrator",
+        model=create_pro_model(),
+        description=(
+            "Reads the Storyteller's blog article and generates a single hero image using Imagen 3. "
+            "Uses region-specific art styles (11 regions × 2 types = 22 styles) based on the article's country. "
+            "Validates generated images against article content for consistency."
+        ),
+        instruction=ILLUSTRATOR_INSTRUCTION,
+        tools=[generate_image, validate_image],
+        output_key="visual_assets",
+        before_tool_callback=_limit_tool_calls,
+    )
+
+
+# 後方互換: デフォルトシングルトン
+illustrator_agent = create_illustrator()

--- a/mystery_agents/agents/publisher.py
+++ b/mystery_agents/agents/publisher.py
@@ -68,10 +68,16 @@ class PublisherAgent(BaseAgent):
         )
 
 
-publisher_agent = PublisherAgent(
-    name="publisher",
-    description=(
-        "Content manager agent that saves all assets to Firestore. "
-        "Deterministic execution without LLM — reads session state directly."
-    ),
-)
+def create_publisher() -> PublisherAgent:
+    """Publisher エージェントを新規生成する。"""
+    return PublisherAgent(
+        name="publisher",
+        description=(
+            "Content manager agent that saves all assets to Firestore. "
+            "Deterministic execution without LLM — reads session state directly."
+        ),
+    )
+
+
+# 後方互換: デフォルトシングルトン
+publisher_agent = create_publisher()

--- a/mystery_agents/agents/theme_analyzer.py
+++ b/mystery_agents/agents/theme_analyzer.py
@@ -91,15 +91,21 @@ Add other languages only when the theme's geographic or cultural context clearly
 - Be decisive — select languages that are genuinely relevant, not every possible language
 """
 
-theme_analyzer_agent = LlmAgent(
-    name="theme_analyzer",
-    model=create_flash_model(),
-    description=(
-        "Analyzes investigation themes to determine which language/cultural spheres "
-        "are relevant for multilingual archive research. Selects target languages "
-        "for downstream Librarian and Scholar agents."
-    ),
-    instruction=THEME_ANALYZER_INSTRUCTION,
-    tools=[save_language_selection],
-    output_key="theme_analysis",
-)
+def create_theme_analyzer() -> LlmAgent:
+    """ThemeAnalyzer エージェントを新規生成する。"""
+    return LlmAgent(
+        name="theme_analyzer",
+        model=create_flash_model(),
+        description=(
+            "Analyzes investigation themes to determine which language/cultural spheres "
+            "are relevant for multilingual archive research. Selects target languages "
+            "for downstream Librarian and Scholar agents."
+        ),
+        instruction=THEME_ANALYZER_INSTRUCTION,
+        tools=[save_language_selection],
+        output_key="theme_analysis",
+    )
+
+
+# 後方互換: デフォルトシングルトン
+theme_analyzer_agent = create_theme_analyzer()

--- a/tests/integration/test_agent_handover.py
+++ b/tests/integration/test_agent_handover.py
@@ -307,36 +307,57 @@ class TestArmchairPolymath:
         assert "armchair_polymath" in repr(armchair_polymath_agent)
 
 
+def _find_sub_agent(pipeline, name: str):
+    """パイプライン内のサブエージェントを名前で再帰検索する。"""
+    for agent in pipeline.sub_agents:
+        if hasattr(agent, "name") and agent.name == name:
+            return agent
+        # MagicMock 環境では name が内部名として repr に含まれる
+        if name in repr(agent):
+            return agent
+        # 再帰検索
+        if hasattr(agent, "sub_agents"):
+            found = _find_sub_agent(agent, name)
+            if found is not None:
+                return found
+    return None
+
+
 class TestDebateLoopConfiguration:
     """Tests for the debate loop LoopAgent configuration."""
 
     def test_debate_loop_is_created_via_loop_agent(self):
         """debate_loop should be created via LoopAgent constructor."""
-        from mystery_agents.agent import debate_loop
+        from mystery_agents.agent import ghost_commander
 
-        # MagicMock 環境では LoopAgent(...) の戻り値は MagicMock インスタンス
-        # debate_loop が存在し、名前に debate_loop が含まれることを確認
+        debate_loop = _find_sub_agent(ghost_commander, "debate_loop")
+        assert debate_loop is not None
         assert "debate_loop" in repr(debate_loop)
 
     def test_debate_loop_max_iterations(self):
         """debate_loop should have max_iterations=2."""
-        from mystery_agents.agent import debate_loop
+        from mystery_agents.agent import ghost_commander
 
+        debate_loop = _find_sub_agent(ghost_commander, "debate_loop")
         assert debate_loop.max_iterations == 2
 
     def test_debate_loop_has_gate_callback(self):
         """debate_loop should have a before_agent_callback."""
-        from mystery_agents.agent import debate_loop
+        from mystery_agents.agent import ghost_commander
 
+        debate_loop = _find_sub_agent(ghost_commander, "debate_loop")
         # before_agent_callback が設定されていること（callable であること）
         assert debate_loop.before_agent_callback is not None
         assert callable(debate_loop.before_agent_callback)
 
-    def test_debate_loop_sub_agents_count(self):
-        """debate_loop should have 6 sub_agents (one per language)."""
-        from mystery_agents.agent import debate_loop
+    def test_debate_loop_contains_debate_round(self):
+        """debate_loop should contain debate_round as its sub_agent."""
+        from mystery_agents.agent import ghost_commander
 
-        assert len(debate_loop.sub_agents) == 6
+        debate_loop = _find_sub_agent(ghost_commander, "debate_loop")
+        # LoopAgent の直接の sub_agent は debate_round（1つ）
+        assert len(debate_loop.sub_agents) == 1
+        assert "debate_round" in repr(debate_loop.sub_agents[0])
 
 
 class TestPipelineGateCallbacks:
@@ -344,29 +365,33 @@ class TestPipelineGateCallbacks:
 
     def test_scholar_block_has_gate(self):
         """scholar_block should have a before_agent_callback."""
-        from mystery_agents.agent import scholar_block
+        from mystery_agents.agent import ghost_commander
 
+        scholar_block = _find_sub_agent(ghost_commander, "scholar_block")
         assert scholar_block.before_agent_callback is not None
         assert callable(scholar_block.before_agent_callback)
 
     def test_polymath_block_has_gate(self):
         """polymath_block should have a before_agent_callback."""
-        from mystery_agents.agent import polymath_block
+        from mystery_agents.agent import ghost_commander
 
+        polymath_block = _find_sub_agent(ghost_commander, "polymath_block")
         assert polymath_block.before_agent_callback is not None
         assert callable(polymath_block.before_agent_callback)
 
     def test_storyteller_block_has_gate(self):
         """storyteller_block should have a before_agent_callback."""
-        from mystery_agents.agent import storyteller_block
+        from mystery_agents.agent import ghost_commander
 
+        storyteller_block = _find_sub_agent(ghost_commander, "storyteller_block")
         assert storyteller_block.before_agent_callback is not None
         assert callable(storyteller_block.before_agent_callback)
 
     def test_post_story_block_has_gate(self):
         """post_story_block should have a before_agent_callback."""
-        from mystery_agents.agent import post_story_block
+        from mystery_agents.agent import ghost_commander
 
+        post_story_block = _find_sub_agent(ghost_commander, "post_story_block")
         assert post_story_block.before_agent_callback is not None
         assert callable(post_story_block.before_agent_callback)
 

--- a/tests/unit/test_reporter_selection.py
+++ b/tests/unit/test_reporter_selection.py
@@ -147,3 +147,25 @@ class TestBuildPipeline:
 
         with pytest.raises(ValueError, match="Unknown storyteller"):
             build_pipeline("nonexistent")
+
+    def test_multiple_build_pipeline_no_parent_conflict(self):
+        """build_pipeline() を複数回呼び出しても ADK 親重複エラーが発生しないこと。
+
+        回帰テスト: 旧実装ではモジュールレベルのシングルトンを再利用していたため、
+        2回目の呼び出しで「Agent already has a parent agent」エラーが発生していた。
+        """
+        from mystery_agents.agent import build_pipeline
+
+        pipeline1 = build_pipeline()
+        pipeline2 = build_pipeline("gemini")
+        # 両方とも正常に構築され、異なるインスタンスであること
+        assert pipeline1 is not pipeline2
+
+    def test_build_pipeline_returns_independent_instances(self):
+        """build_pipeline() が毎回独立したエージェントインスタンスを返すこと。"""
+        from mystery_agents.agent import build_pipeline
+
+        pipeline1 = build_pipeline()
+        pipeline2 = build_pipeline()
+        # sub_agents が異なるインスタンスであること
+        assert pipeline1.sub_agents[0] is not pipeline2.sub_agents[0]


### PR DESCRIPTION
## Summary
- `build_pipeline()` でカスタム Storyteller を指定すると ADK の単一親制約（`Agent already has a parent agent`）に違反するバグを修正
- 5つのリーフエージェントに `create_*()` ファクトリ関数を追加し、`build_pipeline()` を毎回全エージェントを新規生成するファクトリに変更
- モジュールレベルのグローバル中間エージェント（`debate_loop`, `scholar_block` 等）を削除し、テストを `ghost_commander` 経由の検証に移行

## Test plan
- [x] `pytest tests/unit/test_reporter_selection.py -v` — 18 passed（回帰テスト2件追加含む）
- [x] `pytest tests/integration/test_agent_handover.py -v -k "not podcast"` — 35 passed
- [x] `pytest tests/unit/ -v` — 984 passed
- [ ] `build_pipeline()` を複数回呼び出してもエラーが発生しないことを確認
- [ ] カスタム Storyteller（gemini 等）での実行確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)