### PR TITLE
chore: Europeana API 有効化に伴い「申請中」表示を削除

### DIFF
--- a/packages/shared/src/components/footer.tsx
+++ b/packages/shared/src/components/footer.tsx
@@ -21,7 +21,7 @@ const PRIMARY_SOURCES = [
   { label: "Digital Public Library of America", href: "https://dp.la/" },
   { label: "NYPL Digital Collections", href: "https://digitalcollections.nypl.org/" },
   // 欧州
-  { label: "Europeana", href: "https://www.europeana.eu/", pending: true },
+  { label: "Europeana", href: "https://www.europeana.eu/" },
   { label: "Deutsche Digitale Bibliothek", href: "https://www.deutsche-digitale-bibliothek.de/" },
   { label: "Delpher (KB)", href: "https://www.delpher.nl/" },
   { label: "Wellcome Collection", href: "https://wellcomecollection.org/" },


### PR DESCRIPTION
## Summary

- Europeana API キーが承認・設定済みのため、web-public フッターの `pending: true` フラグを削除
- Trove は引き続き申請中のため `pending: true` を維持

## 変更ファイル

- `packages/shared/src/components/footer.tsx` — Europeana エントリから `pending: true` を削除

## Test plan

- [ ] フッターで Europeana の横に「申請中」が表示されないことを確認
- [ ] Trove は引き続き「申請中」が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)