### PR TITLE
fix: Alchemist 管理画面改善 + 透過背景生成

### DIFF
--- a/alchemist_agents/tools/render_tools.py
+++ b/alchemist_agents/tools/render_tools.py
@@ -5,10 +5,12 @@ AlchemistRenderer エージェントが使用するツール:
 
 mystery_agents/tools/illustrator_tools.py の generate_image() をラップ。
 product_type から aspect_ratio を自動決定し、セッション状態に累積保存する。
+生成後に Imagen Edit API + PIL クロマキーで背景を透過処理する。
 """
 
 import json
 import logging
+import os
 from typing import Optional
 
 from google.adk.tools.tool_context import ToolContext
@@ -20,6 +22,97 @@ PRODUCT_ASPECT_RATIOS = {
     "tshirt": "1:1",
     "mug": "16:9",
 }
+
+
+def _remove_background(filepath: str) -> str:
+    """Imagen Edit API でマゼンタ背景置換 → PIL クロマキーで透過 PNG に変換する。
+
+    処理フロー:
+    1. Imagen Edit API (MASK_MODE_BACKGROUND + EDIT_MODE_BGSWAP) で背景をマゼンタに置換
+    2. PIL で マゼンタ (#FF00FF) ピクセルを透明化（閾値処理でアンチエイリアス保全）
+    3. 透過 PNG を上書き保存
+
+    エラー時は元の不透過画像パスをそのまま返す（フェイルオープン）。
+
+    Args:
+        filepath: 元画像の絶対パス。
+
+    Returns:
+        透過 PNG のパス（成功時は同じパス、失敗時も同じパス）。
+    """
+    try:
+        from google import genai
+        from google.genai import types
+        from PIL import Image as PILImage
+        import numpy as np
+
+        # genai クライアント取得（illustrator_tools と同じロジック）
+        if os.environ.get("GOOGLE_GENAI_USE_VERTEXAI", "").upper() == "TRUE":
+            client = genai.Client(
+                vertexai=True,
+                project=os.environ.get("GOOGLE_CLOUD_PROJECT"),
+                location=os.environ.get("GOOGLE_CLOUD_LOCATION", "asia-northeast1"),
+            )
+        else:
+            client = genai.Client()
+
+        # 元画像を読み込み
+        with open(filepath, "rb") as f:
+            image_bytes = f.read()
+
+        raw_ref = types.RawReferenceImage(
+            reference_image=types.Image(
+                image_bytes=image_bytes,
+                mime_type="image/png",
+            ),
+            reference_id=0,
+        )
+
+        mask_ref = types.MaskReferenceImage(
+            reference_id=1,
+            config=types.MaskReferenceConfig(
+                mask_mode="MASK_MODE_BACKGROUND",
+                mask_dilation=0.0,
+            ),
+        )
+
+        # Imagen Edit API で背景をマゼンタに置換
+        response = client.models.edit_image(
+            model="imagen-3.0-capability-001",
+            prompt="solid pure magenta #FF00FF background, uniform flat color",
+            reference_images=[raw_ref, mask_ref],
+            config=types.EditImageConfig(
+                edit_mode="EDIT_MODE_BGSWAP",
+            ),
+        )
+
+        if not response.generated_images:
+            logger.warning("背景置換: 生成画像なし、元画像を維持: %s", filepath)
+            return filepath
+
+        # 生成画像を取得
+        edited_bytes = response.generated_images[0].image.image_bytes
+
+        # PIL でマゼンタ → 透明に変換
+        import io
+        img = PILImage.open(io.BytesIO(edited_bytes)).convert("RGBA")
+        data = np.array(img)
+
+        # マゼンタ (#FF00FF) の許容範囲検出（アンチエイリアス対応）
+        r, g, b = data[:, :, 0], data[:, :, 1], data[:, :, 2]
+        magenta_mask = (r > 200) & (g < 50) & (b > 200)
+
+        # 透明化
+        data[magenta_mask, 3] = 0
+        result = PILImage.fromarray(data)
+        result.save(filepath, "PNG")
+
+        logger.info("背景透過完了: %s", filepath)
+        return filepath
+
+    except Exception as e:
+        logger.warning("背景透過処理に失敗、元画像を維持: %s — %s", filepath, e)
+        return filepath
 
 
 def generate_design_asset(
@@ -91,6 +184,12 @@ def generate_design_asset(
     result["product_type"] = product_type
     result["asset_layer"] = asset_layer
     result["aspect_ratio"] = aspect_ratio
+
+    # 背景透過処理（生成成功時のみ）
+    if result.get("status") == "success" and result.get("filepath"):
+        original_path = result["filepath"]
+        result["filepath"] = _remove_background(original_path)
+        result["transparent_background"] = True
 
     # セッション状態に累積保存
     if tool_context is not None:

--- a/tests/unit/test_render_tools.py
+++ b/tests/unit/test_render_tools.py
@@ -1,9 +1,13 @@
 """Unit tests for alchemist_agents/tools/render_tools.py - generate_design_asset."""
 
 import json
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
-from alchemist_agents.tools.render_tools import generate_design_asset, PRODUCT_ASPECT_RATIOS
+from alchemist_agents.tools.render_tools import (
+    generate_design_asset,
+    _remove_background,
+    PRODUCT_ASPECT_RATIOS,
+)
 from tests.fakes import make_tool_context
 
 # generate_image は関数内で遅延 import されるため、import 元をパッチする
@@ -215,3 +219,106 @@ class TestGenerateDesignAsset:
         """PRODUCT_ASPECT_RATIOS の定義を検証する。"""
         assert PRODUCT_ASPECT_RATIOS["tshirt"] == "1:1"
         assert PRODUCT_ASPECT_RATIOS["mug"] == "16:9"
+
+
+class TestRemoveBackground:
+    """Tests for _remove_background()."""
+
+    def test_returns_original_path_on_error(self):
+        """ファイルが存在しない場合、元のパスをフォールバックで返す。"""
+        result = _remove_background("/nonexistent/path.png")
+        assert result == "/nonexistent/path.png"
+
+    @patch("google.genai.Client")
+    def test_replaces_magenta_with_transparency(self, mock_client_cls, tmp_path):
+        """マゼンタ背景がアルファ 0 に変換される。"""
+        from PIL import Image as PILImage
+        import numpy as np
+        import io
+
+        # マゼンタ背景 + 赤い前景のテスト画像を作成
+        img = PILImage.new("RGB", (10, 10), (255, 0, 255))  # 全面マゼンタ
+        # 中央 4px を赤に（前景）
+        for x in range(4, 6):
+            for y in range(4, 6):
+                img.putpixel((x, y), (255, 0, 0))
+        filepath = str(tmp_path / "test.png")
+        img.save(filepath, "PNG")
+
+        # Edit API が返す画像バイト列（同じ画像 = 背景がマゼンタになった想定）
+        buf = io.BytesIO()
+        img.save(buf, "PNG")
+        edited_bytes = buf.getvalue()
+
+        mock_image = MagicMock()
+        mock_image.image_bytes = edited_bytes
+
+        mock_response = MagicMock()
+        mock_response.generated_images = [MagicMock(image=mock_image)]
+
+        mock_client = MagicMock()
+        mock_client.models.edit_image.return_value = mock_response
+        mock_client_cls.return_value = mock_client
+
+        result = _remove_background(filepath)
+
+        assert result == filepath
+
+        # 結果画像を検証
+        result_img = PILImage.open(filepath).convert("RGBA")
+        data = np.array(result_img)
+
+        # マゼンタ領域（背景）は透明になっている
+        assert data[0, 0, 3] == 0  # 左上（元マゼンタ）→ 透明
+        # 赤い領域（前景）は不透明のまま
+        assert data[4, 4, 3] == 255  # 中央（赤）→ 不透明
+
+    @patch("google.genai.Client")
+    def test_returns_original_on_empty_response(self, mock_client_cls, tmp_path):
+        """Edit API が空レスポンスを返した場合、元画像を維持する。"""
+        from PIL import Image as PILImage
+
+        filepath = str(tmp_path / "test.png")
+        PILImage.new("RGB", (4, 4), (100, 100, 100)).save(filepath, "PNG")
+
+        mock_response = MagicMock()
+        mock_response.generated_images = []
+
+        mock_client = MagicMock()
+        mock_client.models.edit_image.return_value = mock_response
+        mock_client_cls.return_value = mock_client
+
+        result = _remove_background(filepath)
+
+        assert result == filepath
+
+    @patch(_PATCH_GENERATE_IMAGE)
+    @patch("alchemist_agents.tools.render_tools._remove_background")
+    def test_generate_calls_remove_background_on_success(self, mock_remove_bg, mock_gen):
+        """generate_design_asset が成功時に _remove_background を呼び出す。"""
+        mock_gen.return_value = json.dumps({
+            "status": "success",
+            "filepath": "/tmp/test.png",
+        })
+        mock_remove_bg.return_value = "/tmp/test.png"
+
+        result_json = generate_design_asset(
+            prompt="Test", product_type="tshirt",
+        )
+        result = json.loads(result_json)
+
+        mock_remove_bg.assert_called_once_with("/tmp/test.png")
+        assert result["transparent_background"] is True
+
+    @patch(_PATCH_GENERATE_IMAGE)
+    @patch("alchemist_agents.tools.render_tools._remove_background")
+    def test_generate_skips_remove_background_on_error(self, mock_remove_bg, mock_gen):
+        """generate_design_asset がエラー時に _remove_background を呼び出さない。"""
+        mock_gen.return_value = json.dumps({
+            "status": "error",
+            "error": "Generation failed",
+        })
+
+        generate_design_asset(prompt="Test", product_type="tshirt")
+
+        mock_remove_bg.assert_not_called()

--- a/web-admin/src/components/active-pipeline-panel.tsx
+++ b/web-admin/src/components/active-pipeline-panel.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react"
 import Link from "next/link"
 import { cn } from "@ghost/shared/src/lib/utils"
-import type { PipelineRun } from "@ghost/shared/src/types/mystery"
+import type { PipelineRun, PipelineRunType } from "@ghost/shared/src/types/mystery"
 import { resolvePhaseLabel } from "@/lib/pipeline-phases"
 import {
   Loader2,
@@ -49,7 +49,14 @@ export function ActivePipelinePanel({ run, onDismiss }: ActivePipelinePanelProps
     ? resolvePhaseLabel(run.current_agent)
     : null
 
-  const typeLabel = run.type === "blog" ? "ブログ調査" : run.type === "podcast" ? "Podcast 生成" : "翻訳"
+  const TYPE_LABELS: Record<PipelineRunType, string> = {
+    blog: "ブログ調査",
+    translate: "翻訳",
+    podcast: "Podcast 生成",
+    design: "デザイン生成",
+    design_render: "アセットレンダリング",
+  }
+  const typeLabel = TYPE_LABELS[run.type] ?? run.type
 
   return (
     <div className={cn(
@@ -110,8 +117,8 @@ export function ActivePipelinePanel({ run, onDismiss }: ActivePipelinePanelProps
         </div>
       </div>
 
-      {/* 完了時: 記事プレビューリンク */}
-      {run.status === "completed" && run.mystery_id && (
+      {/* 完了時: 記事プレビューリンク（blog / translate のみ） */}
+      {run.status === "completed" && run.mystery_id && (run.type === "blog" || run.type === "translate") && (
         <div className="flex items-center gap-2 mb-2">
           <Link
             href={`/preview/${run.mystery_id}`}

--- a/web-admin/src/components/design-proposal-viewer.tsx
+++ b/web-admin/src/components/design-proposal-viewer.tsx
@@ -63,6 +63,9 @@ export function DesignProposalViewer({ products }: DesignProposalViewerProps) {
             <span className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
               Color Palette
             </span>
+            <p className="text-xs text-muted-foreground/70 mt-1">
+              記事のトーンと地域性に基づく推奨配色。印刷発注・Canva/Adobe でのテキスト配置に使用。
+            </p>
             <div className="flex items-center gap-2 mt-2">
               {product.color_palette.map((color, i) => (
                 <div key={i} className="flex items-center gap-1.5">
@@ -94,6 +97,9 @@ export function DesignProposalViewer({ products }: DesignProposalViewerProps) {
             <span className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
               Composition
             </span>
+            <p className="text-xs text-muted-foreground/70 mt-1">
+              レンダリング画像の空間構成・視覚的レイアウトの設計意図。
+            </p>
             <p className="text-sm text-foreground/80 mt-1 leading-relaxed">
               {product.composition}
             </p>

--- a/web-admin/src/lib/pipeline-phases.ts
+++ b/web-admin/src/lib/pipeline-phases.ts
@@ -25,6 +25,9 @@ const PIPELINE_PHASES: PipelinePhase[] = [
   { id: "script_planning",    label: "アウトライン設計", match: (n) => n === "script_planner" },
   { id: "scriptwriting",      label: "脚本作成",    match: (n) => n === "scriptwriter" },
   { id: "script_translation", label: "脚本翻訳",    match: (n) => n === "podcast_translator_ja" },
+  // Alchemist パイプライン
+  { id: "alchemist",          label: "デザイン企画",       match: (n) => n === "alchemist" },
+  { id: "alchemist_renderer", label: "デザインレンダリング", match: (n) => n === "alchemist_renderer" },
 ]
 
 /**


### PR DESCRIPTION
## Summary

- 進捗パネルの typeLabel をターナリチェーンから `Record<PipelineRunType, string>` マップに置換し、`design` / `design_render` パイプラインの正しいラベル表示に対応
- 完了時の「記事プレビュー」リンクを `blog` / `translate` タイプのみに制限
- `pipeline-phases.ts` に Alchemist パイプラインのフェーズ定義（デザイン企画 / デザインレンダリング）を追加
- `design-proposal-viewer.tsx` の Color Palette / Composition セクションに用途説明テキストを追加
- `render_tools.py` に `_remove_background()` を追加し、Imagen Edit API（MASK_MODE_BACKGROUND + EDIT_MODE_BGSWAP）でマゼンタ背景置換 → PIL クロマキーで透過 PNG を生成
- フェイルオープン設計：背景透過処理に失敗した場合は元の不透過画像をそのまま使用

## Test plan

- [x] TypeScript 型チェック（`tsc --noEmit`）パス
- [x] 既存テスト 14 件パス（回帰なし）
- [x] 新規テスト 5 件追加・パス（`_remove_background` 単体 + `generate_design_asset` 統合）
- [ ] design / design_render パイプライン実行時に正しいラベル表示を目視確認
- [ ] デザイン詳細ページで Color Palette / Composition の説明が表示されることを確認
- [ ] 生成された PNG が透過背景であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)