### PR TITLE
fix: スマホサイズでの目次重複表示を修正

### DIFF
--- a/web-public/src/components/table-of-contents.tsx
+++ b/web-public/src/components/table-of-contents.tsx
@@ -108,7 +108,7 @@ export function TableOfContents({ sections, heading, variant }: TableOfContentsP
 
   if (variant === "desktop") {
     return (
-      <div className="aged-card letterpress-border rounded-sm p-5">
+      <div className="hidden lg:block aged-card letterpress-border rounded-sm p-5">
         <h3 className="font-mono text-xs uppercase tracking-wider text-muted-foreground mb-4 flex items-center gap-2">
           <List className="w-3.5 h-3.5" />
           {heading}


### PR DESCRIPTION
## Summary
- 画面幅 <1024px で記事詳細ページの目次が本文上（モバイル折りたたみ）と本文下（サイドバー落ち）の2箇所に表示されるバグを修正
- デスクトップ variant の目次ラッパーに `hidden lg:block` を追加し、狭い画面ではモバイル目次のみ表示されるようにした

## Test plan
- [ ] `localhost:3000` で記事詳細ページを開く
- [ ] ブラウザ幅を狭める（<1024px）→ 本文上の折りたたみ目次のみ表示されること
- [ ] ブラウザ幅を広げる（≥1024px）→ 右サイドバーの目次のみ表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)