### PR TITLE
fix: Markdown 画像ハイドレーションエラー修正（複数画像対応）+ 画像配置プログラム制御

### DIFF
--- a/packages/shared/src/lib/normalize-image-placement.ts
+++ b/packages/shared/src/lib/normalize-image-placement.ts
@@ -1,0 +1,56 @@
+/**
+ * Markdown テキスト内の画像行をプログラム的に各セクション末尾に再配置する。
+ *
+ * Storyteller が出力した画像（![alt](url)）の位置に依存せず、
+ * H2 セクション 1〜3 の末尾に最大1枚ずつ均等配置する。
+ * セクション4（結び）には画像を配置しない。
+ */
+
+/** 行頭が `![` で始まる独立した画像行にマッチ */
+const IMAGE_LINE_RE = /^!\[.*?\]\(.*?\)\s*$/
+
+export function normalizeImagePlacement(markdown: string): string {
+  const lines = markdown.split("\n")
+
+  // 1. 全画像行を抽出し、元の位置から除去
+  const images: string[] = []
+  const filteredLines: string[] = []
+
+  for (const line of lines) {
+    if (IMAGE_LINE_RE.test(line)) {
+      images.push(line.trim())
+    } else {
+      filteredLines.push(line)
+    }
+  }
+
+  // 画像がなければそのまま返す
+  if (images.length === 0) return markdown
+
+  // 2. H2 見出しの行インデックスを特定
+  const h2Indices: number[] = []
+  for (let i = 0; i < filteredLines.length; i++) {
+    if (filteredLines[i].startsWith("## ")) {
+      h2Indices.push(i)
+    }
+  }
+
+  // H2 が2つ未満なら配置先がないので画像除去のみ
+  if (h2Indices.length < 2) {
+    return filteredLines.join("\n").replace(/\n{3,}/g, "\n\n")
+  }
+
+  // 3. セクション1〜3の末尾（= 次の H2 の直前）に画像を1枚ずつ挿入
+  // 最後のセクション（結び）には入れない
+  const placementSlots = Math.min(h2Indices.length - 1, 3)
+  const imageCount = Math.min(images.length, placementSlots)
+
+  // 後ろから挿入してインデックスのずれを防ぐ
+  for (let i = imageCount - 1; i >= 0; i--) {
+    const insertBefore = h2Indices[i + 1]
+    filteredLines.splice(insertBefore, 0, "", images[i], "")
+  }
+
+  // 余分な連続空行を整理して返す
+  return filteredLines.join("\n").replace(/\n{3,}/g, "\n\n")
+}

--- a/packages/shared/src/lib/rehype-unwrap-images.ts
+++ b/packages/shared/src/lib/rehype-unwrap-images.ts
@@ -20,23 +20,29 @@ export function rehypeUnwrapImages() {
   return (tree: HastNode) => {
     function walk(node: HastNode) {
       if (!node.children) return
-      for (let i = 0; i < node.children.length; i++) {
-        const child = node.children[i]
+      // 新配列を構築して置換（splice によるインデックスずれを回避）
+      const newChildren: HastNode[] = []
+      for (const child of node.children) {
         if (child.type === "element" && child.tagName === "p") {
           // 空白テキストノードを除外し、意味のあるノードのみ抽出
           const meaningful = (child.children || []).filter(
             (c) => !(c.type === "text" && !c.value?.trim())
           )
+          // 画像のみで構成された段落なら <p> を除去し、画像を直接展開
           if (
-            meaningful.length === 1 &&
-            meaningful[0].type === "element" &&
-            meaningful[0].tagName === "img"
+            meaningful.length >= 1 &&
+            meaningful.every(
+              (c) => c.type === "element" && c.tagName === "img"
+            )
           ) {
-            node.children[i] = meaningful[0]
+            newChildren.push(...meaningful)
+            continue
           }
         }
+        newChildren.push(child)
         walk(child)
       }
+      node.children = newChildren
     }
     walk(tree)
   }

--- a/web-admin/src/app/(main)/preview/[id]/preview-content.tsx
+++ b/web-admin/src/app/(main)/preview/[id]/preview-content.tsx
@@ -22,6 +22,7 @@ import {
 import Markdown, { type Components } from "react-markdown"
 import remarkGfm from "remark-gfm"
 import { rehypeUnwrapImages } from "@ghost/shared/src/lib/rehype-unwrap-images"
+import { normalizeImagePlacement } from "@ghost/shared/src/lib/normalize-image-placement"
 import { stripLeadingH1 } from "@ghost/shared/src/lib/utils"
 import { useState } from "react"
 
@@ -200,7 +201,7 @@ export function PreviewContent({ mystery }: PreviewContentProps) {
                       img: ({ src, alt }) => <PreviewArchiveImage src={src} alt={alt} />,
                     }}
                   >
-                    {stripLeadingH1(narrativeContent).replace(/\*\*(.+?)\*\*/g, ' **$1** ')}
+                    {normalizeImagePlacement(stripLeadingH1(narrativeContent).replace(/\*\*(.+?)\*\*/g, ' **$1** '))}
                   </Markdown>
                 </section>
               ) : (

--- a/web-public/src/components/mystery/narrative-section.tsx
+++ b/web-public/src/components/mystery/narrative-section.tsx
@@ -1,6 +1,7 @@
 import Markdown, { type Components } from "react-markdown"
 import remarkGfm from "remark-gfm"
 import { rehypeUnwrapImages } from "@ghost/shared/src/lib/rehype-unwrap-images"
+import { normalizeImagePlacement } from "@ghost/shared/src/lib/normalize-image-placement"
 import { FileText } from "lucide-react"
 import { stripLeadingH1 } from "@ghost/shared/src/lib/utils"
 import { slugify } from "@/lib/markdown-headings"
@@ -80,7 +81,7 @@ export function NarrativeSection({ narrativeContent, summary, lang = "en" }: Nar
     return (
       <section id="section-narrative" className="scroll-mt-24 prose prose-lg prose-invert max-w-none prose-headings:font-serif prose-headings:text-parchment prose-headings:mt-12 prose-headings:mb-4 prose-p:text-foreground/90 prose-p:leading-loose prose-p:mb-6 prose-a:text-gold prose-strong:text-parchment prose-hr:border-border">
         <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeUnwrapImages]} components={markdownComponents}>
-          {stripLeadingH1(narrativeContent).replace(/\*\*(.+?)\*\*/g, ' **$1** ')}
+          {normalizeImagePlacement(stripLeadingH1(narrativeContent).replace(/\*\*(.+?)\*\*/g, ' **$1** '))}
         </Markdown>
       </section>
     )


### PR DESCRIPTION
## Summary

PR #312, #314 で修正した画像ハイドレーションエラーが、**複数画像が同一段落に存在するケース**で再発していた問題を修正。加えて、Storyteller（LLM）の画像配置に依存しないプログラム的な画像配置制御を導入。

## 変更内容

### 1. normalizeImagePlacement — 画像配置のプログラム制御（新規）
- Markdown テキストから全ての画像行を抽出
- 元の位置から除去し、H2 セクション1〜3の末尾に各1枚ずつ再配置
- セクション4（結び）には画像を配置しない
- LLM が画像をどう配置しても、レンダリング時に正しい位置に補正される

### 2. rehypeUnwrapImages — 複数画像段落対応（防御層）
- 画像1枚限定の条件を緩和し、画像のみで構成された段落は枚数に関わらず unwrap
- 新配列構築方式で splice のインデックスずれ問題を回避

### 3. レンダリング側に正規化適用
- web-public と web-admin の両方で normalizeImagePlacement を ReactMarkdown の前処理として追加
- 過去記事・翻訳テキストにも自動適用

## 変更ファイル

| ファイル | 変更 |
|---------|------|
| packages/shared/src/lib/normalize-image-placement.ts | **新規** — 画像配置正規化ユーティリティ |
| packages/shared/src/lib/rehype-unwrap-images.ts | 複数画像段落対応 |
| web-public/src/components/mystery/narrative-section.tsx | 正規化呼び出し追加 |
| web-admin/src/app/(main)/preview/[id]/preview-content.tsx | 正規化呼び出し追加 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)