### PR TITLE
fix: 調査範囲カードを Ghost 評価カードに簡素化

### DIFF
--- a/web-public/src/app/[lang]/mystery/[id]/page.tsx
+++ b/web-public/src/app/[lang]/mystery/[id]/page.tsx
@@ -292,7 +292,6 @@ export default async function MysteryDetailPage({
                 storyAngles: dict.detail.storyAngles,
                 classificationNotice: dict.detail.classificationNotice,
               }}
-              academicCoverage={mystery.academic_coverage}
               confidenceRationale={confidenceRationale}
               sourceCoverageLabels={dict.sourceCoverage}
             >

--- a/web-public/src/components/mystery/detail-sidebar.tsx
+++ b/web-public/src/components/mystery/detail-sidebar.tsx
@@ -1,4 +1,3 @@
-import type { AcademicCoverage } from "@ghost/shared/src/types/mystery"
 import type { Dictionary } from "@/lib/i18n/dictionaries"
 import { SourceCoverageCard } from "@/components/mystery/source-coverage-card"
 
@@ -10,7 +9,6 @@ interface DetailSidebarLabels {
 interface DetailSidebarProps {
   storyHooks: string[]
   labels?: DetailSidebarLabels
-  academicCoverage?: AcademicCoverage
   confidenceRationale?: string
   sourceCoverageLabels?: Dictionary["sourceCoverage"]
   children?: React.ReactNode
@@ -19,7 +17,6 @@ interface DetailSidebarProps {
 export function DetailSidebar({
   storyHooks,
   labels,
-  academicCoverage,
   confidenceRationale,
   sourceCoverageLabels,
   children,
@@ -49,10 +46,9 @@ export function DetailSidebar({
           </div>
         )}
 
-        {/* Source coverage（schema_version=2 の記事のみ表示） */}
-        {sourceCoverageLabels && (academicCoverage || confidenceRationale) && (
+        {/* Ghost 評価（判定根拠がある記事のみ表示） */}
+        {sourceCoverageLabels && confidenceRationale && (
           <SourceCoverageCard
-            academicCoverage={academicCoverage}
             confidenceRationale={confidenceRationale}
             labels={sourceCoverageLabels}
           />

--- a/web-public/src/components/mystery/source-coverage-card.tsx
+++ b/web-public/src/components/mystery/source-coverage-card.tsx
@@ -1,14 +1,11 @@
-import type { AcademicCoverage } from "@ghost/shared/src/types/mystery"
 import type { Dictionary } from "@/lib/i18n/dictionaries"
 
 interface SourceCoverageCardProps {
-  academicCoverage?: AcademicCoverage
   confidenceRationale?: string
   labels: Dictionary["sourceCoverage"]
 }
 
 export function SourceCoverageCard({
-  academicCoverage,
   confidenceRationale,
   labels,
 }: SourceCoverageCardProps) {
@@ -17,48 +14,10 @@ export function SourceCoverageCard({
       <h3 className="font-mono text-xs uppercase tracking-wider text-muted-foreground mb-4">
         {labels.heading}
       </h3>
-
-      {/* 学術論文カバレッジ */}
-      {academicCoverage && academicCoverage.papers_found > 0 && (
-        <div className="mb-3">
-          <p className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground mb-1.5">
-            {labels.academicPapers}
-          </p>
-          <p className="text-xs text-foreground/70 font-mono mb-1.5">
-            {academicCoverage.papers_found.toLocaleString()} papers
-          </p>
-          {Object.keys(academicCoverage.language_distribution).length > 0 && (
-            <div className="flex flex-wrap gap-1.5 mb-1.5">
-              {Object.entries(academicCoverage.language_distribution)
-                .sort(([, a], [, b]) => b - a)
-                .map(([lang, count]) => (
-                  <span
-                    key={lang}
-                    className="inline-flex px-1.5 py-0.5 rounded text-[10px] font-mono uppercase tracking-wider bg-foreground/5 text-foreground/60 border border-border"
-                  >
-                    {lang}: {count}
-                  </span>
-                ))}
-            </div>
-          )}
-          {academicCoverage.consensus_vs_primary && (
-            <p className="text-xs text-foreground/70 leading-relaxed mt-1.5">
-              {academicCoverage.consensus_vs_primary}
-            </p>
-          )}
-        </div>
-      )}
-
-      {/* 判定根拠 */}
       {confidenceRationale && (
-        <div className="mb-3">
-          <p className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground mb-1.5">
-            {labels.confidenceRationale}
-          </p>
-          <p className="text-xs text-foreground/70 leading-relaxed">
-            {confidenceRationale}
-          </p>
-        </div>
+        <p className="text-xs text-foreground/70 leading-relaxed">
+          {confidenceRationale}
+        </p>
       )}
     </div>
   )

--- a/web-public/src/lib/i18n/dictionaries/de.ts
+++ b/web-public/src/lib/i18n/dictionaries/de.ts
@@ -157,9 +157,7 @@ const dict: Dictionary = {
     archivalEcho: "Archivisches Echo",
   },
   sourceCoverage: {
-    heading: "Untersuchungsumfang",
-    academicPapers: "Akademische Publikationen",
-    confidenceRationale: "Bewertungsgrundlage",
+    heading: "Ghost-Bewertung",
   },
   seo: {
     homeDescription: "Ein autonomes KI-Agentensystem, das die öffentlichen digitalen Archive der Welt über fünf akademische Disziplinen hinweg kreuzanalysiert — Anomalien aufdeckend, die kein einzelnes Dokument, keine Sprache und kein Fachgebiet allein erklären kann.",

--- a/web-public/src/lib/i18n/dictionaries/en.ts
+++ b/web-public/src/lib/i18n/dictionaries/en.ts
@@ -156,9 +156,7 @@ const dict: Dictionary = {
     archivalEcho: "Archival Echo",
   },
   sourceCoverage: {
-    heading: "Investigation Scope",
-    academicPapers: "Academic Papers",
-    confidenceRationale: "Assessment Rationale",
+    heading: "Ghost Assessment",
   },
   seo: {
     homeDescription: "An autonomous AI agent system cross-analyzing the world's public digital archives through five academic disciplines — unearthing anomalies that no single record, language, or field can explain.",

--- a/web-public/src/lib/i18n/dictionaries/es.ts
+++ b/web-public/src/lib/i18n/dictionaries/es.ts
@@ -157,9 +157,7 @@ const dict: Dictionary = {
     archivalEcho: "Eco de archivo",
   },
   sourceCoverage: {
-    heading: "Alcance de la investigación",
-    academicPapers: "Artículos académicos",
-    confidenceRationale: "Fundamento de la evaluación",
+    heading: "Evaluación Ghost",
   },
   seo: {
     homeDescription: "Un sistema autónomo de agentes de IA que analiza los archivos digitales públicos del mundo a través de cinco disciplinas académicas — revelando anomalías que ningún registro, idioma o campo puede explicar por sí solo.",

--- a/web-public/src/lib/i18n/dictionaries/fr.ts
+++ b/web-public/src/lib/i18n/dictionaries/fr.ts
@@ -157,9 +157,7 @@ const dict: Dictionary = {
     archivalEcho: "Écho archivistique",
   },
   sourceCoverage: {
-    heading: "Portée de l'investigation",
-    academicPapers: "Articles académiques",
-    confidenceRationale: "Fondement de l'évaluation",
+    heading: "Évaluation Ghost",
   },
   seo: {
     homeDescription: "Un système autonome d'agents IA qui analyse les archives numériques publiques du monde à travers cinq disciplines académiques — révélant les anomalies qu'aucun document, langue ou domaine ne peut expliquer seul.",

--- a/web-public/src/lib/i18n/dictionaries/ja.ts
+++ b/web-public/src/lib/i18n/dictionaries/ja.ts
@@ -156,9 +156,7 @@ const dict: Dictionary = {
     archivalEcho: "アーカイブの残響",
   },
   sourceCoverage: {
-    heading: "調査範囲",
-    academicPapers: "学術論文",
-    confidenceRationale: "判定根拠",
+    heading: "Ghost 評価",
   },
   seo: {
     homeDescription: "世界の公開デジタルアーカイブを5つの学術領域で多言語横断分析する自律型AIエージェントシステム。単一の記録・言語・学問分野では説明できないアノマリーを発掘する。",

--- a/web-public/src/lib/i18n/dictionaries/nl.ts
+++ b/web-public/src/lib/i18n/dictionaries/nl.ts
@@ -157,9 +157,7 @@ const dict: Dictionary = {
     archivalEcho: "Archiefecho",
   },
   sourceCoverage: {
-    heading: "Onderzoeksomvang",
-    academicPapers: "Academische publicaties",
-    confidenceRationale: "Beoordelingsgrondslag",
+    heading: "Ghost-beoordeling",
   },
   seo: {
     homeDescription: "Een autonoom AI-agentsysteem dat de openbare digitale archieven van de wereld kruislings analyseert via vijf academische disciplines — anomalieën blootleggend die geen enkel document, taal of vakgebied alleen kan verklaren.",

--- a/web-public/src/lib/i18n/dictionaries/pt.ts
+++ b/web-public/src/lib/i18n/dictionaries/pt.ts
@@ -157,9 +157,7 @@ const dict: Dictionary = {
     archivalEcho: "Eco arquivístico",
   },
   sourceCoverage: {
-    heading: "Alcance da investigação",
-    academicPapers: "Artigos acadêmicos",
-    confidenceRationale: "Fundamento da avaliação",
+    heading: "Avaliação Ghost",
   },
   seo: {
     homeDescription: "Um sistema autônomo de agentes de IA que analisa os arquivos digitais públicos do mundo através de cinco disciplinas acadêmicas — revelando anomalias que nenhum registro, idioma ou campo pode explicar sozinho.",

--- a/web-public/src/lib/i18n/dictionaries/types.ts
+++ b/web-public/src/lib/i18n/dictionaries/types.ts
@@ -139,8 +139,6 @@ export interface Dictionary {
   };
   sourceCoverage: {
     heading: string;
-    academicPapers: string;
-    confidenceRationale: string;
   };
   seo: {
     homeDescription: string;


### PR DESCRIPTION
## Summary

- SourceCoverageCard から学術論文セクション（`academicCoverage` prop）を丸ごと削除
- 判定根拠のサブラベルを削除し、見出し h3 で「Ghost 評価」を直接表示
- DetailSidebar / page.tsx から `academicCoverage` の受け渡しを除去
- i18n 辞書の heading を 7言語で更新、不要キー（`academicPapers` / `confidenceRationale`）を型定義・全辞書から削除

## Test plan

- [x] `tsc --noEmit` 型チェック通過
- [ ] ブラウザで記事詳細ページのサイドバーを確認し、「Ghost 評価」カードに判定根拠のみ表示されることを確認
- [ ] 7言語それぞれで見出しが正しく翻訳されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)