### PR TITLE
feat: 証拠出典の多様性改善（3層対策 — ランキング/インベントリ/選定基準）

### DIFF
--- a/mystery_agents/agents/armchair_polymath.py
+++ b/mystery_agents/agents/armchair_polymath.py
@@ -11,6 +11,7 @@ from google.adk.agents import LlmAgent
 
 from shared.model_config import create_pro_model
 
+from ..tools.document_inventory import get_document_inventory
 from ..tools.openalex import search_academic_papers
 from ..tools.scholar_tools import save_structured_report
 from ..tools.search_metadata import get_search_metadata
@@ -88,6 +89,24 @@ from ..tools.search_metadata import get_search_metadata
 # - 分野バイアス: 特定分野では網羅されているが他分野では見落とされていないか
 # - 時代バイアス: 学術的関心の変遷による研究の偏り
 # - アクセスバイアス: 主要一次資料がアクセス制限のある機関に保管されていないか
+#
+# ## 証拠ソース選定（必須 — 証拠選定前に実施）
+# evidence_a, evidence_b, additional_evidence を選定する前に `get_document_inventory` を呼び出し、
+# Librarian が収集した全文書をアーカイブ別に確認する。
+#
+# ### 選定原則
+# 1. **メタデータの豊富さより学術的権威**: LOC の一次資料は、説明文が短くても、
+#    Internet Archive の長い説明文付きエントリより証拠として価値が高い。
+# 2. **アグリゲータより機関一次アーカイブ**: Internet Archive は他機関の資料の
+#    デジタル化コピーを多く保持する。同等の資料が機関アーカイブと IA の両方にある場合、
+#    必ず機関アーカイブを引用する。
+# 3. **additional_evidence のソース多様性**: 資料が許す限り、できるだけ多くの
+#    異なるアーカイブから支持証拠を選ぶ。LOC, Europeana, NDL にも関連文書があるのに
+#    IA だけから5件選ぶことは避ける。
+# 4. **文書インベントリを活用**: インベントリは Scholar の分析テキストで目立った
+#    文書だけでなく、全アーカイブの全文書を表示する。証拠選定を確定する前に確認し、
+#    機関アーカイブの価値ある一次資料が Scholar の分析で簡潔にしか言及されていない
+#    可能性を考慮する。
 #
 # ## confidence_level チェックリスト
 # HIGH（Confirmed Ghost）: 3+独立資料の矛盾 + API限界で説明不可 + 2+代替仮説を検討・棄却 + 再現可能
@@ -250,6 +269,33 @@ Structure your integrated analysis as a "Mystery Report":
 **Points Requiring Further Investigation:**
 [What needs further research, especially in languages not yet searched]
 
+## Evidence Source Selection (MANDATORY — before selecting evidence)
+
+Before filling evidence_a, evidence_b, and additional_evidence, call `get_document_inventory`
+to see all documents collected by the Librarian, organized by archive.
+
+### Selection Principles
+
+1. **Scholarly authority over metadata richness**: A Library of Congress primary document
+   with a brief description is more valuable as evidence than an Internet Archive entry
+   with a long description. Judge evidence by its scholarly provenance, not by how much
+   text accompanies it.
+
+2. **Institutional primary archives over aggregators**: Internet Archive often hosts
+   digitized copies of materials held by other institutions (LOC, DPLA, Europeana, NDL).
+   When the same or equivalent material exists in both an institutional archive and
+   Internet Archive, ALWAYS cite the institutional archive.
+
+3. **Source diversity in additional_evidence**: Select supporting evidence from as many
+   different archives as the material allows. Do not fill additional_evidence with
+   5 items all from Internet Archive when LOC, Europeana, or NDL also provided relevant
+   documents.
+
+4. **Use the document inventory**: The inventory shows you ALL documents from ALL archives,
+   not just what was prominent in the Scholar analyses. Check it before finalizing evidence
+   selection — there may be valuable primary sources from institutional archives that
+   the Scholars mentioned only briefly.
+
 ## Save Structured Report (MANDATORY)
 
 After completing your analysis, you MUST call `save_structured_report` with a JSON containing:
@@ -397,7 +443,7 @@ def create_armchair_polymath() -> LlmAgent:
             "and Anthropology perspectives from all available language sources."
         ),
         instruction=ARMCHAIR_POLYMATH_INSTRUCTION,
-        tools=[save_structured_report, get_search_metadata, search_academic_papers],
+        tools=[save_structured_report, get_search_metadata, search_academic_papers, get_document_inventory],
         output_key="mystery_report",  # 既存と同じキー → 下流互換性維持
     )
 

--- a/mystery_agents/tools/document_inventory.py
+++ b/mystery_agents/tools/document_inventory.py
@@ -1,0 +1,143 @@
+"""文書インベントリツール。
+
+raw_search_results から全文書のアーカイブ別カタログを生成する。
+Polymath が Scholar のテキスト経由ではなく、直接どのアーカイブに
+どの文書があるかを確認できるようにする。
+
+summary / raw_text は意図的に除外する。含めると Polymath が
+メタデータの情報量で判断してしまうため。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections import defaultdict
+from typing import Any, Optional
+
+from google.adk.tools.tool_context import ToolContext
+
+logger = logging.getLogger(__name__)
+
+# アーカイブ名マッピング（source_type → 表示名）
+_ARCHIVE_NAMES: dict[str, str] = {
+    "loc_digital": "LOC Digital Collections",
+    "dpla": "DPLA",
+    "nypl": "NYPL Digital Collections",
+    "internet_archive": "Internet Archive",
+    "ddb": "Deutsche Digitale Bibliothek",
+    "europeana": "Europeana",
+    "trove": "Trove (Australia)",
+    "delpher": "Delpher (Netherlands)",
+    "ndl": "NDL (National Diet Library, Japan)",
+    "wellcome": "Wellcome Collection",
+    "newspaper": "Historical Newspapers",
+    "chronicling_america": "Chronicling America",
+}
+
+_NO_DATA_RESPONSE = {
+    "status": "no_data",
+    "message": "No raw_search_results found in session state.",
+    "total_documents": 0,
+    "by_archive": {},
+    "archive_summary": "",
+}
+
+
+def _extract_documents_from_result(result: dict[str, Any]) -> list[dict[str, Any]]:
+    """検索結果エントリからドキュメントリストを抽出する。"""
+    docs = result.get("documents", [])
+    if not isinstance(docs, list):
+        return []
+    return docs
+
+
+def _get_archive_name(source_type: str) -> str:
+    """source_type からアーカイブ表示名を取得する。"""
+    return _ARCHIVE_NAMES.get(source_type, source_type)
+
+
+def get_document_inventory(tool_context: Optional[ToolContext] = None) -> str:
+    """Librarian が収集した全文書のカタログを返す。
+
+    各文書について以下の情報のみ返す（summary/raw_text は意図的に除外）:
+    - title: 文書タイトル
+    - source_url: 原本URL
+    - archive: アーカイブ名（LOC, Europeana, Internet Archive 等）
+    - source_type: API ソースキー
+    - date: 日付
+    - language: 言語コード
+
+    Args:
+        tool_context: ADK tool context（セッション状態アクセス用）
+
+    Returns:
+        JSON: アーカイブ別にグループ化された文書カタログ
+    """
+    if tool_context is None:
+        return json.dumps(_NO_DATA_RESPONSE, ensure_ascii=False)
+
+    state = tool_context.state
+
+    # raw_search_results と raw_search_results_{lang} を収集
+    all_results: list[dict[str, Any]] = []
+
+    # ベースキー
+    base_results = state.get("raw_search_results")
+    if base_results and isinstance(base_results, list):
+        for r in base_results:
+            if isinstance(r, dict):
+                all_results.append(r)
+
+    # 言語別キー
+    state_dict = state.to_dict() if hasattr(state, "to_dict") else state
+    for key in list(state_dict.keys()):
+        if key.startswith("raw_search_results_") and key != "raw_search_results":
+            lang_results = state.get(key)
+            if lang_results and isinstance(lang_results, list):
+                for r in lang_results:
+                    if isinstance(r, dict):
+                        all_results.append(r)
+
+    if not all_results:
+        return json.dumps(_NO_DATA_RESPONSE, ensure_ascii=False)
+
+    # 全文書を抽出してアーカイブ別にグループ化
+    by_archive: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    seen_urls: set[str] = set()
+    total = 0
+
+    for result in all_results:
+        docs = _extract_documents_from_result(result)
+        for doc in docs:
+            url = doc.get("source_url", "")
+            if not url or url in seen_urls:
+                continue
+            seen_urls.add(url)
+
+            source_type = doc.get("source_type", "unknown")
+            archive_name = _get_archive_name(source_type)
+
+            # メタデータのみ抽出（summary/raw_text は除外）
+            entry = {
+                "title": doc.get("title", ""),
+                "source_url": url,
+                "date": doc.get("date"),
+                "language": doc.get("language", ""),
+            }
+            by_archive[archive_name].append(entry)
+            total += 1
+
+    # サマリ文字列の生成
+    archive_counts = sorted(by_archive.items(), key=lambda x: len(x[1]), reverse=True)
+    summary_parts = [f"{name}: {len(docs)} docs" for name, docs in archive_counts]
+    archive_summary = ", ".join(summary_parts)
+
+    response = {
+        "status": "ok",
+        "total_documents": total,
+        "by_archive": dict(by_archive),
+        "archive_summary": archive_summary,
+    }
+
+    return json.dumps(response, ensure_ascii=False)

--- a/mystery_agents/tools/librarian_tools.py
+++ b/mystery_agents/tools/librarian_tools.py
@@ -7,6 +7,7 @@
 import concurrent.futures
 import json
 import logging
+from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
@@ -349,11 +350,31 @@ def _search_single_source(
 def _rank_documents(
     docs: list[ArchiveDocument],
 ) -> list[ArchiveDocument]:
-    """keywords_matched 数でドキュメントをランキングする。
+    """ソースインターリーブでドキュメントをランキングする。
 
-    同点の場合は元の順序（API 応答順）を維持する。
+    各ソース（source_type）ごとに keywords_matched 数でソートした後、
+    ラウンドロビンで各ソースから1件ずつ取り出して最終リストを構築する。
+    これにより、メタデータ豊富な特定ソースが上位を独占するのを防ぐ。
     """
-    return sorted(docs, key=lambda d: len(d.keywords_matched), reverse=True)
+    # ソースごとにグループ化して各グループ内でランキング
+    by_source: dict[str, list[ArchiveDocument]] = defaultdict(list)
+    for doc in docs:
+        by_source[doc.source_type].append(doc)
+    for key in by_source:
+        by_source[key].sort(key=lambda d: len(d.keywords_matched), reverse=True)
+
+    # ラウンドロビンインターリーブ
+    result: list[ArchiveDocument] = []
+    source_iters = [iter(v) for v in by_source.values()]
+    while source_iters:
+        next_round = []
+        for it in source_iters:
+            doc = next(it, None)
+            if doc is not None:
+                result.append(doc)
+                next_round.append(it)
+        source_iters = next_round
+    return result
 
 
 def search_archives(

--- a/tests/unit/test_document_inventory.py
+++ b/tests/unit/test_document_inventory.py
@@ -1,0 +1,218 @@
+"""Unit tests for mystery_agents/tools/document_inventory.py"""
+
+import json
+
+from mystery_agents.tools.document_inventory import get_document_inventory
+from tests.fakes import make_tool_context
+
+
+class TestGetDocumentInventory:
+    """get_document_inventory のテスト"""
+
+    def test_no_tool_context_returns_no_data(self):
+        """tool_context が None の場合は no_data を返す。"""
+        result = json.loads(get_document_inventory(None))
+
+        assert result["status"] == "no_data"
+        assert result["total_documents"] == 0
+
+    def test_empty_state_returns_no_data(self):
+        """セッション状態が空の場合は no_data を返す。"""
+        ctx = make_tool_context(state={})
+
+        result = json.loads(get_document_inventory(ctx))
+
+        assert result["status"] == "no_data"
+
+    def test_groups_documents_by_archive(self):
+        """文書がアーカイブ別にグループ化される。"""
+        ctx = make_tool_context(state={
+            "raw_search_results_en": [{
+                "documents": [
+                    {
+                        "title": "LOC Doc 1",
+                        "source_url": "https://loc.gov/item/1",
+                        "source_type": "loc_digital",
+                        "date": "1893-01-01",
+                        "language": "en",
+                        "summary": "should be excluded",
+                    },
+                    {
+                        "title": "IA Doc 1",
+                        "source_url": "https://archive.org/details/1",
+                        "source_type": "internet_archive",
+                        "date": "1893-06-15",
+                        "language": "en",
+                        "summary": "should be excluded",
+                    },
+                    {
+                        "title": "LOC Doc 2",
+                        "source_url": "https://loc.gov/item/2",
+                        "source_type": "loc_digital",
+                        "date": "1894-03-20",
+                        "language": "en",
+                        "summary": "should be excluded",
+                    },
+                ],
+            }],
+        })
+
+        result = json.loads(get_document_inventory(ctx))
+
+        assert result["status"] == "ok"
+        assert result["total_documents"] == 3
+        assert "LOC Digital Collections" in result["by_archive"]
+        assert "Internet Archive" in result["by_archive"]
+        assert len(result["by_archive"]["LOC Digital Collections"]) == 2
+        assert len(result["by_archive"]["Internet Archive"]) == 1
+
+    def test_excludes_summary_and_raw_text(self):
+        """summary と raw_text が出力に含まれない。"""
+        ctx = make_tool_context(state={
+            "raw_search_results_en": [{
+                "documents": [{
+                    "title": "Test Doc",
+                    "source_url": "https://loc.gov/item/1",
+                    "source_type": "loc_digital",
+                    "date": "1893-01-01",
+                    "language": "en",
+                    "summary": "This should NOT appear",
+                    "raw_text": "This should NOT appear either",
+                }],
+            }],
+        })
+
+        result = json.loads(get_document_inventory(ctx))
+
+        doc = result["by_archive"]["LOC Digital Collections"][0]
+        assert "summary" not in doc
+        assert "raw_text" not in doc
+        assert doc["title"] == "Test Doc"
+        assert doc["source_url"] == "https://loc.gov/item/1"
+        assert doc["date"] == "1893-01-01"
+        assert doc["language"] == "en"
+
+    def test_deduplicates_by_url(self):
+        """同一 URL の文書は重複除去される。"""
+        ctx = make_tool_context(state={
+            "raw_search_results_en": [{
+                "documents": [
+                    {
+                        "title": "Doc A",
+                        "source_url": "https://loc.gov/item/same",
+                        "source_type": "loc_digital",
+                        "language": "en",
+                    },
+                ],
+            }],
+            "raw_search_results_ja": [{
+                "documents": [
+                    {
+                        "title": "Doc A (ja)",
+                        "source_url": "https://loc.gov/item/same",
+                        "source_type": "loc_digital",
+                        "language": "ja",
+                    },
+                ],
+            }],
+        })
+
+        result = json.loads(get_document_inventory(ctx))
+
+        assert result["total_documents"] == 1
+
+    def test_collects_from_multiple_language_keys(self):
+        """複数言語の raw_search_results を集約する。"""
+        ctx = make_tool_context(state={
+            "raw_search_results_en": [{
+                "documents": [{
+                    "title": "EN Doc",
+                    "source_url": "https://loc.gov/en/1",
+                    "source_type": "loc_digital",
+                    "language": "en",
+                }],
+            }],
+            "raw_search_results_ja": [{
+                "documents": [{
+                    "title": "JA Doc",
+                    "source_url": "https://ndl.go.jp/ja/1",
+                    "source_type": "ndl",
+                    "language": "ja",
+                }],
+            }],
+        })
+
+        result = json.loads(get_document_inventory(ctx))
+
+        assert result["total_documents"] == 2
+        assert "LOC Digital Collections" in result["by_archive"]
+        assert "NDL (National Diet Library, Japan)" in result["by_archive"]
+
+    def test_archive_summary_format(self):
+        """archive_summary が件数降順でフォーマットされる。"""
+        ctx = make_tool_context(state={
+            "raw_search_results_en": [{
+                "documents": [
+                    {"title": "IA 1", "source_url": "https://ia.org/1", "source_type": "internet_archive", "language": "en"},
+                    {"title": "IA 2", "source_url": "https://ia.org/2", "source_type": "internet_archive", "language": "en"},
+                    {"title": "IA 3", "source_url": "https://ia.org/3", "source_type": "internet_archive", "language": "en"},
+                    {"title": "LOC 1", "source_url": "https://loc.gov/1", "source_type": "loc_digital", "language": "en"},
+                ],
+            }],
+        })
+
+        result = json.loads(get_document_inventory(ctx))
+
+        # IA 3件 > LOC 1件 の順
+        assert result["archive_summary"].startswith("Internet Archive: 3 docs")
+        assert "LOC Digital Collections: 1 docs" in result["archive_summary"]
+
+    def test_base_key_raw_search_results(self):
+        """ベースキー raw_search_results からも文書を取得する。"""
+        ctx = make_tool_context(state={
+            "raw_search_results": [{
+                "documents": [{
+                    "title": "Base Doc",
+                    "source_url": "https://example.com/base/1",
+                    "source_type": "dpla",
+                    "language": "en",
+                }],
+            }],
+        })
+
+        result = json.loads(get_document_inventory(ctx))
+
+        assert result["total_documents"] == 1
+        assert "DPLA" in result["by_archive"]
+
+    def test_unknown_source_type_uses_key_as_name(self):
+        """未知の source_type はキーをそのまま表示名にする。"""
+        ctx = make_tool_context(state={
+            "raw_search_results_en": [{
+                "documents": [{
+                    "title": "Unknown",
+                    "source_url": "https://unknown.org/1",
+                    "source_type": "new_archive",
+                    "language": "en",
+                }],
+            }],
+        })
+
+        result = json.loads(get_document_inventory(ctx))
+
+        assert "new_archive" in result["by_archive"]
+
+    def test_skips_documents_without_source_url(self):
+        """source_url が空の文書はスキップされる。"""
+        ctx = make_tool_context(state={
+            "raw_search_results_en": [{
+                "documents": [
+                    {"title": "No URL", "source_url": "", "source_type": "loc_digital", "language": "en"},
+                    {"title": "Good", "source_url": "https://loc.gov/1", "source_type": "loc_digital", "language": "en"},
+                ],
+            }],
+        })
+
+        result = json.loads(get_document_inventory(ctx))
+
+        assert result["total_documents"] == 1

--- a/tests/unit/test_librarian_tools.py
+++ b/tests/unit/test_librarian_tools.py
@@ -352,39 +352,104 @@ class TestTotalDocsCap:
 
 
 class TestRankDocuments:
-    """_rank_documents のテスト"""
+    """_rank_documents のテスト（ソースインターリーブ方式）"""
 
-    def test_ranking_by_keyword_match(self):
-        """keywords_matched が多い順にソートされる。"""
-        doc_0kw = _make_doc(url="https://a.com/0", keywords_matched=[])
-        doc_2kw = _make_doc(url="https://a.com/2", keywords_matched=["ghost", "ship"])
-        doc_1kw = _make_doc(url="https://a.com/1", keywords_matched=["ghost"])
+    def test_interleave_prevents_single_source_domination(self):
+        """IA 10件 + LOC 3件 → LOC の上位資料が埋もれない。"""
+        ia_docs = [
+            _make_doc(
+                url=f"https://archive.org/{i}",
+                source_type="internet_archive",
+                keywords_matched=["ghost", "ship", "harbor"][:3 - i % 3],
+            )
+            for i in range(10)
+        ]
+        loc_docs = [
+            _make_doc(
+                url=f"https://loc.gov/{i}",
+                source_type="loc_digital",
+                keywords_matched=["ghost", "ship"][:2 - i % 2],
+            )
+            for i in range(3)
+        ]
+
+        ranked = _rank_documents(ia_docs + loc_docs)
+
+        # 最初の4件には IA と LOC の両方が含まれる
+        source_types_top4 = [d.source_type for d in ranked[:4]]
+        assert "loc_digital" in source_types_top4
+        assert "internet_archive" in source_types_top4
+
+    def test_interleave_round_robin_order(self):
+        """2ソースから交互に取り出される。"""
+        doc_a1 = _make_doc(url="https://a.com/1", source_type="loc_digital", keywords_matched=["ghost", "ship"])
+        doc_a2 = _make_doc(url="https://a.com/2", source_type="loc_digital", keywords_matched=["ghost"])
+        doc_b1 = _make_doc(url="https://b.com/1", source_type="internet_archive", keywords_matched=["ghost", "ship", "harbor"])
+        doc_b2 = _make_doc(url="https://b.com/2", source_type="internet_archive", keywords_matched=["ghost"])
+
+        ranked = _rank_documents([doc_a1, doc_a2, doc_b1, doc_b2])
+
+        # 4件全て含まれる
+        assert len(ranked) == 4
+        # 最初の2件は異なるソースタイプ
+        assert ranked[0].source_type != ranked[1].source_type
+
+    def test_ranking_within_source_by_keyword_match(self):
+        """各ソース内では keywords_matched 数でソートされる。"""
         doc_3kw = _make_doc(
             url="https://a.com/3",
+            source_type="loc_digital",
             keywords_matched=["ghost", "ship", "harbor"],
         )
+        doc_1kw = _make_doc(
+            url="https://a.com/1",
+            source_type="loc_digital",
+            keywords_matched=["ghost"],
+        )
+        doc_2kw = _make_doc(
+            url="https://a.com/2",
+            source_type="loc_digital",
+            keywords_matched=["ghost", "ship"],
+        )
 
-        ranked = _rank_documents([doc_0kw, doc_2kw, doc_1kw, doc_3kw])
+        ranked = _rank_documents([doc_1kw, doc_3kw, doc_2kw])
 
+        # 単一ソースなのでキーワード数順
         assert ranked[0].source_url == "https://a.com/3"
         assert ranked[1].source_url == "https://a.com/2"
         assert ranked[2].source_url == "https://a.com/1"
-        assert ranked[3].source_url == "https://a.com/0"
-
-    def test_ranking_stable_for_same_score(self):
-        """同点の場合は元の順序が維持される（安定ソート）。"""
-        doc_a = _make_doc(url="https://a.com/a", keywords_matched=["ghost"])
-        doc_b = _make_doc(url="https://a.com/b", keywords_matched=["ship"])
-
-        ranked = _rank_documents([doc_a, doc_b])
-
-        # 同スコアなので元の順序を維持
-        assert ranked[0].source_url == "https://a.com/a"
-        assert ranked[1].source_url == "https://a.com/b"
 
     def test_ranking_empty_list(self):
         """空リストでエラーにならない。"""
         assert _rank_documents([]) == []
+
+    def test_ranking_single_source(self):
+        """単一ソースのみの場合は通常のキーワード順。"""
+        doc_a = _make_doc(url="https://a.com/a", source_type="loc_digital", keywords_matched=["ghost"])
+        doc_b = _make_doc(url="https://a.com/b", source_type="loc_digital", keywords_matched=["ghost", "ship"])
+
+        ranked = _rank_documents([doc_a, doc_b])
+
+        assert ranked[0].source_url == "https://a.com/b"
+        assert ranked[1].source_url == "https://a.com/a"
+
+    def test_three_sources_interleave(self):
+        """3ソースが正しくインターリーブされる。"""
+        docs = [
+            _make_doc(url="https://loc.gov/1", source_type="loc_digital", keywords_matched=["a"]),
+            _make_doc(url="https://ia.org/1", source_type="internet_archive", keywords_matched=["a"]),
+            _make_doc(url="https://ia.org/2", source_type="internet_archive", keywords_matched=["a", "b"]),
+            _make_doc(url="https://euro.eu/1", source_type="europeana", keywords_matched=["a"]),
+            _make_doc(url="https://euro.eu/2", source_type="europeana", keywords_matched=["a", "b"]),
+        ]
+
+        ranked = _rank_documents(docs)
+
+        # 5件全て含まれる
+        assert len(ranked) == 5
+        # 最初の3件は全て異なるソース
+        first_three_sources = {d.source_type for d in ranked[:3]}
+        assert len(first_three_sources) == 3
 
 
 class TestSearchSingleSource:


### PR DESCRIPTION
## Summary

公開ページの証拠引用が Internet Archive に偏っている問題を3層で解消:

- **検索ランキング**: `_rank_documents` をソースインターリーブ方式に変更。各ソースごとに `keywords_matched` でソート後、ラウンドロビンで交互配置。IA が10件・LOC が3件でも LOC の上位資料が埋もれない
- **文書インベントリツール**: `get_document_inventory` を新規追加。Polymath が `raw_search_results` の全文書をアーカイブ別に直接確認可能（`summary`/`raw_text` は除外し情報量バイアスを排除）
- **Polymath instruction**: Evidence Source Selection セクションを追加。学術的権威 > メタデータ豊富さ、機関アーカイブ > アグリゲータ、出典多様性の3原則を明示

## 変更ファイル

| ファイル | 変更 |
|---------|------|
| `mystery_agents/tools/librarian_tools.py` | `_rank_documents` をインターリーブ方式に変更 |
| `mystery_agents/tools/document_inventory.py` | 新規: 文書インベントリツール |
| `mystery_agents/agents/armchair_polymath.py` | instruction + tools に証拠選定基準追加 |
| `tests/unit/test_librarian_tools.py` | インターリーブランキングのテスト（6件） |
| `tests/unit/test_document_inventory.py` | 新規: インベントリツールテスト（10件） |

## Test plan

- [x] `python -m pytest tests/unit/test_librarian_tools.py -v` — 25 passed
- [x] `python -m pytest tests/unit/test_document_inventory.py -v` — 10 passed
- [x] `python -m pytest tests/unit/ -v` — 全 1009 テスト passed（回帰なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)