### PR TITLE
fix: 調査範囲カードから分析言語・検索アーカイブ表示を削除

### DIFF
--- a/web-public/src/app/[lang]/mystery/[id]/page.tsx
+++ b/web-public/src/app/[lang]/mystery/[id]/page.tsx
@@ -292,9 +292,7 @@ export default async function MysteryDetailPage({
                 storyAngles: dict.detail.storyAngles,
                 classificationNotice: dict.detail.classificationNotice,
               }}
-              sourceCoverage={mystery.source_coverage}
               academicCoverage={mystery.academic_coverage}
-              languagesAnalyzed={mystery.languages_analyzed}
               confidenceRationale={confidenceRationale}
               sourceCoverageLabels={dict.sourceCoverage}
             >

--- a/web-public/src/components/mystery/detail-sidebar.tsx
+++ b/web-public/src/components/mystery/detail-sidebar.tsx
@@ -1,4 +1,4 @@
-import type { SourceCoverage, AcademicCoverage } from "@ghost/shared/src/types/mystery"
+import type { AcademicCoverage } from "@ghost/shared/src/types/mystery"
 import type { Dictionary } from "@/lib/i18n/dictionaries"
 import { SourceCoverageCard } from "@/components/mystery/source-coverage-card"
 
@@ -10,9 +10,7 @@ interface DetailSidebarLabels {
 interface DetailSidebarProps {
   storyHooks: string[]
   labels?: DetailSidebarLabels
-  sourceCoverage?: SourceCoverage
   academicCoverage?: AcademicCoverage
-  languagesAnalyzed?: string[]
   confidenceRationale?: string
   sourceCoverageLabels?: Dictionary["sourceCoverage"]
   children?: React.ReactNode
@@ -21,9 +19,7 @@ interface DetailSidebarProps {
 export function DetailSidebar({
   storyHooks,
   labels,
-  sourceCoverage,
   academicCoverage,
-  languagesAnalyzed,
   confidenceRationale,
   sourceCoverageLabels,
   children,
@@ -54,11 +50,9 @@ export function DetailSidebar({
         )}
 
         {/* Source coverage（schema_version=2 の記事のみ表示） */}
-        {sourceCoverage && sourceCoverageLabels && (
+        {sourceCoverageLabels && (academicCoverage || confidenceRationale) && (
           <SourceCoverageCard
-            sourceCoverage={sourceCoverage}
             academicCoverage={academicCoverage}
-            languagesAnalyzed={languagesAnalyzed}
             confidenceRationale={confidenceRationale}
             labels={sourceCoverageLabels}
           />

--- a/web-public/src/components/mystery/source-coverage-card.tsx
+++ b/web-public/src/components/mystery/source-coverage-card.tsx
@@ -1,18 +1,14 @@
-import type { SourceCoverage, AcademicCoverage } from "@ghost/shared/src/types/mystery"
+import type { AcademicCoverage } from "@ghost/shared/src/types/mystery"
 import type { Dictionary } from "@/lib/i18n/dictionaries"
 
 interface SourceCoverageCardProps {
-  sourceCoverage: SourceCoverage
   academicCoverage?: AcademicCoverage
-  languagesAnalyzed?: string[]
   confidenceRationale?: string
   labels: Dictionary["sourceCoverage"]
 }
 
 export function SourceCoverageCard({
-  sourceCoverage,
   academicCoverage,
-  languagesAnalyzed,
   confidenceRationale,
   labels,
 }: SourceCoverageCardProps) {
@@ -21,41 +17,6 @@ export function SourceCoverageCard({
       <h3 className="font-mono text-xs uppercase tracking-wider text-muted-foreground mb-4">
         {labels.heading}
       </h3>
-
-      {/* 分析言語 */}
-      {languagesAnalyzed && languagesAnalyzed.length > 0 && (
-        <div className="mb-3">
-          <p className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground mb-1.5">
-            {labels.languagesAnalyzed}
-          </p>
-          <div className="flex flex-wrap gap-1.5">
-            {languagesAnalyzed.map((lang) => (
-              <span
-                key={lang}
-                className="inline-flex px-1.5 py-0.5 rounded text-[10px] font-mono uppercase tracking-wider bg-gold/10 text-gold border border-gold/20"
-              >
-                {lang}
-              </span>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* 検索アーカイブ */}
-      {sourceCoverage.apis_searched.length > 0 && (
-        <div className="mb-3">
-          <p className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground mb-1.5">
-            {labels.apisSearched}
-          </p>
-          <ul className="space-y-0.5">
-            {sourceCoverage.apis_searched.map((api) => (
-              <li key={api} className="text-xs text-foreground/70 font-mono">
-                &bull; {api}
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
 
       {/* 学術論文カバレッジ */}
       {academicCoverage && academicCoverage.papers_found > 0 && (
@@ -99,11 +60,6 @@ export function SourceCoverageCard({
           </p>
         </div>
       )}
-
-      {/* カバレッジ注記 */}
-      <p className="text-[10px] text-muted-foreground/60 leading-relaxed mt-3 pt-3 border-t border-border">
-        {labels.coverageNote}
-      </p>
     </div>
   )
 }

--- a/web-public/src/lib/i18n/dictionaries/de.ts
+++ b/web-public/src/lib/i18n/dictionaries/de.ts
@@ -158,10 +158,7 @@ const dict: Dictionary = {
   },
   sourceCoverage: {
     heading: "Untersuchungsumfang",
-    languagesAnalyzed: "Analysierte Sprachen",
-    apisSearched: "Durchsuchte Archive",
     academicPapers: "Akademische Publikationen",
-    coverageNote: "Diese Analyse basiert auf Materialien, die über die oben aufgeführten digitalen Archiv-APIs verfügbar sind.",
     confidenceRationale: "Bewertungsgrundlage",
   },
   seo: {

--- a/web-public/src/lib/i18n/dictionaries/en.ts
+++ b/web-public/src/lib/i18n/dictionaries/en.ts
@@ -157,10 +157,7 @@ const dict: Dictionary = {
   },
   sourceCoverage: {
     heading: "Investigation Scope",
-    languagesAnalyzed: "Languages Analyzed",
-    apisSearched: "Archives Searched",
     academicPapers: "Academic Papers",
-    coverageNote: "This analysis is based on materials available through the digital archive APIs listed above.",
     confidenceRationale: "Assessment Rationale",
   },
   seo: {

--- a/web-public/src/lib/i18n/dictionaries/es.ts
+++ b/web-public/src/lib/i18n/dictionaries/es.ts
@@ -158,10 +158,7 @@ const dict: Dictionary = {
   },
   sourceCoverage: {
     heading: "Alcance de la investigación",
-    languagesAnalyzed: "Idiomas analizados",
-    apisSearched: "Archivos consultados",
     academicPapers: "Artículos académicos",
-    coverageNote: "Este análisis se basa en materiales disponibles a través de las APIs de archivos digitales mencionadas.",
     confidenceRationale: "Fundamento de la evaluación",
   },
   seo: {

--- a/web-public/src/lib/i18n/dictionaries/fr.ts
+++ b/web-public/src/lib/i18n/dictionaries/fr.ts
@@ -158,10 +158,7 @@ const dict: Dictionary = {
   },
   sourceCoverage: {
     heading: "Portée de l'investigation",
-    languagesAnalyzed: "Langues analysées",
-    apisSearched: "Archives consultées",
     academicPapers: "Articles académiques",
-    coverageNote: "Cette analyse repose sur les matériaux accessibles via les APIs d'archives numériques mentionnées ci-dessus.",
     confidenceRationale: "Fondement de l'évaluation",
   },
   seo: {

--- a/web-public/src/lib/i18n/dictionaries/ja.ts
+++ b/web-public/src/lib/i18n/dictionaries/ja.ts
@@ -157,10 +157,7 @@ const dict: Dictionary = {
   },
   sourceCoverage: {
     heading: "調査範囲",
-    languagesAnalyzed: "分析言語",
-    apisSearched: "検索アーカイブ",
     academicPapers: "学術論文",
-    coverageNote: "本分析は上記のデジタルアーカイブAPIで取得可能な資料に基づいています。",
     confidenceRationale: "判定根拠",
   },
   seo: {

--- a/web-public/src/lib/i18n/dictionaries/nl.ts
+++ b/web-public/src/lib/i18n/dictionaries/nl.ts
@@ -158,10 +158,7 @@ const dict: Dictionary = {
   },
   sourceCoverage: {
     heading: "Onderzoeksomvang",
-    languagesAnalyzed: "Geanalyseerde talen",
-    apisSearched: "Doorzochte archieven",
     academicPapers: "Academische publicaties",
-    coverageNote: "Deze analyse is gebaseerd op materialen die beschikbaar zijn via de hierboven genoemde digitale archief-API's.",
     confidenceRationale: "Beoordelingsgrondslag",
   },
   seo: {

--- a/web-public/src/lib/i18n/dictionaries/pt.ts
+++ b/web-public/src/lib/i18n/dictionaries/pt.ts
@@ -158,10 +158,7 @@ const dict: Dictionary = {
   },
   sourceCoverage: {
     heading: "Alcance da investigação",
-    languagesAnalyzed: "Idiomas analisados",
-    apisSearched: "Arquivos pesquisados",
     academicPapers: "Artigos acadêmicos",
-    coverageNote: "Esta análise baseia-se em materiais disponíveis através das APIs de arquivos digitais listadas acima.",
     confidenceRationale: "Fundamento da avaliação",
   },
   seo: {

--- a/web-public/src/lib/i18n/dictionaries/types.ts
+++ b/web-public/src/lib/i18n/dictionaries/types.ts
@@ -139,10 +139,7 @@ export interface Dictionary {
   };
   sourceCoverage: {
     heading: string;
-    languagesAnalyzed: string;
-    apisSearched: string;
     academicPapers: string;
-    coverageNote: string;
     confidenceRationale: string;
   };
   seo: {


### PR DESCRIPTION
## Summary

- 調査範囲カードから **分析言語**（`languagesAnalyzed`）、**検索アーカイブ**（`apis_searched`）、**カバレッジ注記**（`coverageNote`）を削除
- Librarian が 0 件でも API を呼べば「検索した」扱い、Scholar が薄い資料でも分析すれば「分析言語」に含まれるため、読者に誤解を与える可能性がある
- **学術論文**（`academicCoverage`）と **判定根拠**（`confidenceRationale`）は残存

## 変更ファイル

- `source-coverage-card.tsx` — `sourceCoverage`, `languagesAnalyzed` props 削除、分析言語/検索アーカイブ/注記セクション削除
- `detail-sidebar.tsx` — `sourceCoverage`, `languagesAnalyzed` props 削除、表示条件を `academicCoverage || confidenceRationale` に変更
- `page.tsx` — 不要な props 削除
- `types.ts` + 7言語辞書 — `languagesAnalyzed`, `apisSearched`, `coverageNote` キー削除

## Test plan

- [x] TypeScript 型チェック通過（`tsc --noEmit`）
- [ ] ローカルビルドで記事詳細ページを確認し、学術論文と判定根拠のみ表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)