### PR TITLE
feat: 証拠ブロックにデジタルアーカイブ名の出典表示を追加

### DIFF
--- a/packages/shared/src/components/evidence-block.tsx
+++ b/packages/shared/src/components/evidence-block.tsx
@@ -3,6 +3,7 @@
 import { ExternalLink, FileText } from "lucide-react"
 import type { Evidence } from "../types/mystery"
 import { cn } from "../lib/utils"
+import { getArchiveName } from "../lib/archive-name"
 
 interface EvidenceLabels {
   source?: string
@@ -26,6 +27,7 @@ export function EvidenceBlock({ evidence, label, translatedExcerpt, labels, clas
   // 空 excerpt のフォールバック: テキスト部分を非表示にする（既存 Firestore データ対応）
   const hasExcerpt = !!evidence.relevant_excerpt?.trim()
   const hasTranslatedExcerpt = !!translatedExcerpt?.trim()
+  const archiveName = getArchiveName(evidence)
 
   return (
     <figure className={cn("relative group", className)}>
@@ -88,6 +90,12 @@ export function EvidenceBlock({ evidence, label, translatedExcerpt, labels, clas
           <FileText className="w-4 h-4 text-gold shrink-0 mt-0.5" />
           <p className="text-xs text-muted-foreground leading-relaxed">
             <span className="text-parchment/80 font-medium">{sourceLabel} </span>
+            {archiveName && (
+              <>
+                <span className="text-gold/70">{archiveName}</span>
+                <span className="text-muted-foreground/40"> — </span>
+              </>
+            )}
             {evidence.source_title}
           </p>
         </div>

--- a/packages/shared/src/lib/archive-name.ts
+++ b/packages/shared/src/lib/archive-name.ts
@@ -1,0 +1,67 @@
+import type { Evidence } from "../types/mystery";
+
+/**
+ * URL ドメインパターン → アーカイブ表示名マッピング
+ * ドメインの部分一致で判定（source_url に含まれるか）
+ */
+const URL_DOMAIN_MAP: [string, string][] = [
+  // loc.gov は LOC Digital Collections と Chronicling America の両方を含む
+  ["loc.gov", "Library of Congress"],
+  ["dp.la", "DPLA"],
+  ["nypl.org", "NYPL Digital Collections"],
+  ["archive.org", "Internet Archive"],
+  ["europeana.eu", "Europeana"],
+  ["deutsche-digitale-bibliothek.de", "Deutsche Digitale Bibliothek"],
+  ["delpher.nl", "Delpher"],
+  ["kb.nl", "Delpher"],
+  ["wellcomecollection.org", "Wellcome Collection"],
+  ["nla.gov.au", "Trove"],
+  ["natlib.govt.nz", "DigitalNZ"],
+  ["digitalnz.org", "DigitalNZ"],
+  ["paperspast.natlib.govt.nz", "DigitalNZ"],
+  ["ndlsearch.ndl.go.jp", "National Diet Library"],
+  ["dl.ndl.go.jp", "National Diet Library"],
+];
+
+/**
+ * source_type → アーカイブ表示名フォールバック
+ */
+const SOURCE_TYPE_MAP: Record<string, string> = {
+  newspaper: "Library of Congress",
+  loc_digital: "Library of Congress",
+  dpla: "DPLA",
+  nypl: "NYPL Digital Collections",
+  internet_archive: "Internet Archive",
+  europeana: "Europeana",
+  ddb: "Deutsche Digitale Bibliothek",
+  delpher: "Delpher",
+  wellcome: "Wellcome Collection",
+  trove: "Trove",
+  digitalnz: "DigitalNZ",
+  ndl: "National Diet Library",
+};
+
+/**
+ * 証拠データからデジタルアーカイブ名を導出する
+ *
+ * 1. source_url のドメインパターンマッチ（主）
+ * 2. source_type からのフォールバック（副）
+ * 3. いずれも不明なら undefined
+ */
+export function getArchiveName(evidence: Evidence): string | undefined {
+  // URL パターンマッチ
+  if (evidence.source_url) {
+    for (const [domain, name] of URL_DOMAIN_MAP) {
+      if (evidence.source_url.includes(domain)) {
+        return name;
+      }
+    }
+  }
+
+  // source_type フォールバック
+  if (evidence.source_type) {
+    return SOURCE_TYPE_MAP[evidence.source_type];
+  }
+
+  return undefined;
+}

--- a/packages/shared/src/types/mystery.ts
+++ b/packages/shared/src/types/mystery.ts
@@ -17,7 +17,9 @@ export type ConfidenceLevel = "high" | "medium" | "low";
 
 /** ソースタイプ */
 export type SourceType = "newspaper" | "loc_digital" | "dpla" | "nypl"
-  | "pares" | "internet_archive" | "ddb";
+  | "pares" | "internet_archive" | "ddb" | "europeana" | "trove"
+  | "delpher" | "ndl" | "wellcome" | "digitalnz"
+  | "archive" | "book";
 
 /** ソース言語 */
 export type SourceLanguage = "en" | "es" | "de" | "fr" | "nl" | "pt";

--- a/tests/unit/test_archive_name_mapping.py
+++ b/tests/unit/test_archive_name_mapping.py
@@ -1,0 +1,84 @@
+"""archive-name.ts マッピングと source_registry.py の同期テスト。
+
+TypeScript の URL ドメインマッピング・source_type フォールバックが
+Python ソースレジストリの全 ArchiveSource をカバーしているか検証する。
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from mystery_agents.tools.source_registry import get_all_sources
+
+# TypeScript マッピングファイルのパス
+_TS_FILE = (
+    Path(__file__).resolve().parents[2]
+    / "packages"
+    / "shared"
+    / "src"
+    / "lib"
+    / "archive-name.ts"
+)
+
+
+@pytest.fixture(scope="module")
+def ts_content() -> str:
+    """archive-name.ts の内容を読み込む。"""
+    return _TS_FILE.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def ts_url_domains(ts_content: str) -> set[str]:
+    """URL_DOMAIN_MAP に含まれるドメイン文字列を抽出する。"""
+    # ["loc.gov", "Library of Congress"] 形式の1要素目を抽出
+    return set(re.findall(r'\["([^"]+)",\s*"[^"]+"', ts_content))
+
+
+@pytest.fixture(scope="module")
+def ts_source_types(ts_content: str) -> set[str]:
+    """SOURCE_TYPE_MAP のキーを抽出する。"""
+    # SOURCE_TYPE_MAP ブロック内の `key: "value"` パターン
+    block_match = re.search(
+        r"SOURCE_TYPE_MAP.*?=\s*\{(.*?)\}", ts_content, re.DOTALL
+    )
+    assert block_match, "SOURCE_TYPE_MAP が archive-name.ts に見つからない"
+    return set(re.findall(r"(\w+):", block_match.group(1)))
+
+
+class TestUrlDomainCoverage:
+    """全 ArchiveSource の expected_domains が URL マッピングにカバーされているか。"""
+
+    def test_all_expected_domains_covered(self, ts_url_domains: set[str]):
+        """各ソースの expected_domains が TS の URL_DOMAIN_MAP に含まれる。"""
+        all_sources = get_all_sources()
+        uncovered: list[str] = []
+
+        for key, source in all_sources.items():
+            for domain in source.expected_domains:
+                if not any(ts_domain in domain or domain in ts_domain
+                           for ts_domain in ts_url_domains):
+                    uncovered.append(f"{key}: {domain}")
+
+        assert not uncovered, (
+            f"以下のドメインが archive-name.ts の URL_DOMAIN_MAP に不足:\n"
+            + "\n".join(f"  - {u}" for u in uncovered)
+        )
+
+
+class TestSourceTypeCoverage:
+    """全 ArchiveSource の source_type が source_type フォールバックにカバーされているか。"""
+
+    def test_all_source_types_covered(self, ts_source_types: set[str]):
+        """各ソースの source_type が TS の SOURCE_TYPE_MAP に含まれる。"""
+        all_sources = get_all_sources()
+        uncovered: list[str] = []
+
+        for key, source in all_sources.items():
+            if source.source_type not in ts_source_types:
+                uncovered.append(f"{key}: source_type={source.source_type}")
+
+        assert not uncovered, (
+            f"以下の source_type が archive-name.ts の SOURCE_TYPE_MAP に不足:\n"
+            + "\n".join(f"  - {u}" for u in uncovered)
+        )


### PR DESCRIPTION
## Summary

- EvidenceBlock の出典行に「どのデジタルアーカイブから取得したか」を自動表示
- URL ドメインパターンマッチング（主）+ `source_type` フォールバック（副）で導出
- **スキーマ変更なし**、表示レイヤーのみの変更。既存記事にも即時適用

表示例:
```
現在: 出典 The National Prohibitionist (Chicago)
変更: 出典 Library of Congress — The National Prohibitionist (Chicago)
```

## Changes

| ファイル | 変更内容 |
|---|---|
| `packages/shared/src/lib/archive-name.ts` | 新規: URL→アーカイブ名マッピング（11アーカイブ対応）+ source_type フォールバック |
| `packages/shared/src/components/evidence-block.tsx` | アーカイブ名を citation 行に統合（`text-gold/70` で色分け） |
| `packages/shared/src/types/mystery.ts` | `SourceType` に不足していた7値を追加（europeana, trove, delpher, ndl, wellcome, digitalnz, archive, book） |
| `tests/unit/test_archive_name_mapping.py` | Python `source_registry.py` と TS マッピングの同期テスト |

## Test plan

- [x] `python -m pytest tests/unit/test_archive_name_mapping.py -v` — マッピング同期テスト PASSED
- [x] `tsc --noEmit` — web-public / web-admin 型チェック PASSED
- [ ] ブラウザで既存記事の詳細ページを確認し、出典にアーカイブ名が表示されることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)