### PR TITLE
fix: Markdown 画像レンダリング修正（rehype プラグイン方式に切り替え）

### DIFF
--- a/packages/shared/src/lib/rehype-unwrap-images.ts
+++ b/packages/shared/src/lib/rehype-unwrap-images.ts
@@ -1,0 +1,43 @@
+/**
+ * 画像のみを含む <p> タグを AST レベルで除去する rehype プラグイン。
+ *
+ * react-markdown は Markdown の `![alt](url)` を `<p><img></p>` に変換するが、
+ * カスタム img コンポーネントがブロックレベル要素（<figure><div>）を返す場合、
+ * `<p><figure><div>` という不正な HTML ネストが生じてハイドレーションエラーになる。
+ *
+ * このプラグインは hast AST を走査し、画像のみを含む段落から <p> ラッパーを除去する。
+ * 外部パッケージ（rehype-unwrap-images）不要のインライン実装。
+ */
+
+interface HastNode {
+  type: string
+  tagName?: string
+  value?: string
+  children?: HastNode[]
+}
+
+export function rehypeUnwrapImages() {
+  return (tree: HastNode) => {
+    function walk(node: HastNode) {
+      if (!node.children) return
+      for (let i = 0; i < node.children.length; i++) {
+        const child = node.children[i]
+        if (child.type === "element" && child.tagName === "p") {
+          // 空白テキストノードを除外し、意味のあるノードのみ抽出
+          const meaningful = (child.children || []).filter(
+            (c) => !(c.type === "text" && !c.value?.trim())
+          )
+          if (
+            meaningful.length === 1 &&
+            meaningful[0].type === "element" &&
+            meaningful[0].tagName === "img"
+          ) {
+            node.children[i] = meaningful[0]
+          }
+        }
+        walk(child)
+      }
+    }
+    walk(tree)
+  }
+}

--- a/web-admin/src/app/(main)/preview/[id]/preview-content.tsx
+++ b/web-admin/src/app/(main)/preview/[id]/preview-content.tsx
@@ -21,6 +21,7 @@ import {
 } from "lucide-react"
 import Markdown, { type Components } from "react-markdown"
 import remarkGfm from "remark-gfm"
+import { rehypeUnwrapImages } from "@ghost/shared/src/lib/rehype-unwrap-images"
 import { stripLeadingH1 } from "@ghost/shared/src/lib/utils"
 import { useState } from "react"
 
@@ -194,14 +195,9 @@ export function PreviewContent({ mystery }: PreviewContentProps) {
                 <section className="prose prose-lg prose-invert max-w-none prose-headings:font-serif prose-headings:text-parchment prose-headings:mt-12 prose-headings:mb-4 prose-p:text-foreground/90 prose-p:leading-loose prose-p:mb-6 prose-a:text-gold prose-blockquote:border-gold/30 prose-blockquote:bg-card prose-blockquote:px-6 prose-blockquote:py-4 prose-blockquote:rounded-sm prose-blockquote:text-foreground/70 prose-blockquote:italic prose-blockquote:font-serif prose-strong:text-parchment prose-hr:border-border">
                   <Markdown
                     remarkPlugins={[remarkGfm]}
+                    rehypePlugins={[rehypeUnwrapImages]}
                     components={{
                       img: ({ src, alt }) => <PreviewArchiveImage src={src} alt={alt} />,
-                      p: ({ children, node }) => {
-                        const hasImage = node?.children?.some(
-                          (child: any) => child.type === "element" && child.tagName === "img"
-                        )
-                        return hasImage ? <>{children}</> : <p>{children}</p>
-                      },
                     }}
                   >
                     {stripLeadingH1(narrativeContent).replace(/\*\*(.+?)\*\*/g, ' **$1** ')}

--- a/web-public/src/components/mystery/narrative-section.tsx
+++ b/web-public/src/components/mystery/narrative-section.tsx
@@ -1,5 +1,6 @@
 import Markdown, { type Components } from "react-markdown"
 import remarkGfm from "remark-gfm"
+import { rehypeUnwrapImages } from "@ghost/shared/src/lib/rehype-unwrap-images"
 import { FileText } from "lucide-react"
 import { stripLeadingH1 } from "@ghost/shared/src/lib/utils"
 import { slugify } from "@/lib/markdown-headings"
@@ -64,12 +65,6 @@ export function NarrativeSection({ narrativeContent, summary, lang = "en" }: Nar
       img: ({ src, alt }) => (
         <ArchiveImage src={src} alt={alt} lang={lang} />
       ),
-      p: ({ children, node }) => {
-        const hasImage = node?.children?.some(
-          (child: any) => child.type === "element" && child.tagName === "img"
-        )
-        return hasImage ? <>{children}</> : <p>{children}</p>
-      },
       h2: ({ children }) => {
         const text = getTextContent(children)
         // 空スラグのフォールバック（Unicode 対応で解消済みだが安全策）
@@ -84,7 +79,7 @@ export function NarrativeSection({ narrativeContent, summary, lang = "en" }: Nar
 
     return (
       <section id="section-narrative" className="scroll-mt-24 prose prose-lg prose-invert max-w-none prose-headings:font-serif prose-headings:text-parchment prose-headings:mt-12 prose-headings:mb-4 prose-p:text-foreground/90 prose-p:leading-loose prose-p:mb-6 prose-a:text-gold prose-strong:text-parchment prose-hr:border-border">
-        <Markdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+        <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeUnwrapImages]} components={markdownComponents}>
           {stripLeadingH1(narrativeContent).replace(/\*\*(.+?)\*\*/g, ' **$1** ')}
         </Markdown>
       </section>


### PR DESCRIPTION
## Summary

- #312 の `p` ハンドラ方式（hast `node.children` チェック）ではハイドレーションエラーは解消したが画像が表示されない問題を修正
- `components.p` での hast ノード検査を廃止し、`rehypePlugins` で AST レベルで画像のみを含む `<p>` タグを除去する方式に変更
- 共有 rehype プラグイン `rehypeUnwrapImages` を `packages/shared/` に新設（外部パッケージ不要のインライン実装）

## 技術的背景

react-markdown は Markdown の `![alt](url)` を `<p><img></p>` に変換する。カスタム `img` コンポーネントが `<figure><div>` を返すと不正な HTML ネスト（`<p><figure><div>`）が発生する。

**旧方式（#312）**: `components.p` で `node.children` をチェックし画像含有時にフラグメントを返す → ハイドレーションエラーは解消するが画像非表示

**新方式**: `rehypePlugins` で hast AST を事前変換し、画像のみの段落から `<p>` ラッパーを除去 → `img` コンポーネントが直接レンダリングされる

## 変更ファイル

- `packages/shared/src/lib/rehype-unwrap-images.ts` — 新規: rehype プラグイン
- `web-admin/src/app/(main)/preview/[id]/preview-content.tsx` — `p` ハンドラ削除、`rehypePlugins` 追加
- `web-public/src/components/mystery/narrative-section.tsx` — 同上

## Test plan

- [ ] 管理画面プレビューで画像入り記事を表示し、アーカイブ画像が表示されることを確認
- [ ] Console にハイドレーションエラーが出ないことを確認
- [ ] 画像のない段落が通常通り `<p>` タグでレンダリングされることを確認
- [ ] 公開サイトで画像入り記事を同様に確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)