### PR TITLE
fix: dynamicParams ランタイム式によるビルドエラー修正

### DIFF
--- a/web-public/src/app/[lang]/archive/[[...page]]/page.tsx
+++ b/web-public/src/app/[lang]/archive/[[...page]]/page.tsx
@@ -15,10 +15,6 @@ import type { SupportedLang } from "@/lib/i18n/config"
 import { getDictionary } from "@/lib/i18n/dictionaries"
 import { buildOgpMetadata, buildAlternates } from "@/lib/seo"
 
-// SSG: 本番ビルドではビルド時に生成されたページ以外は 404
-// dev モードでは Firestore 初回接続遅延による 404 を防ぐため動的レンダリングを許可
-export const dynamicParams = process.env.NODE_ENV === "production" ? false : true
-
 export async function generateStaticParams() {
   const mysteries = await getPublishedMysteries(1000)
   const totalPages = Math.max(1, Math.ceil(mysteries.length / ARCHIVE_PAGE_SIZE))

--- a/web-public/src/app/[lang]/mystery/[id]/page.tsx
+++ b/web-public/src/app/[lang]/mystery/[id]/page.tsx
@@ -28,10 +28,6 @@ import { extractHeadings } from "@/lib/markdown-headings"
 import { stripLeadingH1 } from "@ghost/shared/src/lib/utils"
 import type { TocSection } from "@/lib/toc-config"
 
-// SSG: 本番ビルドではビルド時に生成されたページ以外は 404
-// dev モードでは Firestore 初回接続遅延による 404 を防ぐため動的レンダリングを許可
-export const dynamicParams = process.env.NODE_ENV === "production" ? false : true
-
 export async function generateStaticParams() {
   let ids: string[]
   try {


### PR DESCRIPTION
## Summary

PR #317 で `dynamicParams` を `process.env.NODE_ENV === "production" ? false : true` に変更したが、Next.js は `dynamicParams` に**静的ブールリテラルのみ**を受け付けるためビルドエラーが発生。

## 根本分析

| 環境 | `output` 設定 | `dynamicParams = false` の効果 |
|------|----------|-------------------------------|
| **dev** (`next dev`) | なし（通常サーバー） | `generateStaticParams()` にないパラメータを 404 にする → Firestore 初回遅延で失敗 |
| **production** (`next build`) | `"export"` | SSG で全ページ事前生成、サーバーなし → 動的レンダリング不可能 |

本番では `output: "export"` がある時点でサーバーが存在せず、`generateStaticParams()` で生成されなかったパスは静的ファイルが存在しない = 自然に 404。`dynamicParams = false` は本番では**冗長**、dev では**有害**。

## 変更内容

- `web-public/src/app/[lang]/mystery/[id]/page.tsx`: `dynamicParams` 削除
- `web-public/src/app/[lang]/archive/[[...page]]/page.tsx`: `dynamicParams` 削除

`about/page.tsx` は Firestore 非依存（`SUPPORTED_LANGS` のみ使用）のため変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)