### PR TITLE
fix: ストーリーテラー表示名にモデルバージョン番号を追加

### DIFF
--- a/packages/shared/src/types/mystery.ts
+++ b/packages/shared/src/types/mystery.ts
@@ -556,10 +556,10 @@ export const AGENT_NAME_LABELS: Record<string, string> = {
  * ストーリーテラー（LLM）の表示名マッピング
  */
 export const STORYTELLER_DISPLAY_NAMES: Record<string, string> = {
-  claude: "Claude",
-  gemini: "Gemini",
-  gpt: "GPT",
-  llama: "Llama",
-  deepseek: "DeepSeek",
-  mistral: "Mistral",
+  claude: "Claude Sonnet 4.5",
+  gemini: "Gemini 3 Pro",
+  gpt: "GPT-4o",
+  llama: "Llama 4 Maverick",
+  deepseek: "DeepSeek V3",
+  mistral: "Mistral Large",
 };

--- a/shared/model_config.py
+++ b/shared/model_config.py
@@ -34,32 +34,32 @@ STORYTELLER_MODELS: dict[str, dict] = {
     "claude": {
         "model_id": "openrouter/anthropic/claude-sonnet-4.5",
         "provider": "litellm",
-        "display_name": "Claude",
+        "display_name": "Claude Sonnet 4.5",
     },
     "gemini": {
         "model_id": MODEL_PRO,
         "provider": "native_gemini",
-        "display_name": "Gemini",
+        "display_name": "Gemini 3 Pro",
     },
     "gpt": {
         "model_id": "openrouter/openai/gpt-4o",
         "provider": "litellm",
-        "display_name": "GPT",
+        "display_name": "GPT-4o",
     },
     "llama": {
         "model_id": "openrouter/meta-llama/llama-4-maverick",
         "provider": "litellm",
-        "display_name": "Llama",
+        "display_name": "Llama 4 Maverick",
     },
     "deepseek": {
         "model_id": "openrouter/deepseek/deepseek-chat",
         "provider": "litellm",
-        "display_name": "DeepSeek",
+        "display_name": "DeepSeek V3",
     },
     "mistral": {
         "model_id": "openrouter/mistralai/mistral-large-2512",
         "provider": "litellm",
-        "display_name": "Mistral",
+        "display_name": "Mistral Large",
     },
 }
 

--- a/web-admin/src/components/investigation-form.tsx
+++ b/web-admin/src/components/investigation-form.tsx
@@ -6,12 +6,12 @@ import {
 } from "lucide-react"
 
 const STORYTELLER_OPTIONS = [
-  { value: "claude", label: "Claude" },
-  { value: "gemini", label: "Gemini" },
-  { value: "gpt", label: "GPT" },
-  { value: "llama", label: "Llama" },
-  { value: "deepseek", label: "DeepSeek" },
-  { value: "mistral", label: "Mistral" },
+  { value: "claude", label: "Claude Sonnet 4.5" },
+  { value: "gemini", label: "Gemini 3 Pro" },
+  { value: "gpt", label: "GPT-4o" },
+  { value: "llama", label: "Llama 4 Maverick" },
+  { value: "deepseek", label: "DeepSeek V3" },
+  { value: "mistral", label: "Mistral Large" },
 ] as const
 
 interface ThemeSuggestion {


### PR DESCRIPTION
## Summary
- ストーリーテラー表示名を汎用名からモデルバージョン番号付きの正確な名称に変更
  - Claude → Claude Sonnet 4.5, Gemini → Gemini 3 Pro, GPT → GPT-4o, Llama → Llama 4 Maverick, DeepSeek → DeepSeek V3, Mistral → Mistral Large
- Python バックエンド (`shared/model_config.py`)、TypeScript 共有定数 (`packages/shared/src/types/mystery.ts`)、管理画面ドロップダウン (`web-admin/src/components/investigation-form.tsx`) の3箇所を同期更新

## Test plan
- [x] `pytest tests/unit/test_reporter_selection.py -v` — 全18テストパス
- [ ] web-admin のストーリーテラードロップダウンに正確なモデル名が表示されること（目視確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)