### PR TITLE
fix: ローカル開発環境での初回リンクエラー修正（dynamicParams 条件分岐）

### DIFF
--- a/web-public/src/app/[lang]/archive/[[...page]]/page.tsx
+++ b/web-public/src/app/[lang]/archive/[[...page]]/page.tsx
@@ -15,8 +15,9 @@ import type { SupportedLang } from "@/lib/i18n/config"
 import { getDictionary } from "@/lib/i18n/dictionaries"
 import { buildOgpMetadata, buildAlternates } from "@/lib/seo"
 
-// SSG: ビルド時に生成されたページ以外は 404
-export const dynamicParams = false
+// SSG: 本番ビルドではビルド時に生成されたページ以外は 404
+// dev モードでは Firestore 初回接続遅延による 404 を防ぐため動的レンダリングを許可
+export const dynamicParams = process.env.NODE_ENV === "production" ? false : true
 
 export async function generateStaticParams() {
   const mysteries = await getPublishedMysteries(1000)

--- a/web-public/src/app/[lang]/mystery/[id]/page.tsx
+++ b/web-public/src/app/[lang]/mystery/[id]/page.tsx
@@ -28,8 +28,9 @@ import { extractHeadings } from "@/lib/markdown-headings"
 import { stripLeadingH1 } from "@ghost/shared/src/lib/utils"
 import type { TocSection } from "@/lib/toc-config"
 
-// SSG: ビルド時に生成されたページ以外は 404
-export const dynamicParams = false
+// SSG: 本番ビルドではビルド時に生成されたページ以外は 404
+// dev モードでは Firestore 初回接続遅延による 404 を防ぐため動的レンダリングを許可
+export const dynamicParams = process.env.NODE_ENV === "production" ? false : true
 
 export async function generateStaticParams() {
   let ids: string[]


### PR DESCRIPTION
## Summary

- `next dev` で記事カードをクリックした際、Firestore 初回接続遅延により `generateStaticParams()` が失敗し、`dynamicParams = false` で 404 になる問題を修正
- `process.env.NODE_ENV === "production"` で条件分岐し、dev モードでは `dynamicParams = true`（動的レンダリング許可）に設定
- 本番ビルド（SSG）では従来通り `false` を維持し、ビルド時に生成されたページ以外は 404

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `web-public/src/app/[lang]/mystery/[id]/page.tsx` | `dynamicParams` を環境条件分岐に変更 |
| `web-public/src/app/[lang]/archive/[[...page]]/page.tsx` | 同上 |

## 変更しなかったもの

- `about/page.tsx` — `generateStaticParams` が Firestore に依存せず、静的な `SUPPORTED_LANGS` のみ使用のため影響なし

## Test plan

- [ ] `next dev` でローカル開発サーバーを起動し、ホームページから記事カードクリックで初回表示が成功することを確認
- [ ] アーカイブページも同様に初回アクセスで正常表示されることを確認
- [ ] `next build` で本番ビルドが正常に完了することを確認（SSG 挙動に変化なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)