### PR TITLE
Secret Manager に4つの新規 API キーを追加

### DIFF
--- a/terraform/cloud-run.tf
+++ b/terraform/cloud-run.tf
@@ -225,6 +225,46 @@ resource "google_cloud_run_v2_service" "pipeline" {
       }
 
       env {
+        name = "OPENROUTER_API_KEY"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.openrouter_api_key.secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name = "EUROPEANA_API_KEY"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.europeana_api_key.secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name = "OPENALEX_API_KEY"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.openalex_api_key.secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name = "DDB_API_KEY"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.ddb_api_key.secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      env {
         name  = "CLOUD_BUILD_TRIGGER_ID"
         value = google_cloudbuild_trigger.web_public.name
       }

--- a/terraform/secrets.tf
+++ b/terraform/secrets.tf
@@ -55,6 +55,50 @@ resource "google_secret_manager_secret" "nypl_api_token" {
   depends_on = [google_project_service.apis]
 }
 
+# OpenRouter API key (Storyteller LLM selection via OpenRouter)
+resource "google_secret_manager_secret" "openrouter_api_key" {
+  secret_id = "openrouter-api-key"
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
+# Europeana API key (European cultural heritage archive search)
+resource "google_secret_manager_secret" "europeana_api_key" {
+  secret_id = "europeana-api-key"
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
+# OpenAlex API key (academic paper search)
+resource "google_secret_manager_secret" "openalex_api_key" {
+  secret_id = "openalex-api-key"
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
+# DDB API key (Deutsche Digitale Bibliothek OAuth)
+resource "google_secret_manager_secret" "ddb_api_key" {
+  secret_id = "ddb-api-key"
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
 # Output instructions for setting secret values
 output "secret_setup_instructions" {
   description = "Instructions for setting up secrets"
@@ -66,5 +110,9 @@ output "secret_setup_instructions" {
     echo -n "YOUR_VALUE" | gcloud secrets versions add google-oauth-client-secret --data-file=-
     echo -n "YOUR_VALUE" | gcloud secrets versions add dpla-api-key --data-file=-
     echo -n "YOUR_VALUE" | gcloud secrets versions add nypl-api-token --data-file=-
+    echo -n "YOUR_VALUE" | gcloud secrets versions add openrouter-api-key --data-file=-
+    echo -n "YOUR_VALUE" | gcloud secrets versions add europeana-api-key --data-file=-
+    echo -n "YOUR_VALUE" | gcloud secrets versions add openalex-api-key --data-file=-
+    echo -n "YOUR_VALUE" | gcloud secrets versions add ddb-api-key --data-file=-
   EOT
 }


### PR DESCRIPTION
## Summary

release/v2.0 で追加された機能（Storyteller 選択、新規アーカイブソース）に必要な4つの API キーの Terraform 定義を追加。

- `OPENROUTER_API_KEY` — Storyteller 選択機能（OpenRouter 経由で Claude/GPT/Llama 等）
- `EUROPEANA_API_KEY` — Europeana アーカイブ検索
- `OPENALEX_API_KEY` — OpenAlex 学術論文検索
- `DDB_API_KEY` — Deutsche Digitale Bibliothek OAuth 認証

## 変更内容

| ファイル | 変更 |
|---|---|
| `terraform/secrets.tf` | 4つの `google_secret_manager_secret` リソース追加 + output に `gcloud` コマンド追記 |
| `terraform/cloud-run.tf` | `pipeline` サービスに4つの Secret Manager 環境変数参照を追加 |

## 変更不要の確認

- `terraform/iam.tf` — `pipelines-sa` は既に `roles/secretmanager.secretAccessor` を持つため変更不要
- Python コード — 既に `os.environ.get()` で参照済みのため変更不要

## デプロイ手順

`terraform apply` 後にシークレット値を登録:

```bash
echo -n "$VALUE" | gcloud secrets versions add openrouter-api-key --data-file=-
echo -n "$VALUE" | gcloud secrets versions add europeana-api-key --data-file=-
echo -n "$VALUE" | gcloud secrets versions add openalex-api-key --data-file=-
echo -n "$VALUE" | gcloud secrets versions add ddb-api-key --data-file=-
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)