### PR TITLE
feat: Librarian 検索メトリクスの Firestore 永続化

### DIFF
--- a/shared/orchestrator.py
+++ b/shared/orchestrator.py
@@ -24,6 +24,7 @@ from google.genai import types
 from mystery_agents.agents.pipeline_gate import _is_meaningful
 from mystery_agents.utils.pipeline_logger import PipelineLogger
 from shared.logging_config import PipelineContext, set_pipeline_context
+from shared.search_metrics import extract_search_metrics, save_search_metrics
 from shared.pipeline_run import (
     create_pipeline_run,
     update_agent_started,
@@ -403,6 +404,12 @@ async def run_pipeline(
             # pipeline_log をセッション状態に保存
             if session:
                 session.state["pipeline_log"] = pipeline_logger.get_logs()
+
+            # 検索メトリクスの保存（Librarian の API ソース別統計）
+            # ゲート失敗時でも Librarian は動いた可能性があるので mystery_id 抽出より前に配置
+            if run_type == "blog":
+                search_metrics = extract_search_metrics(session_state)
+                save_search_metrics(run_id, search_metrics)
 
             # mystery_id 抽出（blog パイプラインのみ）
             mystery_id = None

--- a/shared/search_metrics.py
+++ b/shared/search_metrics.py
@@ -1,0 +1,183 @@
+"""Librarian 検索メトリクスの抽出・Firestore 永続化。
+
+セッション状態の raw_search_results / raw_search_results_{lang} から
+API ソース別の検索統計を抽出し、pipeline_runs ドキュメントに保存する。
+パイプライン終了後のデータ分析・改善に活用する。
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _extract_from_single_result(result: dict[str, Any]) -> dict[str, Any]:
+    """単一の検索結果エントリからメタデータを抽出する。
+
+    search_newspapers 形式と search_archives 形式の両方に対応。
+    mystery_agents/tools/search_metadata.py の同名関数と同一ロジック。
+    shared → mystery_agents の逆方向 import を避けるためインライン。
+
+    Returns:
+        per_api: api_name → {total_hits, documents_returned} の dict
+        errors: api_name → エラーメッセージ の dict
+        fallback_used: フォールバック検索が使用されたか
+    """
+    per_api: dict[str, dict[str, int]] = {}
+    errors: dict[str, str] = {}
+    fallback_used = False
+
+    # search_newspapers 形式: source フィールドで API を識別
+    source = result.get("source")
+    if source and source != "none":
+        per_api[source] = {
+            "total_hits": result.get("total_hits", 0),
+            "documents_returned": result.get("documents_returned", 0),
+        }
+        if result.get("error"):
+            errors[source] = result["error"]
+
+    # search_archives 形式: sources_searched dict で各 API の統計を取得
+    sources_searched = result.get("sources_searched")
+    if sources_searched and isinstance(sources_searched, dict):
+        for api_key, stats in sources_searched.items():
+            if isinstance(stats, dict):
+                per_api[api_key] = {
+                    "total_hits": stats.get("total_hits", 0),
+                    "documents_returned": stats.get("documents_returned", 0),
+                }
+
+    # search_archives のエラー情報
+    result_errors = result.get("errors")
+    if result_errors and isinstance(result_errors, dict):
+        errors.update(result_errors)
+
+    # fallback_used
+    if result.get("fallback_used"):
+        fallback_used = True
+
+    return {
+        "per_api": per_api,
+        "errors": errors,
+        "fallback_used": fallback_used,
+    }
+
+
+def extract_search_metrics(session_state: dict) -> dict | None:
+    """セッション状態から検索メトリクスを抽出する。
+
+    raw_search_results（ベースキー: 新聞検索等）と
+    raw_search_results_{lang}（言語別アーカイブ検索）を走査し、
+    コンパクトなメトリクス dict を返す。
+
+    Args:
+        session_state: パイプラインのセッション状態 dict
+
+    Returns:
+        検索メトリクス dict、データなしなら None
+    """
+    # raw_search_results と raw_search_results_{lang} を収集
+    all_results: list[tuple[str, list]] = []
+
+    # ベースキー（新聞検索等）
+    base_results = session_state.get("raw_search_results")
+    if base_results and isinstance(base_results, list):
+        all_results.append(("newspapers", base_results))
+
+    # 言語別キー
+    languages: list[str] = []
+    for key in list(session_state.keys()):
+        if key.startswith("raw_search_results_") and key != "raw_search_results":
+            lang = key.replace("raw_search_results_", "")
+            lang_results = session_state.get(key)
+            if lang_results and isinstance(lang_results, list):
+                all_results.append((lang, lang_results))
+                languages.append(lang)
+
+    if not all_results:
+        return None
+
+    # 言語別 × API 別の内訳
+    by_language: dict[str, dict[str, dict[str, int]]] = {}
+    # 全言語横断の API 集約
+    by_api: dict[str, dict[str, int]] = {}
+    all_errors: dict[str, str] = {}
+    any_fallback = False
+    total_documents = 0
+
+    for label, results_list in all_results:
+        lang_apis: dict[str, dict[str, int]] = {}
+
+        for result in results_list:
+            if not isinstance(result, dict):
+                continue
+            extracted = _extract_from_single_result(result)
+
+            for api_name, stats in extracted["per_api"].items():
+                # 言語別集約
+                if api_name in lang_apis:
+                    lang_apis[api_name]["total_hits"] += stats["total_hits"]
+                    lang_apis[api_name]["documents_returned"] += stats["documents_returned"]
+                else:
+                    lang_apis[api_name] = dict(stats)
+
+                # 全言語横断集約
+                if api_name in by_api:
+                    by_api[api_name]["total_hits"] += stats["total_hits"]
+                    by_api[api_name]["documents_returned"] += stats["documents_returned"]
+                else:
+                    by_api[api_name] = dict(stats)
+
+            all_errors.update(extracted["errors"])
+            if extracted["fallback_used"]:
+                any_fallback = True
+
+        if lang_apis:
+            by_language[label] = lang_apis
+            total_documents += sum(
+                s["documents_returned"] for s in lang_apis.values()
+            )
+
+    metrics: dict[str, Any] = {
+        "languages": sorted(languages),
+        "total_documents": total_documents,
+        "by_language": by_language,
+        "by_api": by_api,
+    }
+    if all_errors:
+        metrics["errors"] = all_errors
+    if any_fallback:
+        metrics["fallback_used"] = True
+
+    return metrics
+
+
+def save_search_metrics(run_id: str | None, metrics: dict | None) -> None:
+    """検索メトリクスを pipeline_runs ドキュメントに保存する（非ブロッキング）。
+
+    Args:
+        run_id: パイプライン実行ドキュメントの ID
+        metrics: extract_search_metrics() の戻り値。None なら何もしない。
+    """
+    if not run_id or metrics is None:
+        return
+    try:
+        from shared.firestore import get_firestore_client
+
+        db = get_firestore_client()
+        db.collection("pipeline_runs").document(run_id).update({
+            "search_metrics": metrics,
+            "updated_at": datetime.now(timezone.utc),
+        })
+        logger.info(
+            "検索メトリクス保存: %s (API数=%d, 文書数=%d)",
+            run_id,
+            len(metrics.get("by_api", {})),
+            metrics.get("total_documents", 0),
+        )
+    except Exception:
+        # メトリクス保存失敗はパイプラインをブロックしない
+        logger.warning("Failed to save search metrics to Firestore", exc_info=True)

--- a/shared/state_registry.py
+++ b/shared/state_registry.py
@@ -51,13 +51,13 @@ STATE_KEYS: list[StateKey] = [
         name="raw_search_results",
         description="Librarian ツールが直接書き込む検索結果リスト（ベースキー）",
         written_by=("librarian_tools",),
-        read_by=("search_metadata",),
+        read_by=("search_metadata", "search_metrics"),
     ),
     StateKey(
         name="raw_search_results_{lang}",
         description="Librarian ツールが直接書き込む検索結果リスト（言語別）",
         written_by=("librarian_tools",),
-        read_by=("search_metadata",),
+        read_by=("search_metadata", "search_metrics"),
     ),
     StateKey(
         name="scholar_analysis_{lang}",

--- a/tests/unit/test_search_metrics.py
+++ b/tests/unit/test_search_metrics.py
@@ -1,0 +1,302 @@
+"""Tests for Librarian search metrics extraction and Firestore persistence."""
+
+from unittest.mock import MagicMock, patch
+
+from shared.search_metrics import (
+    _extract_from_single_result,
+    extract_search_metrics,
+    save_search_metrics,
+)
+
+
+class TestExtractFromSingleResult:
+    """_extract_from_single_result のテスト。"""
+
+    def test_newspaper_format(self):
+        """search_newspapers 形式の結果を正しくパースする。"""
+        result = {
+            "source": "chronicling_america",
+            "total_hits": 50,
+            "documents_returned": 8,
+        }
+        extracted = _extract_from_single_result(result)
+
+        assert extracted["per_api"] == {
+            "chronicling_america": {"total_hits": 50, "documents_returned": 8},
+        }
+        assert extracted["errors"] == {}
+        assert extracted["fallback_used"] is False
+
+    def test_archive_format(self):
+        """search_archives 形式の結果を正しくパースする。"""
+        result = {
+            "sources_searched": {
+                "loc": {"total_hits": 150, "documents_returned": 5},
+                "dpla": {"total_hits": 30, "documents_returned": 3},
+            },
+        }
+        extracted = _extract_from_single_result(result)
+
+        assert extracted["per_api"]["loc"] == {"total_hits": 150, "documents_returned": 5}
+        assert extracted["per_api"]["dpla"] == {"total_hits": 30, "documents_returned": 3}
+
+    def test_error_extraction(self):
+        """エラー情報を正しく抽出する。"""
+        result = {
+            "source": "chronicling_america",
+            "total_hits": 0,
+            "documents_returned": 0,
+            "error": "API timeout",
+        }
+        extracted = _extract_from_single_result(result)
+
+        assert extracted["errors"] == {"chronicling_america": "API timeout"}
+
+    def test_archive_errors(self):
+        """search_archives 形式のエラー情報を抽出する。"""
+        result = {
+            "sources_searched": {
+                "loc": {"total_hits": 10, "documents_returned": 2},
+            },
+            "errors": {"dpla": "API key not set"},
+        }
+        extracted = _extract_from_single_result(result)
+
+        assert extracted["errors"] == {"dpla": "API key not set"}
+
+    def test_fallback_used(self):
+        """fallback_used フラグを検出する。"""
+        result = {
+            "source": "chronicling_america",
+            "total_hits": 5,
+            "documents_returned": 5,
+            "fallback_used": True,
+        }
+        extracted = _extract_from_single_result(result)
+
+        assert extracted["fallback_used"] is True
+
+    def test_empty_result(self):
+        """空の結果を安全にパースする。"""
+        extracted = _extract_from_single_result({})
+
+        assert extracted["per_api"] == {}
+        assert extracted["errors"] == {}
+        assert extracted["fallback_used"] is False
+
+    def test_source_none_is_ignored(self):
+        """source が "none" の場合は無視する。"""
+        result = {"source": "none", "total_hits": 0, "documents_returned": 0}
+        extracted = _extract_from_single_result(result)
+
+        assert extracted["per_api"] == {}
+
+
+class TestExtractSearchMetrics:
+    """extract_search_metrics のテスト。"""
+
+    def test_empty_state_returns_none(self):
+        """セッション状態が空なら None を返す。"""
+        assert extract_search_metrics({}) is None
+
+    def test_no_raw_search_results_returns_none(self):
+        """raw_search_results キーがなければ None を返す。"""
+        state = {"creative_content": "some content"}
+        assert extract_search_metrics(state) is None
+
+    def test_single_language(self):
+        """単一言語の検索結果を正しく集約する。"""
+        state = {
+            "raw_search_results_en": [
+                {
+                    "sources_searched": {
+                        "loc": {"total_hits": 150, "documents_returned": 5},
+                        "dpla": {"total_hits": 30, "documents_returned": 3},
+                    },
+                },
+            ],
+        }
+        metrics = extract_search_metrics(state)
+
+        assert metrics is not None
+        assert metrics["languages"] == ["en"]
+        assert metrics["total_documents"] == 8
+        assert metrics["by_language"]["en"]["loc"] == {"total_hits": 150, "documents_returned": 5}
+        assert metrics["by_api"]["loc"] == {"total_hits": 150, "documents_returned": 5}
+        assert metrics["by_api"]["dpla"] == {"total_hits": 30, "documents_returned": 3}
+
+    def test_multiple_languages(self):
+        """複数言語の検索結果を by_language と by_api に正しく集約する。"""
+        state = {
+            "raw_search_results_en": [
+                {
+                    "sources_searched": {
+                        "loc": {"total_hits": 100, "documents_returned": 5},
+                    },
+                },
+            ],
+            "raw_search_results_de": [
+                {
+                    "sources_searched": {
+                        "ddb": {"total_hits": 12, "documents_returned": 7},
+                        "europeana": {"total_hits": 8, "documents_returned": 5},
+                    },
+                },
+            ],
+        }
+        metrics = extract_search_metrics(state)
+
+        assert metrics is not None
+        assert sorted(metrics["languages"]) == ["de", "en"]
+        assert metrics["total_documents"] == 17
+
+        # by_language
+        assert "en" in metrics["by_language"]
+        assert "de" in metrics["by_language"]
+        assert metrics["by_language"]["en"]["loc"]["documents_returned"] == 5
+        assert metrics["by_language"]["de"]["ddb"]["documents_returned"] == 7
+
+        # by_api（全言語横断集約）
+        assert metrics["by_api"]["loc"]["total_hits"] == 100
+        assert metrics["by_api"]["ddb"]["total_hits"] == 12
+        assert metrics["by_api"]["europeana"]["total_hits"] == 8
+
+    def test_base_key_as_newspapers(self):
+        """ベースキー raw_search_results は "newspapers" ラベルで by_language に入る。"""
+        state = {
+            "raw_search_results": [
+                {
+                    "source": "chronicling_america",
+                    "total_hits": 50,
+                    "documents_returned": 8,
+                },
+            ],
+        }
+        metrics = extract_search_metrics(state)
+
+        assert metrics is not None
+        assert "newspapers" in metrics["by_language"]
+        assert metrics["by_language"]["newspapers"]["chronicling_america"]["documents_returned"] == 8
+        assert metrics["by_api"]["chronicling_america"]["total_hits"] == 50
+        # ベースキーは languages リストに含まれない
+        assert metrics["languages"] == []
+
+    def test_by_api_cross_language_aggregation(self):
+        """同じ API が複数言語で使われた場合、by_api では合算される。"""
+        state = {
+            "raw_search_results_en": [
+                {
+                    "sources_searched": {
+                        "europeana": {"total_hits": 20, "documents_returned": 3},
+                    },
+                },
+            ],
+            "raw_search_results_de": [
+                {
+                    "sources_searched": {
+                        "europeana": {"total_hits": 15, "documents_returned": 5},
+                    },
+                },
+            ],
+        }
+        metrics = extract_search_metrics(state)
+
+        assert metrics["by_api"]["europeana"] == {"total_hits": 35, "documents_returned": 8}
+        # by_language では言語ごとの値
+        assert metrics["by_language"]["en"]["europeana"]["total_hits"] == 20
+        assert metrics["by_language"]["de"]["europeana"]["total_hits"] == 15
+
+    def test_errors_collected(self):
+        """エラー情報がメトリクスに含まれる。"""
+        state = {
+            "raw_search_results_en": [
+                {
+                    "sources_searched": {
+                        "loc": {"total_hits": 10, "documents_returned": 2},
+                    },
+                    "errors": {"dpla": "API key not set"},
+                },
+            ],
+        }
+        metrics = extract_search_metrics(state)
+
+        assert metrics["errors"] == {"dpla": "API key not set"}
+
+    def test_fallback_used_flag(self):
+        """fallback_used フラグがメトリクスに含まれる。"""
+        state = {
+            "raw_search_results_en": [
+                {
+                    "sources_searched": {
+                        "loc": {"total_hits": 5, "documents_returned": 5},
+                    },
+                    "fallback_used": True,
+                },
+            ],
+        }
+        metrics = extract_search_metrics(state)
+
+        assert metrics["fallback_used"] is True
+
+    def test_non_dict_results_ignored(self):
+        """リスト内の非 dict エントリは無視する。"""
+        state = {
+            "raw_search_results_en": [
+                "invalid_entry",
+                {
+                    "sources_searched": {
+                        "loc": {"total_hits": 10, "documents_returned": 2},
+                    },
+                },
+            ],
+        }
+        metrics = extract_search_metrics(state)
+
+        assert metrics is not None
+        assert metrics["by_api"]["loc"]["documents_returned"] == 2
+
+
+class TestSaveSearchMetrics:
+    """save_search_metrics のテスト。"""
+
+    def test_saves_to_firestore(self, mock_firestore_client):
+        """pipeline_runs ドキュメントに search_metrics を書き込む。"""
+        metrics = {
+            "languages": ["en"],
+            "total_documents": 8,
+            "by_language": {"en": {"loc": {"total_hits": 150, "documents_returned": 5}}},
+            "by_api": {"loc": {"total_hits": 150, "documents_returned": 5}},
+        }
+
+        with patch("shared.firestore.get_firestore_client", return_value=mock_firestore_client):
+            save_search_metrics("run-123", metrics)
+
+        mock_firestore_client.collection.assert_called_with("pipeline_runs")
+        mock_firestore_client.collection().document.assert_called_with("run-123")
+        mock_firestore_client.collection().document().update.assert_called_once()
+
+        call_args = mock_firestore_client.collection().document().update.call_args
+        data = call_args[0][0]
+        assert data["search_metrics"] == metrics
+        assert "updated_at" in data
+
+    def test_none_metrics_returns_early(self):
+        """metrics が None なら Firestore に書き込まない。"""
+        with patch("shared.firestore.get_firestore_client") as mock_get:
+            save_search_metrics("run-123", None)
+            mock_get.assert_not_called()
+
+    def test_none_run_id_returns_early(self):
+        """run_id が None なら Firestore に書き込まない。"""
+        with patch("shared.firestore.get_firestore_client") as mock_get:
+            save_search_metrics(None, {"total_documents": 5})
+            mock_get.assert_not_called()
+
+    def test_does_not_raise_on_firestore_error(self):
+        """Firestore エラー時に例外を投げない（非ブロッキング）。"""
+        mock_client = MagicMock()
+        mock_client.collection.side_effect = Exception("Firestore unavailable")
+
+        with patch("shared.firestore.get_firestore_client", return_value=mock_client):
+            # 例外が発生しないことを確認
+            save_search_metrics("run-123", {"total_documents": 5})


### PR DESCRIPTION
## Summary

- Librarian が各アーカイブ API から取得した資料数を、パイプライン実行ごとに Firestore `pipeline_runs` ドキュメントの `search_metrics` フィールドに永続化
- `raw_search_results` / `raw_search_results_{lang}` セッション状態から言語別×API別の内訳（`by_language`）と全言語横断の集約（`by_api`）を抽出
- メトリクス保存は非ブロッキング（失敗してもパイプラインを止めない）

## 変更内容

- `shared/search_metrics.py` — メトリクス抽出 + Firestore 保存モジュール（新規）
- `shared/orchestrator.py` — blog パイプライン完了時に `extract_search_metrics` → `save_search_metrics` を呼び出し
- `shared/state_registry.py` — `raw_search_results` / `raw_search_results_{lang}` の `read_by` に `search_metrics` 追加
- `tests/unit/test_search_metrics.py` — 20 テスト追加

## Firestore ドキュメント例

```json
{
  "search_metrics": {
    "languages": ["de", "en"],
    "total_documents": 25,
    "by_language": {
      "en": { "loc": { "total_hits": 150, "documents_returned": 5 } },
      "de": { "ddb": { "total_hits": 12, "documents_returned": 7 } }
    },
    "by_api": {
      "loc": { "total_hits": 150, "documents_returned": 5 },
      "ddb": { "total_hits": 12, "documents_returned": 7 }
    },
    "errors": { "dpla": "API key not set" },
    "fallback_used": true
  }
}
```

## Test plan

- [x] 新規テスト 20 件全パス
- [x] 既存テスト 1067 件全パス（回帰なし）
- [ ] 実環境でパイプライン実行後、Firestore Console で `pipeline_runs/{run_id}.search_metrics` を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)