### PR TITLE
fix: Markdown 画像の <p> > <div> ハイドレーションエラー修正

### DIFF
--- a/web-admin/src/app/(main)/preview/[id]/preview-content.tsx
+++ b/web-admin/src/app/(main)/preview/[id]/preview-content.tsx
@@ -196,6 +196,12 @@ export function PreviewContent({ mystery }: PreviewContentProps) {
                     remarkPlugins={[remarkGfm]}
                     components={{
                       img: ({ src, alt }) => <PreviewArchiveImage src={src} alt={alt} />,
+                      p: ({ children, node }) => {
+                        const hasImage = node?.children?.some(
+                          (child: any) => child.type === "element" && child.tagName === "img"
+                        )
+                        return hasImage ? <>{children}</> : <p>{children}</p>
+                      },
                     }}
                   >
                     {stripLeadingH1(narrativeContent).replace(/\*\*(.+?)\*\*/g, ' **$1** ')}

--- a/web-public/src/components/mystery/narrative-section.tsx
+++ b/web-public/src/components/mystery/narrative-section.tsx
@@ -64,6 +64,12 @@ export function NarrativeSection({ narrativeContent, summary, lang = "en" }: Nar
       img: ({ src, alt }) => (
         <ArchiveImage src={src} alt={alt} lang={lang} />
       ),
+      p: ({ children, node }) => {
+        const hasImage = node?.children?.some(
+          (child: any) => child.type === "element" && child.tagName === "img"
+        )
+        return hasImage ? <>{children}</> : <p>{children}</p>
+      },
       h2: ({ children }) => {
         const text = getTextContent(children)
         // 空スラグのフォールバック（Unicode 対応で解消済みだが安全策）


### PR DESCRIPTION
## Summary

- react-markdown が `![alt](url)` を `<p>` タグで囲むが、カスタム `img` コンポーネントがブロックレベルの `<figure><div>` を返すため `<p><figure><div>...</div></figure></p>` という不正な HTML ネストが発生し、ハイドレーションエラーになっていた
- カスタム `p` ハンドラを追加し、子要素に画像が含まれる場合は `<p>` の代わりにフラグメント（`<>...</>`）を返すように修正
- web-admin（管理画面プレビュー）と web-public（公開サイト）の両方を修正

## 変更ファイル

- `web-admin/src/app/(main)/preview/[id]/preview-content.tsx` — `components` prop に `p` ハンドラ追加
- `web-public/src/components/mystery/narrative-section.tsx` — `markdownComponents` に `p` ハンドラ追加

## Test plan

- [ ] 管理画面プレビューで画像入り記事を表示し、Console にハイドレーションエラーが出ないことを確認
- [ ] 公開サイトで画像入り記事を表示し、Console にハイドレーションエラーが出ないことを確認
- [ ] 画像のない段落が通常通り `<p>` タグでレンダリングされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)