### PR TITLE
fix: Wellcome パースバグ修正 + 証拠品質チェック

### DIFF
--- a/mystery_agents/tools/document_inventory.py
+++ b/mystery_agents/tools/document_inventory.py
@@ -133,6 +133,9 @@ def get_document_inventory(tool_context: Optional[ToolContext] = None) -> str:
     summary_parts = [f"{name}: {len(docs)} docs" for name, docs in archive_counts]
     archive_summary = ", ".join(summary_parts)
 
+    # inventory 参照済みフラグをセット（save_structured_report が確認する）
+    tool_context.state["_inventory_consulted"] = True
+
     response = {
         "status": "ok",
         "total_documents": total,

--- a/mystery_agents/tools/scholar_tools.py
+++ b/mystery_agents/tools/scholar_tools.py
@@ -481,6 +481,100 @@ def _validate_evidence(evidence: dict, label: str) -> list[str]:
     return warnings
 
 
+def _build_url_index(tool_context: ToolContext) -> dict[str, dict[str, Any]]:
+    """raw_search_results から URL→文書メタデータのマッピングを構築する。
+
+    raw_search_results と raw_search_results_{lang} の両方から文書を収集し、
+    source_url をキーとする辞書を返す。
+    """
+    url_index: dict[str, dict[str, Any]] = {}
+    state = tool_context.state
+
+    # ベースキー
+    base = state.get("raw_search_results")
+    if base and isinstance(base, list):
+        for result in base:
+            if isinstance(result, dict):
+                for doc in result.get("documents", []):
+                    url = doc.get("source_url", "")
+                    if url:
+                        url_index[url] = doc
+
+    # 言語別キー
+    state_dict = state.to_dict() if hasattr(state, "to_dict") else state
+    for key in list(state_dict.keys()):
+        if key.startswith("raw_search_results_") and key != "raw_search_results":
+            lang_results = state.get(key)
+            if lang_results and isinstance(lang_results, list):
+                for result in lang_results:
+                    if isinstance(result, dict):
+                        for doc in result.get("documents", []):
+                            url = doc.get("source_url", "")
+                            if url:
+                                url_index[url] = doc
+
+    return url_index
+
+
+def _validate_evidence_grounding(
+    report_data: dict, tool_context: ToolContext
+) -> list[str]:
+    """証拠を raw_search_results と照合し、正確性を検証・修正する。
+
+    1. URL 照合: evidence の source_url が raw_search_results に存在するか確認
+       → 不在なら warning（ハルシネーションの可能性）
+    2. メタデータ修正: URL 一致した場合、raw_search_results の title / date で
+       evidence の source_title / source_date を上書き（LLM の転記ミスを修正）
+    3. ソース識別: raw_search_results の source_type を evidence に
+       archive_source として付与（ログ・デバッグ用）
+
+    Returns: warning メッセージのリスト
+    """
+    url_index = _build_url_index(tool_context)
+    if not url_index:
+        return []
+
+    warnings: list[str] = []
+
+    # 検証対象の evidence 項目を収集
+    evidence_items: list[tuple[str, dict]] = []
+    for key in ("evidence_a", "evidence_b"):
+        ev = report_data.get(key)
+        if ev and isinstance(ev, dict):
+            evidence_items.append((key, ev))
+
+    additional = report_data.get("additional_evidence")
+    if additional and isinstance(additional, list):
+        for i, ev in enumerate(additional):
+            if isinstance(ev, dict):
+                evidence_items.append((f"additional_evidence[{i}]", ev))
+
+    for label, ev in evidence_items:
+        source_url = ev.get("source_url", "")
+        if not source_url:
+            continue
+
+        raw_doc = url_index.get(source_url)
+        if raw_doc:
+            # メタデータを raw データで上書き（LLM 転記ミス修正）
+            raw_title = raw_doc.get("title")
+            if raw_title:
+                ev["source_title"] = raw_title
+            raw_date = raw_doc.get("date")
+            if raw_date:
+                ev["source_date"] = raw_date
+            # ソース種別を付与
+            raw_source_type = raw_doc.get("source_type")
+            if raw_source_type:
+                ev["archive_source"] = raw_source_type
+        else:
+            warnings.append(
+                f"{label}: source_url not found in collected documents"
+            )
+
+    return warnings
+
+
 def save_structured_report(
     report_json: str,
     tool_context: ToolContext,
@@ -491,9 +585,16 @@ def save_structured_report(
     structured data (evidence, hypothesis, etc.) directly in session
     state, bypassing LLM text interpretation for downstream agents.
 
+    前提条件:
+    - get_document_inventory が事前に呼ばれていること（_inventory_consulted フラグ）
+
     evidence バリデーション:
     - evidence_a / evidence_b: 空 excerpt は警告のみ（構造上必須のため除外しない）
     - additional_evidence: 空 excerpt の項目はフィルタリング（除外）
+
+    証拠グラウンディング:
+    - raw_search_results と照合し、メタデータを自動修正
+    - URL 不一致の場合は警告
 
     Args:
         report_json: JSON string containing the structured report with fields:
@@ -518,6 +619,17 @@ def save_structured_report(
     Returns:
         JSON string with save status and warnings.
     """
+    # inventory 参照チェック
+    if not tool_context.state.get("_inventory_consulted"):
+        return json.dumps(
+            {
+                "status": "error",
+                "error": "get_document_inventory must be called before saving the report. "
+                "Review ALL available documents across ALL archives before selecting evidence.",
+            },
+            ensure_ascii=False,
+        )
+
     try:
         report_data = json.loads(report_json)
     except json.JSONDecodeError as e:
@@ -550,6 +662,10 @@ def save_structured_report(
                     f"additional_evidence[{i}]: removed (empty relevant_excerpt)"
                 )
         report_data["additional_evidence"] = filtered
+
+    # 証拠グラウンディング検証（URL 照合 + メタデータ修正）
+    grounding_warnings = _validate_evidence_grounding(report_data, tool_context)
+    warnings.extend(grounding_warnings)
 
     # Store structured report in session state
     tool_context.state["structured_report"] = report_data

--- a/mystery_agents/tools/wellcome_collection.py
+++ b/mystery_agents/tools/wellcome_collection.py
@@ -43,17 +43,22 @@ _LANG_1_TO_3: dict[str, str] = {
 }
 
 
-def _strip_html(text: str | None) -> str:
+def _strip_html(text: str | list | None) -> str:
     """HTML タグを除去する。
 
     Args:
-        text: HTML を含む可能性のあるテキスト
+        text: HTML を含む可能性のあるテキスト。
+              Wellcome API の notes[].contents は list[str] の場合がある。
 
     Returns:
         タグ除去済みのプレーンテキスト。None の場合は空文字列。
     """
     if not text:
         return ""
+    if isinstance(text, list):
+        text = " ".join(str(item) for item in text if item)
+    if not isinstance(text, str):
+        return str(text)
     return re.sub(r"<[^>]+>", "", text).strip()
 
 

--- a/tests/unit/test_document_inventory.py
+++ b/tests/unit/test_document_inventory.py
@@ -216,3 +216,28 @@ class TestGetDocumentInventory:
         result = json.loads(get_document_inventory(ctx))
 
         assert result["total_documents"] == 1
+
+    def test_sets_inventory_consulted_flag(self):
+        """正常実行後に _inventory_consulted フラグがセットされる。"""
+        ctx = make_tool_context(state={
+            "raw_search_results_en": [{
+                "documents": [{
+                    "title": "Doc",
+                    "source_url": "https://loc.gov/1",
+                    "source_type": "loc_digital",
+                    "language": "en",
+                }],
+            }],
+        })
+
+        get_document_inventory(ctx)
+
+        assert ctx.state["_inventory_consulted"] is True
+
+    def test_no_data_does_not_set_flag(self):
+        """no_data の場合はフラグがセットされない。"""
+        ctx = make_tool_context(state={})
+
+        get_document_inventory(ctx)
+
+        assert "_inventory_consulted" not in ctx.state

--- a/tests/unit/test_scholar_tools.py
+++ b/tests/unit/test_scholar_tools.py
@@ -8,8 +8,16 @@ from unittest.mock import MagicMock
 
 from mystery_agents.tools.scholar_tools import (
     _validate_evidence,
+    _validate_evidence_grounding,
     save_structured_report,
 )
+
+
+def _make_ctx(state: dict | None = None) -> MagicMock:
+    """inventory 参照済みフラグ付きのモック ToolContext を作成する。"""
+    ctx = MagicMock()
+    ctx.state = {"_inventory_consulted": True, **(state or {})}
+    return ctx
 
 
 class TestSaveStructuredReport:
@@ -30,8 +38,7 @@ class TestSaveStructuredReport:
         }
         report_json = json.dumps(report_data)
 
-        mock_tool_context = MagicMock()
-        mock_tool_context.state = {}
+        mock_tool_context = _make_ctx()
 
         result = save_structured_report(report_json, mock_tool_context)
         result_data = json.loads(result)
@@ -49,8 +56,7 @@ class TestSaveStructuredReport:
         }
         report_json = json.dumps(report_data)
 
-        mock_tool_context = MagicMock()
-        mock_tool_context.state = {}
+        mock_tool_context = _make_ctx()
 
         result = save_structured_report(report_json, mock_tool_context)
         result_data = json.loads(result)
@@ -59,8 +65,7 @@ class TestSaveStructuredReport:
 
     def test_handles_invalid_json(self):
         """Should return error for invalid JSON input."""
-        mock_tool_context = MagicMock()
-        mock_tool_context.state = {}
+        mock_tool_context = _make_ctx()
 
         result = save_structured_report("not valid json", mock_tool_context)
         result_data = json.loads(result)
@@ -71,10 +76,9 @@ class TestSaveStructuredReport:
 
     def test_overwrites_previous_report(self):
         """Should overwrite any previous structured_report in state."""
-        mock_tool_context = MagicMock()
-        mock_tool_context.state = {
+        mock_tool_context = _make_ctx({
             "structured_report": {"old": "data"},
-        }
+        })
 
         new_report = {"title": "New Report", "hypothesis": "New hypothesis"}
         result = save_structured_report(json.dumps(new_report), mock_tool_context)
@@ -128,8 +132,7 @@ class TestSaveStructuredReport:
         }
         report_json = json.dumps(report_data)
 
-        mock_tool_context = MagicMock()
-        mock_tool_context.state = {}
+        mock_tool_context = _make_ctx()
 
         save_structured_report(report_json, mock_tool_context)
 
@@ -226,8 +229,7 @@ class TestSaveStructuredReportEvidenceValidation:
                 "relevant_excerpt": "Valid excerpt",
             },
         }
-        mock_ctx = MagicMock()
-        mock_ctx.state = {}
+        mock_ctx = _make_ctx()
 
         result = save_structured_report(json.dumps(report_data), mock_ctx)
         result_data = json.loads(result)
@@ -260,8 +262,7 @@ class TestSaveStructuredReportEvidenceValidation:
                 },
             ],
         }
-        mock_ctx = MagicMock()
-        mock_ctx.state = {}
+        mock_ctx = _make_ctx()
 
         result = save_structured_report(json.dumps(report_data), mock_ctx)
         result_data = json.loads(result)
@@ -283,8 +284,7 @@ class TestSaveStructuredReportEvidenceValidation:
                 {"source_url": "https://b.com", "relevant_excerpt": "  "},
             ],
         }
-        mock_ctx = MagicMock()
-        mock_ctx.state = {}
+        mock_ctx = _make_ctx()
 
         result = save_structured_report(json.dumps(report_data), mock_ctx)
         result_data = json.loads(result)
@@ -311,8 +311,7 @@ class TestSaveStructuredReportEvidenceValidation:
                 },
             ],
         }
-        mock_ctx = MagicMock()
-        mock_ctx.state = {}
+        mock_ctx = _make_ctx()
 
         result = save_structured_report(json.dumps(report_data), mock_ctx)
         result_data = json.loads(result)
@@ -336,8 +335,7 @@ class TestSaveStructuredReportNewFields:
                 "coverage_assessment": "About 20% digitized",
             },
         }
-        mock_ctx = MagicMock()
-        mock_ctx.state = {}
+        mock_ctx = _make_ctx()
 
         result = save_structured_report(json.dumps(report_data), mock_ctx)
         result_data = json.loads(result)
@@ -354,8 +352,7 @@ class TestSaveStructuredReportNewFields:
             "title": "Test",
             "confidence_rationale": "Rated LOW because only one source was found via API.",
         }
-        mock_ctx = MagicMock()
-        mock_ctx.state = {}
+        mock_ctx = _make_ctx()
 
         result = save_structured_report(json.dumps(report_data), mock_ctx)
         result_data = json.loads(result)
@@ -363,3 +360,261 @@ class TestSaveStructuredReportNewFields:
         assert result_data["status"] == "success"
         saved = mock_ctx.state["structured_report"]
         assert saved["confidence_rationale"] == "Rated LOW because only one source was found via API."
+
+
+class TestInventoryConsultedCheck:
+    """inventory 参照強制チェックのテスト。"""
+
+    def test_error_when_inventory_not_consulted(self):
+        """inventory 未参照で save_structured_report → エラー。"""
+        mock_ctx = MagicMock()
+        mock_ctx.state = {}  # _inventory_consulted なし
+
+        report_data = {"title": "Test", "hypothesis": "Test"}
+        result = save_structured_report(json.dumps(report_data), mock_ctx)
+        result_data = json.loads(result)
+
+        assert result_data["status"] == "error"
+        assert "get_document_inventory" in result_data["error"]
+        assert "structured_report" not in mock_ctx.state
+
+    def test_error_when_inventory_consulted_false(self):
+        """_inventory_consulted = False でもエラー。"""
+        mock_ctx = MagicMock()
+        mock_ctx.state = {"_inventory_consulted": False}
+
+        report_data = {"title": "Test"}
+        result = save_structured_report(json.dumps(report_data), mock_ctx)
+        result_data = json.loads(result)
+
+        assert result_data["status"] == "error"
+
+    def test_success_when_inventory_consulted(self):
+        """_inventory_consulted = True で正常保存。"""
+        mock_ctx = _make_ctx()
+
+        report_data = {"title": "Test"}
+        result = save_structured_report(json.dumps(report_data), mock_ctx)
+        result_data = json.loads(result)
+
+        assert result_data["status"] == "success"
+
+    def test_invalid_json_error_takes_priority_over_inventory(self):
+        """不正 JSON のエラーは inventory チェックより後（inventory チェックが先）。"""
+        mock_ctx = MagicMock()
+        mock_ctx.state = {"_inventory_consulted": True}
+
+        result = save_structured_report("not valid json", mock_ctx)
+        result_data = json.loads(result)
+
+        assert result_data["status"] == "error"
+        assert "Invalid JSON" in result_data["error"]
+
+
+class TestEvidenceGrounding:
+    """証拠グラウンディング検証のテスト。"""
+
+    def test_matching_url_overwrites_metadata(self):
+        """URL が raw_search_results と一致 → title/date を上書き。"""
+        mock_ctx = _make_ctx({
+            "raw_search_results_en": [{
+                "documents": [{
+                    "title": "Correct Title From API",
+                    "source_url": "https://loc.gov/item/123",
+                    "date": "1893-01-15",
+                    "source_type": "loc_digital",
+                }],
+            }],
+        })
+
+        report_data = {
+            "title": "Test",
+            "evidence_a": {
+                "source_url": "https://loc.gov/item/123",
+                "source_title": "Wrong Title From LLM",
+                "source_date": "1893",
+                "relevant_excerpt": "Some text",
+            },
+        }
+        result = save_structured_report(json.dumps(report_data), mock_ctx)
+        result_data = json.loads(result)
+
+        assert result_data["status"] == "success"
+        saved_ev = mock_ctx.state["structured_report"]["evidence_a"]
+        # raw データで上書きされている
+        assert saved_ev["source_title"] == "Correct Title From API"
+        assert saved_ev["source_date"] == "1893-01-15"
+        assert saved_ev["archive_source"] == "loc_digital"
+
+    def test_non_matching_url_warns(self):
+        """URL が raw_search_results に不在 → 警告。"""
+        mock_ctx = _make_ctx({
+            "raw_search_results_en": [{
+                "documents": [{
+                    "title": "Real Doc",
+                    "source_url": "https://loc.gov/item/real",
+                    "source_type": "loc_digital",
+                }],
+            }],
+        })
+
+        report_data = {
+            "title": "Test",
+            "evidence_a": {
+                "source_url": "https://loc.gov/item/hallucinated",
+                "relevant_excerpt": "Made up text",
+            },
+        }
+        result = save_structured_report(json.dumps(report_data), mock_ctx)
+        result_data = json.loads(result)
+
+        assert result_data["status"] == "success"
+        assert any("source_url not found" in w for w in result_data["warnings"])
+
+    def test_additional_evidence_grounding(self):
+        """additional_evidence も URL 照合される。"""
+        mock_ctx = _make_ctx({
+            "raw_search_results_en": [{
+                "documents": [
+                    {
+                        "title": "Doc A",
+                        "source_url": "https://archive.org/details/a",
+                        "date": "1900-01-01",
+                        "source_type": "internet_archive",
+                    },
+                    {
+                        "title": "Doc B",
+                        "source_url": "https://loc.gov/item/b",
+                        "date": "1901-06-15",
+                        "source_type": "loc_digital",
+                    },
+                ],
+            }],
+        })
+
+        report_data = {
+            "title": "Test",
+            "evidence_a": {
+                "source_url": "https://archive.org/details/a",
+                "source_title": "Wrong",
+                "relevant_excerpt": "Text",
+            },
+            "evidence_b": {
+                "source_url": "https://loc.gov/item/b",
+                "source_title": "Also Wrong",
+                "relevant_excerpt": "Text",
+            },
+            "additional_evidence": [
+                {
+                    "source_url": "https://not-real.com/fake",
+                    "relevant_excerpt": "Hallucinated",
+                },
+            ],
+        }
+        result = save_structured_report(json.dumps(report_data), mock_ctx)
+        result_data = json.loads(result)
+
+        saved = mock_ctx.state["structured_report"]
+        assert saved["evidence_a"]["source_title"] == "Doc A"
+        assert saved["evidence_a"]["archive_source"] == "internet_archive"
+        assert saved["evidence_b"]["source_title"] == "Doc B"
+        assert saved["evidence_b"]["archive_source"] == "loc_digital"
+        # additional_evidence[0] は URL 不在で警告
+        assert any("additional_evidence[0]" in w for w in result_data["warnings"])
+
+    def test_no_raw_search_results_skips_grounding(self):
+        """raw_search_results がない場合はグラウンディングをスキップ。"""
+        mock_ctx = _make_ctx()  # raw_search_results なし
+
+        report_data = {
+            "title": "Test",
+            "evidence_a": {
+                "source_url": "https://example.com",
+                "relevant_excerpt": "Text",
+            },
+        }
+        result = save_structured_report(json.dumps(report_data), mock_ctx)
+        result_data = json.loads(result)
+
+        assert result_data["status"] == "success"
+        # グラウンディング警告はなし（raw data がないのでスキップ）
+        grounding_warnings = [w for w in result_data["warnings"] if "source_url not found" in w]
+        assert grounding_warnings == []
+
+    def test_grounding_uses_base_and_lang_keys(self):
+        """raw_search_results（ベース）と raw_search_results_{lang} の両方を参照する。"""
+        mock_ctx = _make_ctx({
+            "raw_search_results": [{
+                "documents": [{
+                    "title": "Base Doc",
+                    "source_url": "https://example.com/base",
+                    "date": "1800-01-01",
+                    "source_type": "dpla",
+                }],
+            }],
+            "raw_search_results_ja": [{
+                "documents": [{
+                    "title": "JA Doc",
+                    "source_url": "https://ndl.go.jp/ja/1",
+                    "date": "1900-05-01",
+                    "source_type": "ndl",
+                }],
+            }],
+        })
+
+        report_data = {
+            "title": "Test",
+            "evidence_a": {
+                "source_url": "https://example.com/base",
+                "relevant_excerpt": "Text",
+            },
+            "evidence_b": {
+                "source_url": "https://ndl.go.jp/ja/1",
+                "relevant_excerpt": "Text",
+            },
+        }
+        result = save_structured_report(json.dumps(report_data), mock_ctx)
+        result_data = json.loads(result)
+
+        saved = mock_ctx.state["structured_report"]
+        assert saved["evidence_a"]["archive_source"] == "dpla"
+        assert saved["evidence_b"]["archive_source"] == "ndl"
+        assert result_data["warnings"] == []
+
+
+class TestValidateEvidenceGroundingDirect:
+    """_validate_evidence_grounding 関数の直接テスト。"""
+
+    def test_empty_evidence(self):
+        """evidence がない場合は警告なし。"""
+        mock_ctx = _make_ctx({
+            "raw_search_results_en": [{
+                "documents": [{
+                    "title": "Doc",
+                    "source_url": "https://example.com",
+                    "source_type": "loc_digital",
+                }],
+            }],
+        })
+
+        report_data = {"title": "Test"}
+        warnings = _validate_evidence_grounding(report_data, mock_ctx)
+        assert warnings == []
+
+    def test_evidence_without_source_url_skipped(self):
+        """source_url がない evidence はスキップされる。"""
+        mock_ctx = _make_ctx({
+            "raw_search_results_en": [{
+                "documents": [{
+                    "title": "Doc",
+                    "source_url": "https://example.com",
+                    "source_type": "loc_digital",
+                }],
+            }],
+        })
+
+        report_data = {
+            "evidence_a": {"relevant_excerpt": "Text"},
+        }
+        warnings = _validate_evidence_grounding(report_data, mock_ctx)
+        assert warnings == []

--- a/tests/unit/test_wellcome_collection.py
+++ b/tests/unit/test_wellcome_collection.py
@@ -278,6 +278,18 @@ class TestHelperFunctions:
         """タグなしテキストはそのまま返す。"""
         assert _strip_html("plain text") == "plain text"
 
+    def test_strip_html_list_input(self):
+        """list 型入力（実 Wellcome API の notes[].contents 形式）を処理する。"""
+        assert _strip_html(["<p>text</p>", "more"]) == "text more"
+
+    def test_strip_html_list_with_none_items(self):
+        """list 内の None 項目をスキップする。"""
+        assert _strip_html(["first", None, "third"]) == "first third"
+
+    def test_strip_html_empty_list(self):
+        """空リストの場合は空文字列を返す。"""
+        assert _strip_html([]) == ""
+
     def test_detect_language_english(self):
         """英語の検出。"""
         work = {"languages": [{"id": "eng", "label": "English"}]}
@@ -338,7 +350,7 @@ class TestNotesToRawText:
     """notes → raw_text 変換のテスト。"""
 
     def test_notes_to_raw_text(self):
-        """notes フィールドが raw_text に反映される。"""
+        """notes フィールドが raw_text に反映される（実 API は contents が list）。"""
         data = {
             "totalResults": 1,
             "results": [
@@ -347,8 +359,8 @@ class TestNotesToRawText:
                     "title": "Test Work",
                     "description": None,
                     "notes": [
-                        {"contents": "First note about the manuscript."},
-                        {"contents": "<p>Second note with <b>HTML</b>.</p>"},
+                        {"contents": ["First note about the manuscript."]},
+                        {"contents": ["<p>Second note with <b>HTML</b>.</p>"]},
                     ],
                     "production": [],
                     "languages": [{"id": "eng"}],
@@ -369,7 +381,7 @@ class TestNotesToRawText:
                     "title": "Combined Work",
                     "description": "A detailed description.",
                     "notes": [
-                        {"contents": "Additional context from notes."},
+                        {"contents": ["Additional context from notes."]},
                     ],
                     "production": [],
                     "languages": [{"id": "eng"}],
@@ -426,7 +438,7 @@ class TestNotesToRawText:
                     "id": "long1",
                     "title": "Long Work",
                     "description": None,
-                    "notes": [{"contents": long_note}],
+                    "notes": [{"contents": [long_note]}],
                     "production": [],
                     "languages": [{"id": "eng"}],
                 }


### PR DESCRIPTION
## Summary

- **Wellcome パースバグ修正**: `_strip_html()` が実 API の `list` 型 `notes[].contents` でクラッシュする問題を修正。テストモックも実 API 形式に修正
- **inventory 参照強制**: `save_structured_report` 実行前に `get_document_inventory` の呼び出しを必須化（`_inventory_consulted` フラグで検証）。全アーカイブの文書を確認せずに証拠選定するのを防止
- **証拠グラウンディング検証**: evidence の `source_url` を `raw_search_results` と照合し、メタデータを自動修正（LLM 転記ミス防止）。URL 不一致は警告（ハルシネーションの可能性）

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `mystery_agents/tools/wellcome_collection.py` | `_strip_html()` で `list` 型入力を安全に処理 |
| `mystery_agents/tools/document_inventory.py` | `_inventory_consulted` フラグセット追加 |
| `mystery_agents/tools/scholar_tools.py` | inventory 強制チェック + `_validate_evidence_grounding()` 追加 |
| `tests/unit/test_wellcome_collection.py` | list 型テスト追加 + モックを実 API 形式に修正 |
| `tests/unit/test_scholar_tools.py` | inventory 強制 + グラウンディング検証のテスト追加 |
| `tests/unit/test_document_inventory.py` | フラグセット検証テスト追加 |

## Test plan

- [x] `python -m pytest tests/unit/test_wellcome_collection.py -v` — 40 passed
- [x] `python -m pytest tests/unit/test_scholar_tools.py -v` — 30 passed
- [x] `python -m pytest tests/unit/test_document_inventory.py -v` — 11 passed
- [x] `python -m pytest tests/unit/ -v` — 全 1047 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)