### PR TITLE
feat: アーカイブ資料画像のナラティブ埋め込み

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,6 +346,7 @@ tool_context.state ベース（構造化データ、LLM を経由しない正確
 - `debate_whiteboard` - Scholar（討論モード）が `append_to_whiteboard` で累積書き込みする討論記録（`""` で初期化）
 - `structured_report` - Armchair Polymath の `save_structured_report` ツールが書き込む構造化分析JSON
 - `image_metadata` - Illustrator の `generate_image` ツールが書き込む画像メタデータ
+- `archive_images` - Librarian ツールが蓄積するアーカイブ資料画像リスト（title, source_url, thumbnail_url, image_url, source_type, date）
 
 **Podcast パイプライン（`podcast_agents`）:**
 

--- a/mystery_agents/agents/storyteller.py
+++ b/mystery_agents/agents/storyteller.py
@@ -121,6 +121,20 @@ load_dotenv(Path(__file__).parent.parent / ".env")
 # - 学術研究が乏しい場合: この Ghost が学術的注目の盲点に潜んでいることを強調する
 # - 生の統計を列挙せず、不在または存在のレトリックを強化する素材として使用する
 #
+# ## アーカイブ画像
+# 実際のデジタルアーカイブからの資料画像が {archive_images} に格納されている。
+# 各エントリには title, source_url, thumbnail_url, image_url, source_type, date が含まれる。
+#
+# ### ルール
+# 1. ナラティブのセクション1〜3に最も関連する画像を最大3枚選ぶ。
+# 2. 各画像はそのセクションの末尾、次の ## 見出しの直前に配置する。
+# 3. Markdown 画像構文を使用: ![説明的なキャプション — Source: アーカイブ名](url)
+# 4. thumbnail_url があればそれを使い、なければ image_url を使う。どちらもないエントリはスキップ。
+# 5. セクション4（結び）には画像を配置しない。
+# 6. {archive_images} が空または使える画像がない場合、画像なしで通常通り記事を書く。
+# 7. URL を捏造しない。{archive_images} のURLのみを使用する。
+# 8. 視覚的多様性のため、異なるアーカイブの画像を優先する。
+#
 # ## ペーシングルール
 # 分析・議論の2段落ごとに、以下のいずれか1つを挿入する:
 # - 具体的なアーカイブ引用（blockquote）
@@ -288,6 +302,21 @@ Output the narrative text in Markdown format.
 
 **Do NOT include a Sources (citation list) in the output.** Citations are managed separately as structured data.
 **Do NOT include Open Research Questions in the output.**
+
+## Archival Images
+
+Real archival images from the digital archives are available in {archive_images}.
+Each entry contains: title, source_url, thumbnail_url, image_url, source_type, date.
+
+### Rules
+1. Select up to 3 images most relevant to sections 1-3 of your narrative.
+2. Place each image at the END of its section, just BEFORE the next ## heading.
+3. Use Markdown image syntax: ![descriptive caption — Source: Archive Name](url)
+4. Use thumbnail_url if available; otherwise image_url. Skip entries with neither.
+5. Do NOT place images in section 4 (Conclusion).
+6. If {archive_images} is empty or has no usable images, write normally without images.
+7. NEVER fabricate URLs. Only use URLs from {archive_images}.
+8. Prefer images from different archives for visual variety.
 
 ## Academic Context (if available)
 The Mystery Report may include academic coverage data — how many scholarly papers

--- a/mystery_agents/agents/translator.py
+++ b/mystery_agents/agents/translator.py
@@ -204,6 +204,7 @@ TRANSLATOR_CONFIGS: dict[str, dict[str, str]] = {
 # - 太字（**bold**）、斜体（*italic*）を保持
 # - 引用符（>）を保持
 # - リンク形式を保持
+# - 画像構文 ![キャプション](url) を保持 — [...] 内のキャプションテキストは翻訳するが、(...) 内の URL は変更しない
 #
 # ### 翻訳の正確性
 # - 事実と出典を正確に翻訳
@@ -301,6 +302,7 @@ NO_TRANSLATION: No content to translate. Translation aborted.
 - Preserve bold (**bold**) and italic (*italic*)
 - Preserve blockquotes (>)
 - Preserve link format
+- Preserve image syntax ![caption](url) — translate the caption text inside [...] but keep the URL in (...) unchanged
 
 ### Translation Accuracy
 - Translate facts and sources accurately

--- a/mystery_agents/schemas/document.py
+++ b/mystery_agents/schemas/document.py
@@ -50,6 +50,8 @@ class ArchiveDocument(BaseModel):
     location: str = Field(..., description="Physical location or origin")
     source_type: str = Field(..., description="Source API type (e.g. 'loc_digital', 'dpla')")
     raw_text: Optional[str] = Field(None, description="Full OCR or text content")
+    thumbnail_url: Optional[str] = Field(None, description="Thumbnail image URL from the archive")
+    image_url: Optional[str] = Field(None, description="Full-resolution image URL from the archive")
     record_group: Optional[str] = Field(None, description="Record Group ID")
     keywords_matched: List[str] = Field(
         default_factory=list, description="Keywords that matched this document"

--- a/mystery_agents/tools/chronicling_america.py
+++ b/mystery_agents/tools/chronicling_america.py
@@ -104,6 +104,17 @@ class ChroniclingAmericaSource(ArchiveSource):
             if not url:
                 continue
 
+            # サムネイル / フル画像URL抽出（LOC 新聞ページスキャン）
+            image_url_raw = item.get("image_url", [])
+            if isinstance(image_url_raw, list) and image_url_raw:
+                full_image = str(image_url_raw[0])
+            elif isinstance(image_url_raw, str) and image_url_raw:
+                full_image = image_url_raw
+            else:
+                full_image = None
+            thumbnail_raw = item.get("thumbnail", {})
+            thumbnail_url = thumbnail_raw.get("full") if isinstance(thumbnail_raw, dict) else None
+
             doc = ArchiveDocument(
                 title=str(item.get("title", "Unknown Title"))[:500],
                 date=_parse_newspaper_date(str(date_str)),
@@ -115,6 +126,8 @@ class ChroniclingAmericaSource(ArchiveSource):
                 location=location[:200],
                 source_type=self.source_type,
                 raw_text=description[:5000] if description else None,
+                thumbnail_url=thumbnail_url,
+                image_url=full_image,
                 keywords_matched=_find_matched_keywords(
                     description or str(item.get("title", "")), keywords
                 ),

--- a/mystery_agents/tools/ddb.py
+++ b/mystery_agents/tools/ddb.py
@@ -114,6 +114,13 @@ class DDBSource(ArchiveSource):
             combined = f"{title} {description}".lower()
             matched = [kw for kw in keywords if kw.lower() in combined]
 
+            # サムネイル URL 抽出
+            thumbnail_url = item.get("thumbnail", item.get("preview", None))
+            if isinstance(thumbnail_url, list) and thumbnail_url:
+                thumbnail_url = str(thumbnail_url[0])
+            elif not isinstance(thumbnail_url, str):
+                thumbnail_url = None
+
             doc = ArchiveDocument(
                 title=str(title)[:500],
                 date=self.parse_year(str(date_str), min_century=13),
@@ -123,6 +130,7 @@ class DDBSource(ArchiveSource):
                 location=str(location)[:200],
                 source_type=self.source_type,
                 raw_text=str(description)[:5000] if description else None,
+                thumbnail_url=thumbnail_url,
                 keywords_matched=matched,
             )
             documents.append(doc)

--- a/mystery_agents/tools/dpla.py
+++ b/mystery_agents/tools/dpla.py
@@ -126,6 +126,12 @@ class DPLASource(ArchiveSource):
             if not url:
                 continue
 
+            # サムネイル / フル画像URL抽出
+            obj = item.get("object", "")
+            thumbnail_url = obj if isinstance(obj, str) and obj else None
+            shown_by = item.get("isShownBy", "")
+            full_image = shown_by if isinstance(shown_by, str) and shown_by else None
+
             doc = ArchiveDocument(
                 title=str(title)[:500],
                 date=self.parse_year(str(date_str)),
@@ -135,6 +141,8 @@ class DPLASource(ArchiveSource):
                 location=str(location)[:200],
                 source_type=self.source_type,
                 raw_text=str(description)[:5000] if description else None,
+                thumbnail_url=thumbnail_url,
+                image_url=full_image,
                 keywords_matched=[
                     kw
                     for kw in keywords

--- a/mystery_agents/tools/europeana.py
+++ b/mystery_agents/tools/europeana.py
@@ -132,6 +132,12 @@ class EuropeanaSource(ArchiveSource):
             combined = f"{title} {description}".lower()
             matched = [kw for kw in keywords if kw.lower() in combined]
 
+            # サムネイル / フル画像URL抽出
+            edm_preview = item.get("edmPreview", [])
+            thumbnail = edm_preview[0] if isinstance(edm_preview, list) and edm_preview else None
+            edm_shown_by = item.get("edmIsShownBy", [])
+            full_image = edm_shown_by[0] if isinstance(edm_shown_by, list) and edm_shown_by else None
+
             doc = ArchiveDocument(
                 title=str(title)[:500],
                 date=self.parse_year(str(date_str), min_century=13),
@@ -141,6 +147,8 @@ class EuropeanaSource(ArchiveSource):
                 location=str(location)[:200],
                 source_type=self.source_type,
                 raw_text=str(description)[:5000] if description else None,
+                thumbnail_url=thumbnail,
+                image_url=full_image,
                 keywords_matched=matched,
             )
             documents.append(doc)

--- a/mystery_agents/tools/internet_archive.py
+++ b/mystery_agents/tools/internet_archive.py
@@ -119,6 +119,11 @@ class InternetArchiveSource(ArchiveSource):
             combined = f"{title} {description}".lower()
             matched = [kw for kw in keywords if kw.lower() in combined]
 
+            # サムネイル URL（identifier から構築）
+            thumbnail_url = (
+                f"https://archive.org/services/img/{identifier}" if identifier else None
+            )
+
             doc = ArchiveDocument(
                 title=str(title)[:500],
                 date=self.parse_year(str(date_str), min_century=13),
@@ -128,6 +133,7 @@ class InternetArchiveSource(ArchiveSource):
                 location="Unknown",
                 source_type=self.source_type,
                 raw_text=str(description)[:5000] if description else None,
+                thumbnail_url=thumbnail_url,
                 keywords_matched=matched,
             )
             documents.append(doc)

--- a/mystery_agents/tools/librarian_tools.py
+++ b/mystery_agents/tools/librarian_tools.py
@@ -215,6 +215,24 @@ def search_newspapers(
         existing.append(result)
         tool_context.state["raw_search_results"] = existing
 
+        # archive_images に画像付きドキュメントを蓄積
+        images_with_urls = [
+            {
+                "title": d["title"],
+                "date": d.get("date"),
+                "source_url": d["source_url"],
+                "source_type": d["source_type"],
+                "image_url": d.get("image_url"),
+                "thumbnail_url": d.get("thumbnail_url"),
+            }
+            for d in docs
+            if d.get("thumbnail_url") or d.get("image_url")
+        ]
+        if images_with_urls:
+            existing_images = tool_context.state.get("archive_images", [])
+            existing_images.extend(images_with_urls)
+            tool_context.state["archive_images"] = existing_images
+
     return json.dumps(result, ensure_ascii=False, indent=2)
 
 
@@ -534,6 +552,24 @@ def search_archives(
         existing = tool_context.state.get(state_key, [])
         existing.append(result)
         tool_context.state[state_key] = existing
+
+        # archive_images に画像付きドキュメントを蓄積
+        images_with_urls = [
+            {
+                "title": d["title"],
+                "date": d.get("date"),
+                "source_url": d["source_url"],
+                "source_type": d["source_type"],
+                "image_url": d.get("image_url"),
+                "thumbnail_url": d.get("thumbnail_url"),
+            }
+            for d in all_docs_dicts
+            if d.get("thumbnail_url") or d.get("image_url")
+        ]
+        if images_with_urls:
+            existing_images = tool_context.state.get("archive_images", [])
+            existing_images.extend(images_with_urls)
+            tool_context.state["archive_images"] = existing_images
 
     return json.dumps(result, ensure_ascii=False, indent=2)
 

--- a/mystery_agents/tools/loc_digital.py
+++ b/mystery_agents/tools/loc_digital.py
@@ -87,6 +87,17 @@ class LOCDigitalSource(ArchiveSource):
             if isinstance(date_str, list) and date_str:
                 date_str = str(date_str[0])
 
+            # サムネイル / フル画像URL抽出
+            image_url_raw = item.get("image_url", [])
+            if isinstance(image_url_raw, list) and image_url_raw:
+                full_image = str(image_url_raw[0])
+            elif isinstance(image_url_raw, str) and image_url_raw:
+                full_image = image_url_raw
+            else:
+                full_image = None
+            thumbnail = item.get("thumbnail", {})
+            thumbnail_url = thumbnail.get("full") if isinstance(thumbnail, dict) else None
+
             doc = ArchiveDocument(
                 title=str(item.get("title", "Unknown Title"))[:500],
                 date=self.parse_year(str(date_str)),
@@ -96,6 +107,8 @@ class LOCDigitalSource(ArchiveSource):
                 location=location,
                 source_type=self.source_type,
                 raw_text=description[:5000] if description else None,
+                thumbnail_url=thumbnail_url,
+                image_url=full_image,
                 keywords_matched=[
                     kw for kw in keywords if kw.lower() in (description or "").lower()
                 ],

--- a/mystery_agents/tools/nypl_digital.py
+++ b/mystery_agents/tools/nypl_digital.py
@@ -144,6 +144,14 @@ class NYPLSource(ArchiveSource):
 
             date_str = item.get("dateDigitized", "")
 
+            # サムネイル URL 構築（imageID から）
+            image_id = item.get("imageID", "")
+            thumbnail_url = (
+                f"https://images.nypl.org/index.php?id={image_id}&t=w"
+                if image_id
+                else None
+            )
+
             doc = ArchiveDocument(
                 title=str(title)[:500],
                 date=self.parse_year(str(date_str)),
@@ -153,6 +161,7 @@ class NYPLSource(ArchiveSource):
                 location="New York",
                 source_type=self.source_type,
                 raw_text=None,
+                thumbnail_url=thumbnail_url,
                 keywords_matched=[
                     kw for kw in keywords if kw.lower() in str(title).lower()
                 ],

--- a/mystery_agents/tools/publisher_tools.py
+++ b/mystery_agents/tools/publisher_tools.py
@@ -291,6 +291,14 @@ def publish_mystery(
                 if not any(marker in creative_content for marker in ("NO_CONTENT", "NO_DOCUMENTS_FOUND")):
                     data["narrative_content"] = creative_content
 
+            # narrative_content からアーカイブ画像URLを抽出して images.inserts に保存
+            if data.get("narrative_content"):
+                md_images = re.findall(r'!\[.*?\]\((https?://[^)]+)\)', data["narrative_content"])
+                if md_images:
+                    images_dict = data.get("images", {})
+                    images_dict["inserts"] = md_images
+                    data["images"] = images_dict
+
             # raw_data: collected_documents_en セッション状態から直接読み取り
             collected_docs = tool_context.state.get("collected_documents_en")
             if collected_docs:

--- a/mystery_agents/tools/wellcome_collection.py
+++ b/mystery_agents/tools/wellcome_collection.py
@@ -156,6 +156,10 @@ def _parse_wellcome_response(
         combined = f"{title} {summary_text}".lower()
         matched = [kw for kw in keywords if kw.lower() in combined]
 
+        # サムネイル URL 抽出
+        thumbnail = work.get("thumbnail", {})
+        thumbnail_url = thumbnail.get("url") if isinstance(thumbnail, dict) else None
+
         doc = ArchiveDocument(
             title=str(title)[:500],
             date=parsed_date,
@@ -165,6 +169,7 @@ def _parse_wellcome_response(
             location=str(location)[:200],
             source_type="wellcome",
             raw_text=raw_text,
+            thumbnail_url=thumbnail_url,
             keywords_matched=matched,
         )
         documents.append(doc)

--- a/shared/state_registry.py
+++ b/shared/state_registry.py
@@ -108,6 +108,12 @@ STATE_KEYS: list[StateKey] = [
         read_by=("publisher_tools",),
     ),
     StateKey(
+        name="archive_images",
+        description="Librarian が収集したアーカイブ資料画像リスト（title, source_url, thumbnail_url, image_url 等）",
+        written_by=("librarian_tools",),
+        read_by=("storyteller",),
+    ),
+    StateKey(
         name="published_episode",
         description="Publisher の公開結果（output_key）",
         written_by=("publisher",),

--- a/tests/unit/test_archive_images.py
+++ b/tests/unit/test_archive_images.py
@@ -1,0 +1,103 @@
+"""Unit tests for archival image pipeline (schema, session state, publisher extraction)."""
+
+import re
+
+import pytest
+
+from mystery_agents.schemas.document import ArchiveDocument, SourceLanguage
+
+
+class TestArchiveDocumentImageFields:
+    """ArchiveDocument の画像フィールドのテスト。"""
+
+    def test_create_with_both_image_urls(self):
+        """thumbnail_url と image_url の両方を指定してインスタンス生成できる。"""
+        doc = ArchiveDocument(
+            title="Test Document",
+            source_url="https://example.com/doc",
+            summary="Test summary",
+            language=SourceLanguage.EN,
+            location="Boston",
+            source_type="loc_digital",
+            thumbnail_url="https://example.com/thumb.jpg",
+            image_url="https://example.com/full.jpg",
+        )
+        assert doc.thumbnail_url == "https://example.com/thumb.jpg"
+        assert doc.image_url == "https://example.com/full.jpg"
+
+    def test_create_without_image_urls(self):
+        """画像URL なしでもインスタンス生成できる（後方互換）。"""
+        doc = ArchiveDocument(
+            title="Test Document",
+            source_url="https://example.com/doc",
+            summary="Test summary",
+            language=SourceLanguage.EN,
+            location="Boston",
+            source_type="loc_digital",
+        )
+        assert doc.thumbnail_url is None
+        assert doc.image_url is None
+
+    def test_model_dump_includes_image_fields(self):
+        """model_dump() に画像フィールドが含まれる。"""
+        doc = ArchiveDocument(
+            title="Test",
+            source_url="https://example.com",
+            summary="Summary",
+            language=SourceLanguage.EN,
+            location="NY",
+            source_type="nypl",
+            thumbnail_url="https://example.com/thumb.jpg",
+        )
+        data = doc.model_dump()
+        assert "thumbnail_url" in data
+        assert "image_url" in data
+        assert data["thumbnail_url"] == "https://example.com/thumb.jpg"
+        assert data["image_url"] is None
+
+
+class TestPublisherImageInsertsExtraction:
+    """Publisher の images.inserts 抽出ロジックのテスト。"""
+
+    # Publisher の正規表現を直接テスト
+    _PATTERN = re.compile(r'!\[.*?\]\((https?://[^)]+)\)')
+
+    def test_extract_single_image(self):
+        """単一の Markdown 画像から URL を抽出できる。"""
+        content = "Some text.\n\n![A newspaper scan — Source: LOC](https://www.loc.gov/image.jpg)\n\nMore text."
+        urls = self._PATTERN.findall(content)
+        assert urls == ["https://www.loc.gov/image.jpg"]
+
+    def test_extract_multiple_images(self):
+        """複数の Markdown 画像から URL を抽出できる。"""
+        content = (
+            "## Section 1\n\nText.\n\n"
+            "![Cap A — Source: LOC](https://loc.gov/a.jpg)\n\n"
+            "## Section 2\n\nText.\n\n"
+            "![Cap B — Source: Europeana](https://europeana.eu/b.png)\n\n"
+            "## Section 3\n\nText.\n\n"
+            "![Cap C — Source: DPLA](http://dp.la/c.webp)\n\n"
+            "## Section 4\n\nConclusion."
+        )
+        urls = self._PATTERN.findall(content)
+        assert len(urls) == 3
+        assert urls[0] == "https://loc.gov/a.jpg"
+        assert urls[2] == "http://dp.la/c.webp"
+
+    def test_no_images(self):
+        """画像なしのコンテンツでは空リストを返す。"""
+        content = "## Section 1\n\nJust text, no images."
+        urls = self._PATTERN.findall(content)
+        assert urls == []
+
+    def test_does_not_match_regular_links(self):
+        """通常のリンク [text](url) は抽出しない。"""
+        content = "See [the archive](https://example.com) for details."
+        urls = self._PATTERN.findall(content)
+        assert urls == []
+
+    def test_alt_text_with_special_characters(self):
+        """キャプションに特殊文字を含む画像から URL を抽出できる。"""
+        content = '![A "haunted" map (1842) — Source: NYPL](https://images.nypl.org/map.jpg)'
+        urls = self._PATTERN.findall(content)
+        assert urls == ["https://images.nypl.org/map.jpg"]

--- a/web-admin/src/app/(main)/preview/[id]/preview-content.tsx
+++ b/web-admin/src/app/(main)/preview/[id]/preview-content.tsx
@@ -19,9 +19,10 @@ import {
   Lightbulb,
   Eye
 } from "lucide-react"
-import Markdown from "react-markdown"
+import Markdown, { type Components } from "react-markdown"
 import remarkGfm from "remark-gfm"
 import { stripLeadingH1 } from "@ghost/shared/src/lib/utils"
+import { useState } from "react"
 
 /**
  * Date は Server→Client シリアライズで string になるため、
@@ -31,6 +32,31 @@ function formatDate(d: Date | string | undefined): string {
   if (!d) return ""
   const date = typeof d === "string" ? new Date(d) : d
   return date.toLocaleDateString()
+}
+
+function PreviewArchiveImage({ src, alt }: { src?: string; alt?: string }) {
+  const [hasError, setHasError] = useState(false)
+  if (!src || hasError) return null
+  return (
+    <figure className="not-prose my-8 mx-auto max-w-xl">
+      <div className="aged-card letterpress-border rounded-sm overflow-hidden">
+        <img
+          src={src}
+          alt={alt || "Archival Image"}
+          loading="lazy"
+          onError={() => setHasError(true)}
+          className="w-full h-auto"
+        />
+      </div>
+      {alt && (
+        <figcaption className="mt-2 text-center text-xs font-mono text-muted-foreground/70 leading-relaxed">
+          <span className="uppercase tracking-wider text-gold/60">Archival Image</span>
+          {" — "}
+          {alt}
+        </figcaption>
+      )}
+    </figure>
+  )
 }
 
 interface PreviewContentProps {
@@ -166,7 +192,12 @@ export function PreviewContent({ mystery }: PreviewContentProps) {
               {/* Narrative Content (primary) */}
               {narrativeContent ? (
                 <section className="prose prose-lg prose-invert max-w-none prose-headings:font-serif prose-headings:text-parchment prose-headings:mt-12 prose-headings:mb-4 prose-p:text-foreground/90 prose-p:leading-loose prose-p:mb-6 prose-a:text-gold prose-blockquote:border-gold/30 prose-blockquote:bg-card prose-blockquote:px-6 prose-blockquote:py-4 prose-blockquote:rounded-sm prose-blockquote:text-foreground/70 prose-blockquote:italic prose-blockquote:font-serif prose-strong:text-parchment prose-hr:border-border">
-                  <Markdown remarkPlugins={[remarkGfm]}>
+                  <Markdown
+                    remarkPlugins={[remarkGfm]}
+                    components={{
+                      img: ({ src, alt }) => <PreviewArchiveImage src={src} alt={alt} />,
+                    }}
+                  >
                     {stripLeadingH1(narrativeContent).replace(/\*\*(.+?)\*\*/g, ' **$1** ')}
                   </Markdown>
                 </section>

--- a/web-public/src/components/mystery/archive-image.tsx
+++ b/web-public/src/components/mystery/archive-image.tsx
@@ -1,0 +1,49 @@
+"use client"
+
+import { useState } from "react"
+
+// 7言語のアーカイブ画像ラベル
+const IMAGE_LABEL: Record<string, string> = {
+  en: "Archival Image",
+  ja: "アーカイブ資料",
+  es: "Imagen de archivo",
+  de: "Archivbild",
+  fr: "Image d'archive",
+  nl: "Archiefafbeelding",
+  pt: "Imagem de arquivo",
+}
+
+interface ArchiveImageProps {
+  src?: string
+  alt?: string
+  lang: string
+}
+
+export function ArchiveImage({ src, alt, lang }: ArchiveImageProps) {
+  const [hasError, setHasError] = useState(false)
+
+  if (!src || hasError) return null
+
+  const label = IMAGE_LABEL[lang] || IMAGE_LABEL.en
+
+  return (
+    <figure className="not-prose my-8 mx-auto max-w-xl">
+      <div className="aged-card letterpress-border rounded-sm overflow-hidden">
+        <img
+          src={src}
+          alt={alt || label}
+          loading="lazy"
+          onError={() => setHasError(true)}
+          className="w-full h-auto"
+        />
+      </div>
+      {alt && (
+        <figcaption className="mt-2 text-center text-xs font-mono text-muted-foreground/70 leading-relaxed">
+          <span className="uppercase tracking-wider text-gold/60">{label}</span>
+          {" — "}
+          {alt}
+        </figcaption>
+      )}
+    </figure>
+  )
+}

--- a/web-public/src/components/mystery/narrative-section.tsx
+++ b/web-public/src/components/mystery/narrative-section.tsx
@@ -4,6 +4,7 @@ import { FileText } from "lucide-react"
 import { stripLeadingH1 } from "@ghost/shared/src/lib/utils"
 import { slugify } from "@/lib/markdown-headings"
 import type { ReactNode } from "react"
+import { ArchiveImage } from "./archive-image"
 
 // 7言語のアーカイブ引用ラベル
 const ARCHIVE_LABEL: Record<string, string> = {
@@ -59,6 +60,9 @@ export function NarrativeSection({ narrativeContent, summary, lang = "en" }: Nar
     const markdownComponents: Components = {
       blockquote: ({ children }) => (
         <ArchiveBlockquote lang={lang}>{children}</ArchiveBlockquote>
+      ),
+      img: ({ src, alt }) => (
+        <ArchiveImage src={src} alt={alt} lang={lang} />
       ),
       h2: ({ children }) => {
         const text = getTextContent(children)


### PR DESCRIPTION
## Summary

- 各デジタルアーカイブ API（LOC, Europeana, DPLA, NYPL, Internet Archive, Wellcome, DDB, Chronicling America）から画像URLを抽出し、Storyteller が記事本文に最大3枚の実資料画像を Markdown 形式で埋め込む機能を追加
- 画像が0枚の場合は既存動作と同じ（画像なしで通常通り記事を書く）
- フロントエンドは ArchiveImage クライアントコンポーネントで外部画像を `<img>` + `loading="lazy"` + `onError` 非表示で安全に描画

## 変更内容

### バックエンド（Python）
- `ArchiveDocument` スキーマに `thumbnail_url` / `image_url` フィールド追加
- 8 API ツールで画像URL抽出（Trove/Delpher/NDL は API 制約のためスキップ）
- `archive_images` セッション状態キーで画像付きドキュメントを蓄積
- Storyteller instruction に画像埋め込みルール追加（最大3枚、セクション1〜3末尾）
- Translator instruction に画像 Markdown 保持ルール追加
- Publisher で `narrative_content` から `images.inserts` を自動抽出

### フロントエンド（TypeScript/React）
- `ArchiveImage` クライアントコンポーネント新規作成（7言語ラベル、aged-card スタイル）
- `NarrativeSection` に `img` カスタムコンポーネント追加
- 管理画面プレビューにも `img` ハンドラ追加

### テスト
- ユニットテスト 8 件追加（スキーマ画像フィールド + Publisher 正規表現抽出）
- 既存テスト 1004 件全パス（リグレッションなし）

## Test plan

- [x] `pytest tests/unit/test_archive_images.py -v` — 8 件全パス
- [x] `pytest tests/unit/ -v` — 1004 件全パス
- [ ] パイプラインを実行し、Storyteller が画像付き Markdown を生成することを確認
- [ ] 既存記事の `narrative_content` に手動で `![test](url)` を追加し、web-public / web-admin で正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)