### PR TITLE
fix: 判定根拠翻訳 + 検索アーカイブ正確性保証

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,7 @@ pending (EN原文 + 翻訳あり) → (Approve) → published
 - `discrepancy_detected`, `hypothesis`, `alternative_hypotheses`
 - `historical_context.political_climate`, `story_hooks`
 - `evidence_a_excerpt`, `evidence_b_excerpt`, `additional_evidence_excerpts`
+- `confidence_rationale`
 
 ### Podcast 作成パイプライン（`podcast_agents/`）
 

--- a/mystery_agents/agents/translator.py
+++ b/mystery_agents/agents/translator.py
@@ -172,7 +172,7 @@ TRANSLATOR_CONFIGS: dict[str, dict[str, str]] = {
 # - `mystery_report`: Armchair Polymath の統合分析レポート
 #   → `title`, `summary`, `discrepancy_detected`, `hypothesis`,
 #     `alternative_hypotheses`, `story_hooks`,
-#     `historical_context.political_climate` のソース
+#     `historical_context.political_climate`, `confidence_rationale` のソース
 # - `structured_report`: 構造化データ（dict）
 #   → `evidence_a_excerpt`, `evidence_b_excerpt`,
 #     `additional_evidence_excerpts` のソース
@@ -226,7 +226,8 @@ TRANSLATOR_CONFIGS: dict[str, dict[str, str]] = {
 #   "historical_context": {{ "political_climate": "..." }},
 #   "evidence_a_excerpt": "...",
 #   "evidence_b_excerpt": "...",
-#   "additional_evidence_excerpts": ["...", "..."]
+#   "additional_evidence_excerpts": ["...", "..."],
+#   "confidence_rationale": "..."
 # }}
 #
 # Curator テーマ提案の場合:
@@ -263,7 +264,8 @@ The content you need to translate is available in session state:
   → Use this as the source for the `narrative_content` field.
 - `{{mystery_report}}`: The integrated analysis report by the Armchair Polymath.
   → Use this as the source for `title`, `summary`, `discrepancy_detected`, `hypothesis`,
-    `alternative_hypotheses`, `story_hooks`, and `historical_context.political_climate`.
+    `alternative_hypotheses`, `story_hooks`, `historical_context.political_climate`,
+    and `confidence_rationale`.
 - `{{structured_report}}`: Structured data (dict) from the Armchair Polymath tool.
   → Use this as the source for `evidence_a_excerpt`, `evidence_b_excerpt`,
     and `additional_evidence_excerpts` (extract the `relevant_excerpt` from each evidence).
@@ -321,7 +323,8 @@ For blog article fields:
   "historical_context": {{{{ "political_climate": "..." }}}},
   "evidence_a_excerpt": "...",
   "evidence_b_excerpt": "...",
-  "additional_evidence_excerpts": ["...", "..."]
+  "additional_evidence_excerpts": ["...", "..."],
+  "confidence_rationale": "..."
 }}}}
 
 For curator theme suggestions:

--- a/mystery_agents/tools/publisher_tools.py
+++ b/mystery_agents/tools/publisher_tools.py
@@ -28,6 +28,8 @@ from shared.constants import (
 from shared.firestore import get_firestore_client, get_storage_bucket
 from shared.language_validator import validate_translation_language
 
+from mystery_agents.tools.search_metadata import get_search_metadata as _get_search_metadata
+
 logger = logging.getLogger(__name__)
 
 
@@ -303,6 +305,23 @@ def publish_mystery(
             if multilingual:
                 data["multilingual_analysis"] = multilingual
                 data["languages_analyzed"] = list(multilingual.keys())
+
+            # source_coverage の API フィールドを raw_search_results から programmatic に上書き
+            # （LLM の手動転記ではなくセッション状態から直接生成）
+            search_meta_json = _get_search_metadata(tool_context)
+            search_meta = json.loads(search_meta_json)
+            if search_meta.get("status") == "ok":
+                sc = data.get("source_coverage")
+                if sc and isinstance(sc, dict):
+                    sc["apis_searched"] = search_meta["apis_searched"]
+                    sc["apis_with_results"] = search_meta["apis_with_results"]
+                    sc["apis_without_results"] = search_meta["apis_without_results"]
+                else:
+                    data["source_coverage"] = {
+                        "apis_searched": search_meta["apis_searched"],
+                        "apis_with_results": search_meta["apis_with_results"],
+                        "apis_without_results": search_meta["apis_without_results"],
+                    }
 
             # 全言語の翻訳結果を translations map に収集
             translations: dict[str, dict] = {}

--- a/packages/shared/src/lib/localize.ts
+++ b/packages/shared/src/lib/localize.ts
@@ -12,6 +12,7 @@ export interface LocalizedMystery {
   alternativeHypotheses: string[];
   politicalClimate: string;
   storyHooks: string[];
+  confidenceRationale: string;
 }
 
 /**
@@ -38,6 +39,7 @@ export function localizeMystery(
         mystery.historical_context_en?.political_climate ||
         mystery.historical_context?.political_climate || "",
       storyHooks: mystery.story_hooks_en ?? mystery.story_hooks,
+      confidenceRationale: mystery.confidence_rationale || "",
     };
   }
 
@@ -59,6 +61,8 @@ export function localizeMystery(
         mystery.historical_context_ja?.political_climate ||
         mystery.historical_context?.political_climate || "",
       storyHooks: t?.story_hooks ?? mystery.story_hooks_ja ?? mystery.story_hooks,
+      confidenceRationale:
+        t?.confidence_rationale || mystery.confidence_rationale || "",
     };
   }
 
@@ -74,6 +78,8 @@ export function localizeMystery(
         t.historical_context?.political_climate ||
         mystery.historical_context?.political_climate || "",
       storyHooks: t.story_hooks ?? mystery.story_hooks,
+      confidenceRationale:
+        t.confidence_rationale || mystery.confidence_rationale || "",
     };
   }
 
@@ -86,6 +92,7 @@ export function localizeMystery(
     alternativeHypotheses: mystery.alternative_hypotheses,
     politicalClimate: mystery.historical_context?.political_climate || "",
     storyHooks: mystery.story_hooks,
+    confidenceRationale: mystery.confidence_rationale || "",
   };
 }
 

--- a/packages/shared/src/types/mystery.ts
+++ b/packages/shared/src/types/mystery.ts
@@ -41,6 +41,7 @@ export interface TranslatedContent {
   evidence_a_excerpt?: string;
   evidence_b_excerpt?: string;
   additional_evidence_excerpts?: string[];
+  confidence_rationale?: string;
 }
 
 /** ミステリーのステータス */

--- a/tests/unit/test_publisher_tools.py
+++ b/tests/unit/test_publisher_tools.py
@@ -1099,6 +1099,125 @@ class TestPublishMysteryStructuredDataExtension:
         assert json.loads(result)["status"] == "success"
 
         saved = mock_db.collection.return_value.document.return_value.set.call_args[0][0]
+        # source_coverage は raw_search_results もないため設定されない
         assert "source_coverage" not in saved
         assert "confidence_rationale" not in saved
+
+
+class TestSourceCoverageProgrammaticOverwrite:
+    """source_coverage の API フィールドが raw_search_results から programmatic に上書きされるテスト。"""
+
+    @patch("mystery_agents.tools.publisher_tools.get_storage_bucket")
+    @patch("mystery_agents.tools.publisher_tools.get_firestore_client")
+    def test_overwrites_apis_from_raw_search_results(self, mock_get_db, mock_get_bucket):
+        """raw_search_results がある場合、source_coverage の API フィールドが上書きされる。"""
+        mock_db = MagicMock()
+        mock_get_db.return_value = mock_db
+        mock_get_bucket.return_value = MagicMock()
+
+        state = {
+            "structured_report": {
+                "classification": "OCC",
+                "country_code": "US",
+                "region_code": "BOS",
+                "title": "Test",
+                "summary": "Test summary",
+                "source_coverage": {
+                    "apis_searched": ["llm_hallucinated_api"],
+                    "apis_with_results": ["llm_hallucinated_api"],
+                    "apis_without_results": [],
+                    "known_undigitized_sources": ["Parish registers"],
+                    "coverage_assessment": "Limited coverage",
+                },
+            },
+            # raw_search_results から正確なメタデータが生成される
+            "raw_search_results_en": [
+                {"source": "chronicling_america", "total_hits": 50, "documents_returned": 10},
+                {"source": "loc_digital", "total_hits": 0, "documents_returned": 0},
+            ],
+        }
+        tool_context = MagicMock()
+        tool_context.state = state
+
+        result = publish_mystery(_make_mystery_json(), "", tool_context)
+        assert json.loads(result)["status"] == "success"
+
+        saved = mock_db.collection.return_value.document.return_value.set.call_args[0][0]
+        sc = saved["source_coverage"]
+        # API フィールドは raw_search_results から上書きされている
+        assert "chronicling_america" in sc["apis_searched"]
+        assert "loc_digital" in sc["apis_searched"]
+        assert "llm_hallucinated_api" not in sc["apis_searched"]
+        assert sc["apis_with_results"] == ["chronicling_america"]
+        assert sc["apis_without_results"] == ["loc_digital"]
+        # LLM が生成した人間的判断フィールドは保持される
+        assert sc["known_undigitized_sources"] == ["Parish registers"]
+        assert sc["coverage_assessment"] == "Limited coverage"
+
+    @patch("mystery_agents.tools.publisher_tools.get_storage_bucket")
+    @patch("mystery_agents.tools.publisher_tools.get_firestore_client")
+    def test_creates_source_coverage_when_missing(self, mock_get_db, mock_get_bucket):
+        """structured_report に source_coverage がなくても raw_search_results から生成される。"""
+        mock_db = MagicMock()
+        mock_get_db.return_value = mock_db
+        mock_get_bucket.return_value = MagicMock()
+
+        state = {
+            "structured_report": {
+                "classification": "HIS",
+                "country_code": "GB",
+                "region_code": "LHR",
+                "title": "Test",
+                "summary": "Test summary",
+                # source_coverage なし
+            },
+            "raw_search_results_en": [
+                {"source": "europeana", "total_hits": 20, "documents_returned": 5},
+            ],
+        }
+        tool_context = MagicMock()
+        tool_context.state = state
+
+        result = publish_mystery(_make_mystery_json(), "", tool_context)
+        assert json.loads(result)["status"] == "success"
+
+        saved = mock_db.collection.return_value.document.return_value.set.call_args[0][0]
+        sc = saved["source_coverage"]
+        assert sc["apis_searched"] == ["europeana"]
+        assert sc["apis_with_results"] == ["europeana"]
+        assert sc["apis_without_results"] == []
+
+    @patch("mystery_agents.tools.publisher_tools.get_storage_bucket")
+    @patch("mystery_agents.tools.publisher_tools.get_firestore_client")
+    def test_no_overwrite_without_raw_search_results(self, mock_get_db, mock_get_bucket):
+        """raw_search_results がない場合、LLM 生成の source_coverage がそのまま使われる。"""
+        mock_db = MagicMock()
+        mock_get_db.return_value = mock_db
+        mock_get_bucket.return_value = MagicMock()
+
+        state = {
+            "structured_report": {
+                "classification": "OCC",
+                "country_code": "US",
+                "region_code": "BOS",
+                "title": "Test",
+                "summary": "Test summary",
+                "source_coverage": {
+                    "apis_searched": ["chronicling_america"],
+                    "apis_with_results": ["chronicling_america"],
+                    "apis_without_results": [],
+                },
+            },
+            # raw_search_results なし
+        }
+        tool_context = MagicMock()
+        tool_context.state = state
+
+        result = publish_mystery(_make_mystery_json(), "", tool_context)
+        assert json.loads(result)["status"] == "success"
+
+        saved = mock_db.collection.return_value.document.return_value.set.call_args[0][0]
+        sc = saved["source_coverage"]
+        # LLM 生成値がそのまま残る
+        assert sc["apis_searched"] == ["chronicling_america"]
 

--- a/web-public/src/app/[lang]/mystery/[id]/page.tsx
+++ b/web-public/src/app/[lang]/mystery/[id]/page.tsx
@@ -106,6 +106,7 @@ export default async function MysteryDetailPage({
   const {
     title, summary, narrativeContent, discrepancyDetected,
     hypothesis, alternativeHypotheses, politicalClimate, storyHooks,
+    confidenceRationale,
   } = localizeMystery(mystery, lang)
 
   const location = mystery.historical_context?.geographic_scope?.join(", ") || ""
@@ -293,7 +294,7 @@ export default async function MysteryDetailPage({
               sourceCoverage={mystery.source_coverage}
               academicCoverage={mystery.academic_coverage}
               languagesAnalyzed={mystery.languages_analyzed}
-              confidenceRationale={mystery.confidence_rationale}
+              confidenceRationale={confidenceRationale}
               sourceCoverageLabels={dict.sourceCoverage}
             >
               {/* デスクトップ目次（サイドバー内） */}


### PR DESCRIPTION
## Summary

記事詳細ページ「調査範囲」セクションの2つのデータ品質問題を修正：

- **判定根拠（confidence_rationale）が翻訳されていない** — 英語のまま全言語で表示されていた問題を、翻訳パイプラインに組み込んで解消
- **検索アーカイブ（source_coverage.apis_searched）が LLM 依存** — Armchair Polymath が手動転記していた API リストを、`raw_search_results` から programmatic に生成するよう変更

## 変更内容

### confidence_rationale 翻訳対応
- `TranslatedContent` 型に `confidence_rationale` フィールド追加
- Translator instruction に翻訳対象フィールドとして追加（日本語コメント + 英語 instruction 同期）
- `localizeMystery()` の全4分岐（en / ja / translations[lang] / フォールバック）に対応
- `page.tsx` で翻訳済み値を `DetailSidebar` に渡すよう変更

### source_coverage programmatic 上書き
- Publisher の `publish_mystery()` で `_get_search_metadata()` を呼び出し、`raw_search_results` からAPI検索状況を programmatic に生成
- LLM が生成した `known_undigitized_sources` と `coverage_assessment` は人間的判断を含むため保持
- `raw_search_results` がない場合は LLM 生成値をそのまま使用（後方互換）

### テスト
- source_coverage programmatic 上書きのユニットテスト3件追加
- TypeScript 型チェック PASS
- 既存テスト42件全 PASS

## 後方互換性
- 既存記事は `translations` map に `confidence_rationale` がないため、フォールバックで英語 base field を表示
- `source_coverage` の上書きは `raw_search_results` がある場合のみ実行

## Test plan
- [x] `python -m pytest tests/unit/test_publisher_tools.py -v` — 42 passed
- [x] `npx tsc --noEmit` — TypeScript 型チェック PASS
- [ ] 管理画面で新規記事生成 → 判定根拠が各言語で翻訳されることを確認
- [ ] 調査範囲セクションの API リストが raw_search_results と一致することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)