### PR TITLE
fix: アーカイブ検索有効性の改善（Wellcome 日付フォールバック + Europeana COUNTRY フィルタ + キーワード言語診断）

### DIFF
--- a/mystery_agents/tools/europeana.py
+++ b/mystery_agents/tools/europeana.py
@@ -27,6 +27,19 @@ _LANG_MAP: dict[str, SourceLanguage] = {
     "pt": SourceLanguage.PT,
 }
 
+# 言語コード → Europeana COUNTRY フィルタ値マッピング
+# LANGUAGE フィルタではなく COUNTRY フィルタを使用する理由:
+# 歴史資料（特に 1650-1850 の医学テキスト等）はラテン語で書かれていることが多く、
+# LANGUAGE:de では捕捉できない。COUNTRY フィルタは提供機関の所在国で絞り込むため、
+# ドイツの機関が保管するラテン語文書もヒットする。
+_LANG_TO_COUNTRY: dict[str, str] = {
+    "de": "germany",
+    "es": "spain",
+    "fr": "france",
+    "nl": "netherlands",
+    "pt": "portugal",
+}
+
 
 class EuropeanaSource(ArchiveSource):
     """Europeana ソース。"""
@@ -67,8 +80,10 @@ class EuropeanaSource(ArchiveSource):
         qf_list: list[str] = []
         if date_start and date_end:
             qf_list.append(f"YEAR:[{date_start} TO {date_end}]")
-        if language:
-            qf_list.append(f"LANGUAGE:{language}")
+        # COUNTRY フィルタ: 提供機関の所在国で絞り込む
+        # LANGUAGE フィルタは歴史資料（ラテン語混在）を見逃すため不使用
+        if language and language in _LANG_TO_COUNTRY:
+            qf_list.append(f"COUNTRY:{_LANG_TO_COUNTRY[language]}")
         if qf_list:
             params["qf"] = qf_list
 

--- a/mystery_agents/tools/librarian_tools.py
+++ b/mystery_agents/tools/librarian_tools.py
@@ -395,6 +395,35 @@ def _rank_documents(
     return result
 
 
+def _is_likely_english(keyword: str) -> bool:
+    """キーワードが英語である可能性が高いかを簡易判定する。
+
+    ASCII 文字のみで構成されるキーワードを英語候補とみなす。
+    ドイツ語のウムラウト（ä,ö,ü）、フランス語のアクセント（é,è）等の
+    非 ASCII 文字を含む場合は非英語と判定する。
+    """
+    return all(ord(c) < 128 for c in keyword)
+
+
+def _log_keyword_language_mismatch(
+    keywords: list[str], language: str
+) -> None:
+    """非英語 Librarian が英語キーワードのみで検索していないかログ出力する。"""
+    ascii_only = [kw for kw in keywords if _is_likely_english(kw)]
+    if len(ascii_only) == len(keywords) and keywords:
+        logger.warning(
+            "キーワード言語不一致: language=%s だが全キーワードが ASCII のみ "
+            "(ネイティブ言語キーワード未使用の可能性): %s",
+            language,
+            keywords,
+            extra={
+                "language": language,
+                "keywords": keywords,
+                "all_ascii": True,
+            },
+        )
+
+
 def search_archives(
     keywords: str,
     date_start: Optional[str] = None,
@@ -424,6 +453,10 @@ def search_archives(
         JSON string with merged results from all sources.
     """
     keyword_list = [kw.strip() for kw in keywords.split(",") if kw.strip()]
+
+    # キーワード言語診断ログ: 非英語 API に英語キーワードを渡していないか検出する
+    if language and language != "en":
+        _log_keyword_language_mismatch(keyword_list, language)
 
     keyword_groups = [keyword_list]
 

--- a/mystery_agents/tools/wellcome_collection.py
+++ b/mystery_agents/tools/wellcome_collection.py
@@ -209,6 +209,7 @@ class WellcomeSource(ArchiveSource):
         }
 
         # 日付フィルタ（YYYY-MM-DD 形式）
+        has_date_filter = bool(date_start or date_end)
         if date_start:
             params["production.dates.from"] = f"{date_start[:4]}-01-01"
         if date_end:
@@ -231,7 +232,32 @@ class WellcomeSource(ArchiveSource):
         )
         response.raise_for_status()
 
-        return _parse_wellcome_response(response.json(), keywords)
+        result = _parse_wellcome_response(response.json(), keywords)
+
+        # 日付フィルタ付きで 0 件の場合、日付フィルタなしで再検索する
+        # Wellcome の歴史資料は日付メタデータが不完全なことが多い
+        if not result.documents and has_date_filter:
+            logger.info(
+                "Wellcome 日付フィルタフォールバック: 日付フィルタ(%s〜%s)で 0 件 → 日付なしで再検索",
+                date_start,
+                date_end,
+            )
+            params_no_date = {
+                k: v
+                for k, v in params.items()
+                if k not in ("production.dates.from", "production.dates.to")
+            }
+            self._rate_limit()
+            response = self._session.get(
+                BASE_URL,
+                params=params_no_date,
+                headers=headers,
+                timeout=30,
+            )
+            response.raise_for_status()
+            result = _parse_wellcome_response(response.json(), keywords)
+
+        return result
 
 
 # レジストリに自動登録

--- a/tests/unit/test_europeana.py
+++ b/tests/unit/test_europeana.py
@@ -64,8 +64,8 @@ class TestSearchEuropeana:
         assert "europeana.eu" in doc.source_url
 
     @responses.activate
-    def test_language_filter(self):
-        """language パラメータで qf=LANGUAGE:xx が送信される。"""
+    def test_country_filter(self):
+        """language パラメータで qf=COUNTRY:germany が送信される（LANGUAGE ではなく COUNTRY）。"""
         mock_response = {"success": True, "totalResults": 0, "items": []}
         responses.add(responses.GET, BASE_URL, json=mock_response, status=200)
 
@@ -74,7 +74,36 @@ class TestSearchEuropeana:
             source.search(keywords=["test"], language="de")
 
         request = responses.calls[0].request
-        assert "LANGUAGE%3Ade" in request.url or "LANGUAGE:de" in request.url
+        assert "COUNTRY%3Agermany" in request.url or "COUNTRY:germany" in request.url
+        # LANGUAGE フィルタは送信されないことを確認
+        assert "LANGUAGE" not in request.url
+
+    @responses.activate
+    def test_country_filter_french(self):
+        """フランス語 → COUNTRY:france で送信される。"""
+        mock_response = {"success": True, "totalResults": 0, "items": []}
+        responses.add(responses.GET, BASE_URL, json=mock_response, status=200)
+
+        source = EuropeanaSource()
+        with patch.dict("os.environ", {"EUROPEANA_API_KEY": "test_key"}):
+            source.search(keywords=["test"], language="fr")
+
+        request = responses.calls[0].request
+        assert "COUNTRY%3Afrance" in request.url or "COUNTRY:france" in request.url
+
+    @responses.activate
+    def test_unmapped_language_no_country_filter(self):
+        """マッピングにない言語（en 等）では COUNTRY フィルタが送信されない。"""
+        mock_response = {"success": True, "totalResults": 0, "items": []}
+        responses.add(responses.GET, BASE_URL, json=mock_response, status=200)
+
+        source = EuropeanaSource()
+        with patch.dict("os.environ", {"EUROPEANA_API_KEY": "test_key"}):
+            source.search(keywords=["test"], language="en")
+
+        request = responses.calls[0].request
+        assert "COUNTRY" not in request.url
+        assert "LANGUAGE" not in request.url
 
     @responses.activate
     def test_date_filter(self):

--- a/tests/unit/test_librarian_tools.py
+++ b/tests/unit/test_librarian_tools.py
@@ -8,6 +8,8 @@ from mystery_agents.schemas.document import ArchiveDocument, SourceLanguage
 from mystery_agents.tools.archive_source_base import ArchiveSearchResult
 from mystery_agents.tools.librarian_tools import (
     _TOTAL_DOCS_CAP,
+    _is_likely_english,
+    _log_keyword_language_mismatch,
     _rank_documents,
     _search_single_source,
     search_archives,
@@ -722,3 +724,69 @@ class TestNewspaperDispatcher:
 
         # language 未指定でも resolve_newspaper_sources("en") が呼ばれる
         mock_resolve.assert_called_once_with("en")
+
+
+# === キーワード言語診断ログのテスト ===
+
+
+class TestIsLikelyEnglish:
+    """_is_likely_english のテスト"""
+
+    def test_ascii_keyword_is_english(self):
+        """ASCII のみのキーワードは英語と判定される。"""
+        assert _is_likely_english("nightmare") is True
+        assert _is_likely_english("sleep paralysis") is True
+
+    def test_german_keyword_is_not_english(self):
+        """ウムラウト含むキーワードは非英語と判定される。"""
+        assert _is_likely_english("Alpträume") is False
+        assert _is_likely_english("Ärzte") is False
+
+    def test_french_keyword_is_not_english(self):
+        """アクセント含むキーワードは非英語と判定される。"""
+        assert _is_likely_english("cauchemar médical") is False
+
+    def test_dutch_keyword_is_not_english(self):
+        """オランダ語特有のアクセントを含むキーワード。"""
+        assert _is_likely_english("geneeskunde") is True  # ASCII のみだが正しいオランダ語
+        assert _is_likely_english("coöperatie") is False
+
+    def test_empty_string(self):
+        """空文字列は ASCII のみ扱い。"""
+        assert _is_likely_english("") is True
+
+
+class TestLogKeywordLanguageMismatch:
+    """_log_keyword_language_mismatch のテスト"""
+
+    def test_warning_for_all_ascii_keywords_non_english_lang(self, caplog):
+        """非英語言語で全キーワードが ASCII のみの場合に警告が出る。"""
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            _log_keyword_language_mismatch(
+                ["nightmare", "sleep paralysis"], "de"
+            )
+
+        assert "キーワード言語不一致" in caplog.text
+        assert "de" in caplog.text
+
+    def test_no_warning_for_native_keywords(self, caplog):
+        """ネイティブ言語キーワードが含まれる場合は警告なし。"""
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            _log_keyword_language_mismatch(
+                ["Alpträume", "nightmare"], "de"
+            )
+
+        assert "キーワード言語不一致" not in caplog.text
+
+    def test_no_warning_for_empty_keywords(self, caplog):
+        """空のキーワードリストでは警告なし。"""
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            _log_keyword_language_mismatch([], "de")
+
+        assert "キーワード言語不一致" not in caplog.text

--- a/tests/unit/test_wellcome_collection.py
+++ b/tests/unit/test_wellcome_collection.py
@@ -435,3 +435,114 @@ class TestNotesToRawText:
         result = _parse_wellcome_response(data, keywords=["test"])
         doc = result.documents[0]
         assert len(doc.raw_text) == 5000
+
+
+class TestDateFilterFallback:
+    """日付フィルタのフォールバック機構テスト。"""
+
+    @responses.activate
+    def test_date_filter_fallback_on_zero_results(self):
+        """日付フィルタ付きで 0 件 → 日付フィルタなしで再検索する。"""
+        # 1 回目: 日付フィルタ付き → 0 件
+        responses.add(
+            responses.GET,
+            BASE_URL,
+            json=MOCK_EMPTY_RESPONSE,
+            status=200,
+        )
+        # 2 回目: 日付フィルタなし → 結果あり
+        responses.add(
+            responses.GET,
+            BASE_URL,
+            json=MOCK_RESPONSE,
+            status=200,
+        )
+
+        source = WellcomeSource()
+        result = source.search(
+            keywords=["witchcraft"],
+            date_start="1650",
+            date_end="1850",
+        )
+
+        # フォールバックで結果が取得される
+        assert len(result.documents) == 2
+        assert result.total_hits == 2
+
+        # 2 回リクエストされた
+        assert len(responses.calls) == 2
+
+        # 1 回目: 日付フィルタあり
+        first_request = responses.calls[0].request
+        assert "production.dates.from=1650-01-01" in first_request.url
+
+        # 2 回目: 日付フィルタなし
+        second_request = responses.calls[1].request
+        assert "production.dates.from" not in second_request.url
+        assert "production.dates.to" not in second_request.url
+
+    @responses.activate
+    def test_no_fallback_when_results_found(self):
+        """日付フィルタ付きで結果がある場合、再検索しない。"""
+        responses.add(
+            responses.GET,
+            BASE_URL,
+            json=MOCK_RESPONSE,
+            status=200,
+        )
+
+        source = WellcomeSource()
+        result = source.search(
+            keywords=["witchcraft"],
+            date_start="1650",
+            date_end="1850",
+        )
+
+        assert len(result.documents) == 2
+        # 1 回のみリクエスト
+        assert len(responses.calls) == 1
+
+    @responses.activate
+    def test_no_fallback_without_date_filter(self):
+        """日付フィルタなしの検索で 0 件でも再検索しない。"""
+        responses.add(
+            responses.GET,
+            BASE_URL,
+            json=MOCK_EMPTY_RESPONSE,
+            status=200,
+        )
+
+        source = WellcomeSource()
+        result = source.search(keywords=["nonexistent"])
+
+        assert len(result.documents) == 0
+        # 1 回のみリクエスト
+        assert len(responses.calls) == 1
+
+    @responses.activate
+    def test_fallback_also_zero_returns_empty(self):
+        """フォールバック検索も 0 件の場合は空を返す。"""
+        # 両方 0 件
+        responses.add(
+            responses.GET,
+            BASE_URL,
+            json=MOCK_EMPTY_RESPONSE,
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            BASE_URL,
+            json=MOCK_EMPTY_RESPONSE,
+            status=200,
+        )
+
+        source = WellcomeSource()
+        result = source.search(
+            keywords=["obscure_term"],
+            date_start="1650",
+            date_end="1850",
+        )
+
+        assert len(result.documents) == 0
+        # 2 回リクエスト（フォールバック含む）
+        assert len(responses.calls) == 2


### PR DESCRIPTION
## Summary

PR #308 の出典多様性対策は正常動作しているが、上流の検索層で9 API中6つが0件を返す問題を改善する。

- **Wellcome Collection**: 日付フィルタ付きで0件 → 日付フィルタなしで再検索するフォールバック追加（歴史資料の日付メタデータ不完全問題に対応）
- **Europeana**: `LANGUAGE` フィルタから `COUNTRY` フィルタに変更（ラテン語混在の歴史資料を捕捉可能に）
- **キーワード言語診断**: 非英語 Librarian が ASCII のみキーワードで検索している場合に警告ログ出力

### 変更対象

| ファイル | 変更内容 |
|---|---|
| `wellcome_collection.py` | 日付フィルタフォールバック（0件時に日付なし再検索） |
| `europeana.py` | `LANGUAGE:{lang}` → `COUNTRY:{country}`（独→germany等） |
| `librarian_tools.py` | `_is_likely_english()` + `_log_keyword_language_mismatch()` 追加 |

### NYPL env var 名

確認の結果、`env_var_key = "NYPL_API_TOKEN"` と `.env.example` の `NYPL_API_TOKEN` は一致していた。修正不要。

## Test plan

- [x] Wellcome 日付フォールバックのテスト4件追加（フォールバック発動/不発動/両方0件）
- [x] Europeana COUNTRY フィルタのテスト3件追加（独/仏/マッピング外）
- [x] キーワード言語診断のテスト8件追加（ASCII判定/警告ログ出力）
- [x] 全1031テスト PASS（既存テスト破壊なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)