### PR TITLE
fix: ヒーロー画像レイアウト改善（クリッピング解消 + 図版フレーミング）

### DIFF
--- a/web-admin/src/app/(main)/preview/[id]/preview-content.tsx
+++ b/web-admin/src/app/(main)/preview/[id]/preview-content.tsx
@@ -146,19 +146,21 @@ export function PreviewContent({ mystery }: PreviewContentProps) {
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 lg:gap-12">
             {/* Main content */}
             <div className="lg:col-span-2 space-y-12">
-              {/* Hero image — グリッド内に配置して PC 時は高さ制限 */}
+              {/* Hero image — 学術書の図版のようなフレーミング */}
               {mystery.images?.hero && (
-                <div className="rounded-sm overflow-hidden border border-border lg:max-h-[400px]">
-                  <Image
-                    src={mystery.images.hero}
-                    alt={title}
-                    width={1200}
-                    height={675}
-                    className="w-full h-full object-cover"
-                    priority
-                    unoptimized={mystery.images.hero.includes('localhost')}
-                  />
-                </div>
+                <figure className="mx-auto max-w-2xl">
+                  <div className="aged-card letterpress-border rounded-sm overflow-hidden">
+                    <Image
+                      src={mystery.images.hero}
+                      alt={title}
+                      width={1200}
+                      height={675}
+                      className="w-full h-auto"
+                      priority
+                      unoptimized={mystery.images.hero.includes('localhost')}
+                    />
+                  </div>
+                </figure>
               )}
 
               {/* Narrative Content (primary) */}

--- a/web-public/src/app/[lang]/about/page.tsx
+++ b/web-public/src/app/[lang]/about/page.tsx
@@ -56,21 +56,25 @@ export default async function AboutPage({
         <Hero dict={dict} />
 
         {/* ヒーロー画像バナー */}
-        <section className="relative overflow-hidden max-h-[400px]">
-          <picture>
-            <source media="(max-width: 640px)" srcSet="/images/hero-bg_sm.webp" type="image/webp" />
-            <source media="(max-width: 828px)" srcSet="/images/hero-bg_md.webp" type="image/webp" />
-            <source media="(max-width: 1200px)" srcSet="/images/hero-bg_lg.webp" type="image/webp" />
-            <source media="(min-width: 1201px)" srcSet="/images/hero-bg_xl.webp" type="image/webp" />
-            <img
-              src="/images/hero-bg_xl.webp"
-              alt="Ghost in the Archive"
-              className="w-full h-full object-cover"
-              fetchPriority="high"
-            />
-          </picture>
-
-          <div className="absolute bottom-0 left-0 right-0 h-32 bg-gradient-to-t from-background to-transparent z-10 pointer-events-none" />
+        <section className="py-4">
+          <div className="container mx-auto px-4">
+            <div className="relative max-w-4xl mx-auto rounded-sm overflow-hidden border border-border/50">
+              <picture>
+                <source media="(max-width: 640px)" srcSet="/images/hero-bg_sm.webp" type="image/webp" />
+                <source media="(max-width: 828px)" srcSet="/images/hero-bg_md.webp" type="image/webp" />
+                <source media="(max-width: 1200px)" srcSet="/images/hero-bg_lg.webp" type="image/webp" />
+                <source media="(min-width: 1201px)" srcSet="/images/hero-bg_xl.webp" type="image/webp" />
+                <img
+                  src="/images/hero-bg_xl.webp"
+                  alt="Ghost in the Archive"
+                  className="w-full h-auto"
+                  fetchPriority="high"
+                />
+              </picture>
+              <div className="absolute bottom-0 left-0 right-0 h-24 bg-gradient-to-t from-background to-transparent pointer-events-none" />
+              <div className="absolute top-0 left-0 right-0 h-16 bg-gradient-to-b from-background to-transparent pointer-events-none" />
+            </div>
+          </div>
         </section>
 
         {/* Concept */}

--- a/web-public/src/app/[lang]/mystery/[id]/loading.tsx
+++ b/web-public/src/app/[lang]/mystery/[id]/loading.tsx
@@ -29,7 +29,7 @@ export default function MysteryDetailLoading() {
           </div>
 
           {/* Hero image skeleton */}
-          <div className="mb-12 rounded-sm border border-border aspect-video bg-muted/10 animate-pulse" />
+          <div className="mx-auto max-w-2xl mb-12 rounded-sm border border-border aspect-video bg-muted/10 animate-pulse" />
 
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 lg:gap-12">
             {/* Main content skeleton */}

--- a/web-public/src/app/[lang]/mystery/[id]/page.tsx
+++ b/web-public/src/app/[lang]/mystery/[id]/page.tsx
@@ -194,17 +194,19 @@ export default async function MysteryDetailPage({
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 lg:gap-12">
             {/* Main content */}
             <div className="lg:col-span-2 space-y-12">
-              {/* Hero image — グリッド内に配置して PC 時は高さ制限 */}
+              {/* Hero image — 学術書の図版のようなフレーミング */}
               {mystery.images?.hero && (
-                <div className="rounded-sm overflow-hidden border border-border lg:max-h-[400px]">
-                  <ResponsiveHeroImage
-                    hero={mystery.images.hero}
-                    variants={mystery.images.variants}
-                    alt={title}
-                    priority
-                    className="w-full h-full object-cover"
-                  />
-                </div>
+                <figure className="mx-auto max-w-2xl">
+                  <div className="aged-card letterpress-border rounded-sm overflow-hidden">
+                    <ResponsiveHeroImage
+                      hero={mystery.images.hero}
+                      variants={mystery.images.variants}
+                      alt={title}
+                      priority
+                      className="w-full h-auto"
+                    />
+                  </div>
+                </figure>
               )}
 
               <NarrativeSection narrativeContent={narrativeContent} summary={summary} lang={lang} />


### PR DESCRIPTION
## Summary

- **詳細ページ**: `lg:max-h-[400px]` + `object-cover` → `figure` + `max-w-2xl` + `aged-card` に変更。学術書の図版のようなフレーミングで、アスペクト比を維持してクリッピングを解消
- **About ページ**: ビューポート全幅 + `max-h-[400px]` → `container` 内 `max-w-4xl` に変更。上下グラデーションで自然な視覚遷移
- **管理画面プレビュー**: 公開ページと同じレイアウトに統一
- **ローディングスケルトン**: `max-w-2xl` 追加で実際の画像レイアウトと一致

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `web-public/.../mystery/[id]/page.tsx` | ヒーロー画像を `figure` + `max-w-2xl` + `aged-card letterpress-border` に変更 |
| `web-public/.../about/page.tsx` | バナー画像を `container` 内 `max-w-4xl` + 上下グラデーションに変更 |
| `web-admin/.../preview/[id]/preview-content.tsx` | 公開ページと同じレイアウトに統一 |
| `web-public/.../mystery/[id]/loading.tsx` | スケルトンに `max-w-2xl` + `mx-auto` 追加 |

## Test plan

- [ ] 詳細ページ: 画像がクリップされず、コンテンツ幅より狭いフレームで表示される
- [ ] About ページ: 画像がビューポート全幅ではなく container 内に収まる
- [ ] モバイル: 画像がパディング内で自然に表示される
- [ ] 管理画面プレビュー: 公開ページと同じ見た目になる
- [ ] TypeScript 型チェック通過済み（web-public / web-admin）

🤖 Generated with [Claude Code](https://claude.com/claude-code)