### PR TITLE
feat: デザイン詳細ページで提案と画像を統合カード表示

### DIFF
--- a/web-admin/src/app/(main)/designs/[id]/design-detail.tsx
+++ b/web-admin/src/app/(main)/designs/[id]/design-detail.tsx
@@ -108,6 +108,19 @@ export function DesignDetail({ designId }: DesignDetailProps) {
 
   const isProcessing = design.status === "designing" || design.status === "rendering"
   const canRender = design.status === "design_ready"
+  const isRenderReady = design.status === "render_ready"
+
+  // render_ready 時: アセットが存在するプロダクトのみ表示
+  const assetsForViewer = isRenderReady ? (design.assets ?? []) : undefined
+  const productsForViewer = (() => {
+    const allProducts = design.proposal?.products ?? []
+    if (!isRenderReady || !design.assets || design.assets.length === 0) {
+      return allProducts
+    }
+    // アセットが存在する product_type のみフィルタ
+    const assetProductTypes = new Set(design.assets.map((a) => a.product_type))
+    return allProducts.filter((p) => assetProductTypes.has(p.product_type))
+  })()
 
   return (
     <div className="py-8 md:py-12">
@@ -193,7 +206,7 @@ export function DesignDetail({ designId }: DesignDetailProps) {
           </div>
         )}
 
-        {/* デザイン提案ビューアー */}
+        {/* デザイン提案ビューアー（render_ready 時は統合カード表示） */}
         {design.proposal?.products && (
           <div className="mb-6">
             <div className="flex items-center justify-between mb-4">
@@ -219,12 +232,29 @@ export function DesignDetail({ designId }: DesignDetailProps) {
               )}
             </div>
 
-            <DesignProposalViewer products={design.proposal.products} />
+            {/* render_ready でアセットが全て失敗した場合 */}
+            {isRenderReady && productsForViewer.length === 0 && (
+              <div className="aged-card letterpress-border rounded-sm p-6">
+                <div className="flex items-center gap-3">
+                  <AlertTriangle className="w-5 h-5 text-[#ff6b6b]" />
+                  <span className="text-sm text-[#ff6b6b]">
+                    アセットの生成に失敗しました
+                  </span>
+                </div>
+              </div>
+            )}
+
+            {productsForViewer.length > 0 && (
+              <DesignProposalViewer
+                products={productsForViewer}
+                assets={assetsForViewer}
+              />
+            )}
           </div>
         )}
 
-        {/* アセットギャラリー */}
-        {design.assets && design.assets.length > 0 && (
+        {/* アセットギャラリー（render_ready 時は統合カードで表示するため非表示） */}
+        {!isRenderReady && design.assets && design.assets.length > 0 && (
           <div className="mb-6">
             <h2 className="font-mono text-sm uppercase tracking-wider text-parchment mb-4">
               Generated Assets

--- a/web-admin/src/components/design-proposal-viewer.tsx
+++ b/web-admin/src/components/design-proposal-viewer.tsx
@@ -1,10 +1,11 @@
 "use client"
 
-import type { ProductDesignProposal } from "@ghost/shared/src/types/mystery"
-import { Shirt, Coffee, Type, Paintbrush } from "lucide-react"
+import type { ProductDesignProposal, DesignAsset } from "@ghost/shared/src/types/mystery"
+import { Shirt, Coffee, Type, Paintbrush, Download } from "lucide-react"
 
 interface DesignProposalViewerProps {
   products: ProductDesignProposal[]
+  assets?: DesignAsset[]
 }
 
 const productIcons: Record<string, React.ReactNode> = {
@@ -17,95 +18,145 @@ const productLabels: Record<string, string> = {
   mug: "Mug",
 }
 
-export function DesignProposalViewer({ products }: DesignProposalViewerProps) {
+export function DesignProposalViewer({ products, assets }: DesignProposalViewerProps) {
   return (
     <div className="space-y-6">
-      {products.map((product, index) => (
-        <div
-          key={`${product.product_type}-${index}`}
-          className="aged-card letterpress-border rounded-sm p-5"
-        >
-          {/* 製品ヘッダー */}
-          <div className="flex items-center gap-3 mb-4">
-            <div className="flex items-center justify-center w-10 h-10 bg-gold/10 border border-gold/30 rounded-sm text-[#d4af37]">
-              {productIcons[product.product_type] || <Paintbrush className="w-5 h-5" />}
-            </div>
-            <div>
-              <h3 className="font-mono text-sm uppercase tracking-wider text-parchment">
-                {productLabels[product.product_type] || product.product_type}
-              </h3>
-              <p className="text-xs text-muted-foreground">
-                {product.aspect_ratio} | {product.style_reference}
-              </p>
-            </div>
-          </div>
+      {products.map((product, index) => {
+        // このプロダクトに対応するアセットをフィルタ
+        const productAssets = assets?.filter(
+          (a) => a.product_type === product.product_type
+        ) ?? []
 
-          {/* キャッチフレーズ */}
-          <div className="mb-4">
-            <div className="flex items-center gap-2 mb-2">
-              <Type className="w-4 h-4 text-muted-foreground" />
-              <span className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
-                Catchphrase
-              </span>
+        return (
+          <div
+            key={`${product.product_type}-${index}`}
+            className="aged-card letterpress-border rounded-sm p-5"
+          >
+            {/* 製品ヘッダー */}
+            <div className="flex items-center gap-3 mb-4">
+              <div className="flex items-center justify-center w-10 h-10 bg-gold/10 border border-gold/30 rounded-sm text-[#d4af37]">
+                {productIcons[product.product_type] || <Paintbrush className="w-5 h-5" />}
+              </div>
+              <div>
+                <h3 className="font-mono text-sm uppercase tracking-wider text-parchment">
+                  {productLabels[product.product_type] || product.product_type}
+                </h3>
+                <p className="text-xs text-muted-foreground">
+                  {product.aspect_ratio} | {product.style_reference}
+                </p>
+              </div>
             </div>
-            <div className="space-y-1 pl-6">
-              <p className="text-sm font-serif text-parchment italic">
-                &ldquo;{product.catchphrase_en}&rdquo;
-              </p>
-              <p className="text-sm text-foreground/80">
-                {product.catchphrase_ja}
-              </p>
-            </div>
-          </div>
 
-          {/* カラーパレット */}
-          <div className="mb-4">
-            <span className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
-              Color Palette
-            </span>
-            <p className="text-xs text-muted-foreground/70 mt-1">
-              記事のトーンと地域性に基づく推奨配色。印刷発注・Canva/Adobe でのテキスト配置に使用。
-            </p>
-            <div className="flex items-center gap-2 mt-2">
-              {product.color_palette.map((color, i) => (
-                <div key={i} className="flex items-center gap-1.5">
+            {/* アセット画像（ある場合のみ） */}
+            {productAssets.length > 0 && (
+              <div className="grid grid-cols-2 gap-3 mb-4">
+                {productAssets.map((asset, i) => (
                   <div
-                    className="w-8 h-8 rounded-sm border border-border/50"
-                    style={{ backgroundColor: color }}
-                    title={color}
-                  />
-                  <span className="text-xs font-mono text-muted-foreground">
-                    {color}
-                  </span>
-                </div>
-              ))}
+                    key={`${asset.product_type}-${asset.layer}-${i}`}
+                    className="border border-border/50 rounded-sm overflow-hidden bg-muted/20"
+                  >
+                    {/* 画像プレビュー */}
+                    <div className="relative aspect-video">
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        src={asset.public_url}
+                        alt={`${asset.product_type} ${asset.layer}`}
+                        className="w-full h-full object-contain"
+                      />
+                    </div>
+                    {/* レイヤー名 + DL ボタン */}
+                    <div className="p-2 flex items-center justify-between">
+                      <div>
+                        <p className="text-xs font-mono text-parchment uppercase">
+                          {asset.layer}
+                        </p>
+                        <p className="text-[10px] text-muted-foreground">
+                          {asset.aspect_ratio}
+                        </p>
+                      </div>
+                      <a
+                        href={asset.public_url}
+                        download
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 px-2 py-1 text-xs font-mono text-gold border border-gold/30 rounded-sm hover:bg-gold/20 transition-colors no-underline"
+                      >
+                        <Download className="w-3.5 h-3.5" />
+                        DL
+                      </a>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* キャッチフレーズ */}
+            <div className="mb-4">
+              <div className="flex items-center gap-2 mb-2">
+                <Type className="w-4 h-4 text-muted-foreground" />
+                <span className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
+                  Catchphrase
+                </span>
+              </div>
+              <div className="space-y-1 pl-6">
+                <p className="text-sm font-serif text-parchment italic">
+                  &ldquo;{product.catchphrase_en}&rdquo;
+                </p>
+                <p className="text-sm text-foreground/80">
+                  {product.catchphrase_ja}
+                </p>
+              </div>
+            </div>
+
+            {/* カラーパレット */}
+            <div className="mb-4">
+              <span className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
+                Color Palette
+              </span>
+              <p className="text-xs text-muted-foreground/70 mt-1">
+                記事のトーンと地域性に基づく推奨配色。印刷発注・Canva/Adobe でのテキスト配置に使用。
+              </p>
+              <div className="flex items-center gap-2 mt-2">
+                {product.color_palette.map((color, i) => (
+                  <div key={i} className="flex items-center gap-1.5">
+                    <div
+                      className="w-8 h-8 rounded-sm border border-border/50"
+                      style={{ backgroundColor: color }}
+                      title={color}
+                    />
+                    <span className="text-xs font-mono text-muted-foreground">
+                      {color}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* フォント提案 */}
+            <div className="mb-4">
+              <span className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
+                Font
+              </span>
+              <p className="text-sm text-foreground/80 mt-1">
+                {product.font_suggestion}
+              </p>
+            </div>
+
+            {/* 構図 */}
+            <div>
+              <span className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
+                Composition
+              </span>
+              <p className="text-xs text-muted-foreground/70 mt-1">
+                レンダリング画像の空間構成・視覚的レイアウトの設計意図。
+              </p>
+              <p className="text-sm text-foreground/80 mt-1 leading-relaxed">
+                {product.composition}
+              </p>
             </div>
           </div>
-
-          {/* フォント提案 */}
-          <div className="mb-4">
-            <span className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
-              Font
-            </span>
-            <p className="text-sm text-foreground/80 mt-1">
-              {product.font_suggestion}
-            </p>
-          </div>
-
-          {/* 構図 */}
-          <div>
-            <span className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
-              Composition
-            </span>
-            <p className="text-xs text-muted-foreground/70 mt-1">
-              レンダリング画像の空間構成・視覚的レイアウトの設計意図。
-            </p>
-            <p className="text-sm text-foreground/80 mt-1 leading-relaxed">
-              {product.composition}
-            </p>
-          </div>
-        </div>
-      ))}
+        )
+      })}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Phase 2 完了（`render_ready`）時、各プロダクトの提案情報と生成画像を **1枚のカードに統合表示** し、どの画像がどの提案に対応するか視覚的に明確化
- 画像生成に失敗したプロダクトのカードは非表示にし、全プロダクト失敗時はエラーメッセージを表示
- `design_ready` 時は従来通りテキスト提案のみ表示（変更なし）

## 変更内容

### `design-proposal-viewer.tsx`
- `assets?: DesignAsset[]` オプショナル prop を追加
- 各プロダクトカード内で `product_type` でマッチするアセットをフィルタし、ヘッダー直下に画像をインライン表示（レイヤー名 + DL ボタン付き）

### `design-detail.tsx`
- `render_ready` 時: `DesignProposalViewer` に `assets` を渡し、アセットが存在するプロダクトのみ表示
- `render_ready` 時: `DesignAssetGallery` セクションを非表示（統合カードで代替）
- 全プロダクトのアセット生成失敗時: エラーメッセージを表示

## Test plan

- [ ] `design_ready` ステータスの記事: 従来通りテキスト提案のみ表示されること
- [ ] `render_ready` ステータスの記事: 画像と提案情報が統合カードで表示されること
- [ ] 画像がないプロダクトのカードが非表示になること
- [ ] 全アセット失敗時にエラーメッセージが表示されること
- [ ] TypeScript 型チェックがパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)