### PR TITLE
fix: フッター NDL Search 表記修正

### DIFF
--- a/packages/shared/src/components/footer.tsx
+++ b/packages/shared/src/components/footer.tsx
@@ -26,7 +26,7 @@ const PRIMARY_SOURCES = [
   { label: "Delpher (KB)", href: "https://www.delpher.nl/" },
   { label: "Wellcome Collection", href: "https://wellcomecollection.org/" },
   // アジア太平洋
-  { label: "NDL Search（国立国会図書館）", href: "https://ndlsearch.ndl.go.jp/" },
+  { label: "NDL Search", href: "https://ndlsearch.ndl.go.jp/" },
   { label: "Trove", href: "https://trove.nla.gov.au/", pending: true },
   // グローバル
   { label: "Internet Archive", href: "https://archive.org/" },


### PR DESCRIPTION
## Summary
- フッターの一次資料リンクで「NDL Search（国立国会図書館）」と表示されていた箇所から括弧内の日本語名称を削除し、「NDL Search」のみの表記に統一

## Test plan
- [ ] web-public のフッターで「NDL Search」と表示されることを目視確認
- [ ] web-admin のフッターで「NDL Search」と表示されることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)