### PR TITLE
fix: TOC 固定セクション ID の RSC 境界問題を修正

### DIFF
--- a/web-public/src/app/[lang]/mystery/[id]/page.tsx
+++ b/web-public/src/app/[lang]/mystery/[id]/page.tsx
@@ -10,7 +10,8 @@ import { HypothesisSection } from "@/components/mystery/hypothesis-section"
 import { HistoricalContextSection } from "@/components/mystery/historical-context-section"
 import { DetailSidebar } from "@/components/mystery/detail-sidebar"
 import { Breadcrumb } from "@/components/breadcrumb"
-import { TableOfContents, SECTION_IDS } from "@/components/table-of-contents"
+import { TableOfContents } from "@/components/table-of-contents"
+import { SECTION_IDS } from "@/lib/toc-config"
 import { RelatedArticles } from "@/components/related-articles"
 import { ShareButtons } from "@/components/share-buttons"
 import { ArticleJsonLd } from "@/components/article-json-ld"
@@ -25,7 +26,7 @@ import { getSiteUrl } from "@/lib/site-url"
 import { buildOgpMetadata, buildAlternates } from "@/lib/seo"
 import { extractHeadings } from "@/lib/markdown-headings"
 import { stripLeadingH1 } from "@ghost/shared/src/lib/utils"
-import type { TocSection } from "@/components/table-of-contents"
+import type { TocSection } from "@/lib/toc-config"
 
 // SSG: ビルド時に生成されたページ以外は 404
 export const dynamicParams = false

--- a/web-public/src/components/mystery/narrative-section.tsx
+++ b/web-public/src/components/mystery/narrative-section.tsx
@@ -73,7 +73,7 @@ export function NarrativeSection({ narrativeContent, summary, lang = "en" }: Nar
     }
 
     return (
-      <section className="prose prose-lg prose-invert max-w-none prose-headings:font-serif prose-headings:text-parchment prose-headings:mt-12 prose-headings:mb-4 prose-p:text-foreground/90 prose-p:leading-loose prose-p:mb-6 prose-a:text-gold prose-strong:text-parchment prose-hr:border-border">
+      <section id="section-narrative" className="scroll-mt-24 prose prose-lg prose-invert max-w-none prose-headings:font-serif prose-headings:text-parchment prose-headings:mt-12 prose-headings:mb-4 prose-p:text-foreground/90 prose-p:leading-loose prose-p:mb-6 prose-a:text-gold prose-strong:text-parchment prose-hr:border-border">
         <Markdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
           {stripLeadingH1(narrativeContent).replace(/\*\*(.+?)\*\*/g, ' **$1** ')}
         </Markdown>

--- a/web-public/src/components/table-of-contents.tsx
+++ b/web-public/src/components/table-of-contents.tsx
@@ -2,19 +2,10 @@
 
 import { useCallback, useEffect, useRef, useState } from "react"
 import { List } from "lucide-react"
+import type { TocSection } from "@/lib/toc-config"
 
-export const SECTION_IDS = {
-  narrative: "section-narrative",
-  discrepancy: "section-discrepancy",
-  evidence: "section-evidence",
-  hypothesis: "section-hypothesis",
-  historicalContext: "section-historical-context",
-} as const
-
-export interface TocSection {
-  id: string
-  label: string
-}
+// サーバーコンポーネントからも使えるよう toc-config.ts に分離した定数・型を再エクスポート
+export { SECTION_IDS, type TocSection } from "@/lib/toc-config"
 
 interface TableOfContentsProps {
   sections: TocSection[]

--- a/web-public/src/lib/toc-config.ts
+++ b/web-public/src/lib/toc-config.ts
@@ -1,0 +1,15 @@
+// TOC 固定セクション ID とセクション型
+// サーバー / クライアント両方からインポート可能にするため "use client" を付けない
+
+export const SECTION_IDS = {
+  narrative: "section-narrative",
+  discrepancy: "section-discrepancy",
+  evidence: "section-evidence",
+  hypothesis: "section-hypothesis",
+  historicalContext: "section-historical-context",
+} as const
+
+export interface TocSection {
+  id: string
+  label: string
+}


### PR DESCRIPTION
## Summary

- `SECTION_IDS` 定数と `TocSection` 型を `"use client"` モジュール（`table-of-contents.tsx`）から非クライアントモジュール（`toc-config.ts`）に分離
- サーバーコンポーネント（`page.tsx`）から正しくインポートされるよう修正（`href="#undefined"` → `href="#section-evidence"` 等）
- `NarrativeSection` の `narrativeContent` パスに `id="section-narrative"` を追加（TOC のスクロールスパイ対象に）

## 原因

`SECTION_IDS` が `"use client"` 付きの `table-of-contents.tsx` に定義されていたため、RSC（React Server Components）境界を越えてサーバーコンポーネントからインポートすると `undefined` になっていた。

## 変更ファイル

| ファイル | 変更 |
|---------|------|
| `web-public/src/lib/toc-config.ts` | **新規** — SECTION_IDS + TocSection 型（`"use client"` なし） |
| `web-public/src/components/table-of-contents.tsx` | 定数・型削除 → toc-config から再エクスポート |
| `web-public/src/app/[lang]/mystery/[id]/page.tsx` | インポート元を toc-config に変更 |
| `web-public/src/components/mystery/narrative-section.tsx` | `id="section-narrative"` 追加 |

## Test plan

- [ ] SSG ビルド成功確認
- [ ] 記事詳細ページの HTML で `href="#section-evidence"` 等が正しく出力されていること
- [ ] TOC 固定ラベルクリック → 該当セクションにスクロール
- [ ] ページスクロール時にスクロールスパイが固定セクションでも動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)