### PR TITLE
fix: web-public トレイリングスラッシュ統一（404 解消 + SEO URL 修正）

### DIFF
--- a/web-public/src/app/[lang]/error.tsx
+++ b/web-public/src/app/[lang]/error.tsx
@@ -38,7 +38,7 @@ export default function ErrorPage({
               Try again
             </button>
             <a
-              href={`/${lang}`}
+              href={`/${lang}/`}
               className="px-6 py-2 border border-gold/50 rounded-sm text-gold hover:bg-gold/10 transition-colors no-underline"
             >
               Return home

--- a/web-public/src/app/[lang]/mystery/[id]/page.tsx
+++ b/web-public/src/app/[lang]/mystery/[id]/page.tsx
@@ -63,7 +63,7 @@ export async function generateMetadata({
 
   const { title, summary } = localizeMystery(mystery, lang)
 
-  const pageUrl = `${getSiteUrl()}/${lang}/mystery/${id}`
+  const pageUrl = `${getSiteUrl()}/${lang}/mystery/${id}/`
 
   // hero 画像がある場合のみ images を設定
   const heroUrl = mystery.images?.hero
@@ -132,7 +132,7 @@ export default async function MysteryDetailPage({
   ]
 
   // シェアボタン用の URL
-  const shareUrl = `${getSiteUrl()}/${lang}/mystery/${id}`
+  const shareUrl = `${getSiteUrl()}/${lang}/mystery/${id}/`
 
   // 関連記事の取得（SSG ビルド時は React.cache で共有済み）
   const relatedArticles = findRelatedArticles(

--- a/web-public/src/app/[lang]/page.tsx
+++ b/web-public/src/app/[lang]/page.tsx
@@ -140,7 +140,7 @@ export default async function HomePage({
         <section className="pb-16">
           <div className="container mx-auto px-4 text-center">
             <Link
-              href={`/${lang}/archive`}
+              href={`/${lang}/archive/`}
               className="inline-block text-sm font-mono text-muted-foreground hover:text-gold transition-colors no-underline"
             >
               <span className="redacted">████</span> {dict.home.viewAllArticles} → <span className="redacted">████</span>

--- a/web-public/src/app/page.tsx
+++ b/web-public/src/app/page.tsx
@@ -16,7 +16,7 @@ export default function RootRedirect() {
     // localStorage に保存済みの言語を優先
     const stored = localStorage.getItem("preferred-lang")
     if (stored && (SUPPORTED_LANGS as readonly string[]).includes(stored)) {
-      router.replace(`/${stored}`)
+      router.replace(`/${stored}/`)
       return
     }
 
@@ -28,7 +28,7 @@ export default function RootRedirect() {
         : DEFAULT_LANG
 
     localStorage.setItem("preferred-lang", matched)
-    router.replace(`/${matched}`)
+    router.replace(`/${matched}/`)
   }, [router])
 
   // リダイレクト中のフォールバック表示

--- a/web-public/src/components/archive-filter.tsx
+++ b/web-public/src/components/archive-filter.tsx
@@ -101,7 +101,7 @@ export function ArchiveFilter({ lang, dict, mysteries }: ArchiveFilterProps) {
           {filterCode}
         </span>
         <button
-          onClick={() => router.push(`/${lang}/archive`)}
+          onClick={() => router.push(`/${lang}/archive/`)}
           className="ml-auto flex items-center gap-1.5 text-xs text-muted-foreground hover:text-parchment transition-colors"
         >
           <X className="w-3.5 h-3.5" />
@@ -157,7 +157,7 @@ function FilteredMysteryCard({
     : ""
 
   return (
-    <Link href={`/${lang}/mystery/${mystery.id}`} className="block group no-underline">
+    <Link href={`/${lang}/mystery/${mystery.id}/`} className="block group no-underline">
       <article className="aged-card letterpress-border rounded-sm p-5 h-full transition-all duration-300 hover:bg-paper-light hover:border-parchment-dark/30 hover:shadow-lg hover:shadow-black/20">
         <div className={cn(mystery.thumbnail && "grid grid-cols-[96px_1fr] gap-4")}>
           {/* サムネイル */}

--- a/web-public/src/components/breadcrumb.tsx
+++ b/web-public/src/components/breadcrumb.tsx
@@ -12,8 +12,8 @@ interface BreadcrumbProps {
 
 export function Breadcrumb({ lang, title, labels }: BreadcrumbProps) {
   const items = [
-    { label: labels.home, href: `/${lang}` },
-    { label: labels.archive, href: `/${lang}/archive` },
+    { label: labels.home, href: `/${lang}/` },
+    { label: labels.archive, href: `/${lang}/archive/` },
   ]
 
   // JSON-LD 構造化データ（SSG 環境でドメイン非依存のパスのみ）

--- a/web-public/src/components/classification-guide.tsx
+++ b/web-public/src/components/classification-guide.tsx
@@ -58,7 +58,7 @@ export function ClassificationGuide({ lang, dict }: ClassificationGuideProps) {
             return (
               <Link
                 key={code}
-                href={`/${lang}/archive?c=${code}`}
+                href={`/${lang}/archive/?c=${code}`}
                 className={`group block rounded-lg border ${colors.border} bg-card p-4 transition-transform hover:scale-[1.02] no-underline`}
               >
                 <Icon className={`w-6 h-6 ${colors.icon} mb-2`} aria-hidden="true" />

--- a/web-public/src/components/featured-mystery-card.tsx
+++ b/web-public/src/components/featured-mystery-card.tsx
@@ -25,7 +25,7 @@ export function FeaturedMysteryCard({ mystery, lang, label, classificationLabels
   const hasImage = !!mystery.images?.hero
 
   return (
-    <Link href={`/${lang}/mystery/${mystery.mystery_id}`} className="block group no-underline">
+    <Link href={`/${lang}/mystery/${mystery.mystery_id}/`} className="block group no-underline">
       <article className={cn(
         "aged-card letterpress-border rounded-sm overflow-hidden transition-all duration-300 hover:shadow-lg hover:shadow-black/20",
         hasImage && "lg:grid lg:grid-cols-2"

--- a/web-public/src/components/header.tsx
+++ b/web-public/src/components/header.tsx
@@ -14,14 +14,14 @@ interface HeaderProps {
 export function Header({ lang = "en", nav }: HeaderProps) {
   const pathname = usePathname()
   const isArchiveActive = pathname.startsWith(`/${lang}/archive`)
-  const isAboutActive = pathname === `/${lang}/about`
+  const isAboutActive = pathname.startsWith(`/${lang}/about`)
 
   return (
     <header className="sticky top-0 z-50 border-b border-border/50 bg-background/80 backdrop-blur-sm">
       <div className="container mx-auto px-4">
         <div className="flex items-center justify-between h-16">
           {/* Logo */}
-          <Link href={`/${lang}`} className="flex items-center gap-3 group">
+          <Link href={`/${lang}/`} className="flex items-center gap-3 group">
             <div className="relative">
               <Archive className="w-6 h-6 text-gold" />
               <div className="absolute -top-0.5 -right-0.5 w-2 h-2 bg-blood-red rounded-full animate-pulse" />
@@ -36,7 +36,7 @@ export function Header({ lang = "en", nav }: HeaderProps) {
             {nav && (
               <nav className="flex items-center gap-4">
                 <Link
-                  href={`/${lang}/archive`}
+                  href={`/${lang}/archive/`}
                   className={`text-sm font-mono uppercase tracking-wider transition-colors no-underline ${
                     isArchiveActive
                       ? "text-gold"
@@ -46,7 +46,7 @@ export function Header({ lang = "en", nav }: HeaderProps) {
                   {nav.archive}
                 </Link>
                 <Link
-                  href={`/${lang}/about`}
+                  href={`/${lang}/about/`}
                   className={`text-sm font-mono uppercase tracking-wider transition-colors no-underline ${
                     isAboutActive
                       ? "text-gold"

--- a/web-public/src/components/mystery-card.tsx
+++ b/web-public/src/components/mystery-card.tsx
@@ -25,7 +25,7 @@ export function MysteryCard({ mystery, lang = "en", classificationLabels, confid
   const thumbnailUrl = mystery.images?.thumbnail
 
   return (
-    <Link href={`/${lang}/mystery/${mystery.mystery_id}`} className={cn("block group no-underline", className)}>
+    <Link href={`/${lang}/mystery/${mystery.mystery_id}/`} className={cn("block group no-underline", className)}>
       <article className="aged-card letterpress-border rounded-sm p-5 h-full transition-all duration-300 hover:bg-paper-light hover:border-parchment-dark/30 hover:shadow-lg hover:shadow-black/20">
         <div className={cn(thumbnailUrl && "grid grid-cols-[96px_1fr] gap-4")}>
           {/* サムネイル（あれば表示） */}

--- a/web-public/src/components/pagination.tsx
+++ b/web-public/src/components/pagination.tsx
@@ -41,7 +41,7 @@ function getPageNumbers(current: number, total: number): (number | "ellipsis")[]
 }
 
 function pageHref(basePath: string, page: number): string {
-  return page === 1 ? basePath : `${basePath}/${page}`
+  return page === 1 ? `${basePath}/` : `${basePath}/${page}/`
 }
 
 export function Pagination({ currentPage, totalPages, basePath, labels }: PaginationProps) {

--- a/web-public/src/components/public-footer.tsx
+++ b/web-public/src/components/public-footer.tsx
@@ -11,9 +11,9 @@ export function PublicFooter({ lang, dict }: PublicFooterProps) {
     <Footer
       labels={dict.footer}
       siteLinks={[
-        { label: dict.footer.home, href: `/${lang}` },
-        { label: dict.footer.archive, href: `/${lang}/archive` },
-        { label: dict.footer.about, href: `/${lang}/about` },
+        { label: dict.footer.home, href: `/${lang}/` },
+        { label: dict.footer.archive, href: `/${lang}/archive/` },
+        { label: dict.footer.about, href: `/${lang}/about/` },
       ]}
     />
   )

--- a/web-public/src/lib/seo.ts
+++ b/web-public/src/lib/seo.ts
@@ -33,7 +33,7 @@ export function buildOgpMetadata(
   }
 ): Pick<Metadata, "openGraph" | "twitter"> {
   const { title, description, path, type = "website", images } = options
-  const pageUrl = `${getSiteUrl()}/${lang}${path ? `/${path}` : ""}`
+  const pageUrl = `${getSiteUrl()}/${lang}${path ? `/${path}` : ""}/`
   const ogLocale = OG_LOCALE_MAP[lang]
   const alternateLocales = SUPPORTED_LANGS
     .filter((l) => l !== lang)
@@ -67,9 +67,9 @@ export function buildAlternates(
   return {
     languages: {
       ...Object.fromEntries(
-        SUPPORTED_LANGS.map((l) => [l, `/${l}${prefix}`])
+        SUPPORTED_LANGS.map((l) => [l, `/${l}${prefix}/`])
       ),
-      "x-default": `/${DEFAULT_LANG}${prefix}`,
+      "x-default": `/${DEFAULT_LANG}${prefix}/`,
     },
   }
 }


### PR DESCRIPTION
## Summary

- `trailingSlash: true` 設定下で末尾 `/` なし URL が 404 になる問題を修正
- 全 Link コンポーネント・`router.push`・SEO URL（canonical / OGP / hreflang）に明示的にトレイリングスラッシュを付与し、308 リダイレクトを完全排除
- About ページのヘッダーハイライト判定を `===` → `startsWith` に修正（`usePathname()` が `/${lang}/about/` を返すため厳密一致ではマッチしなかった）

## Changes (13 files, 22 箇所)

**A. Link href / router.push（ナビゲーション）** — 15 箇所
- `mystery-card.tsx`, `featured-mystery-card.tsx`: 記事詳細リンク
- `archive-filter.tsx`: フィルタクリア + フィルタ結果の記事リンク
- `header.tsx`: ロゴ・Archive・About リンク
- `breadcrumb.tsx`: Home・Archive リンク
- `[lang]/page.tsx`: アーカイブ導線リンク
- `classification-guide.tsx`: 分類フィルタリンク（`?c=` → `/?c=`）
- `error.tsx`: Return home リンク
- `public-footer.tsx`: Home・Archive・About リンク
- `page.tsx`（ルート）: 言語リダイレクト
- `pagination.tsx`: ページ番号リンク

**B. ヘッダーアクティブ状態判定** — 1 箇所
- `header.tsx`: `isAboutActive` を `===` → `startsWith` に修正

**C. SEO URL** — 5 箇所
- `mystery/[id]/page.tsx`: canonical URL + shareUrl
- `seo.ts`: OGP pageUrl + hreflang alternates + x-default

## Test plan

- [ ] `npm run dev` でトップページから記事詳細にクリック → 初回で正常表示
- [ ] ブラウザで末尾 `/` なし URL を直打ち → リダイレクトまたは正常表示
- [ ] About / Archive ページでナビリンクがゴールドにハイライト
- [ ] `tsc --noEmit` パス済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)