### PR TITLE
fix: 背景透過処理の成否メタデータ修正（_remove_background 戻り値を tuple 化）

### DIFF
--- a/alchemist_agents/tools/render_tools.py
+++ b/alchemist_agents/tools/render_tools.py
@@ -24,13 +24,14 @@ PRODUCT_ASPECT_RATIOS = {
 }
 
 
-def _remove_background(filepath: str) -> str:
+def _remove_background(filepath: str) -> tuple[str, bool]:
     """Imagen Edit API でマゼンタ背景置換 → PIL クロマキーで透過 PNG に変換する。
 
     処理フロー:
     1. Imagen Edit API (MASK_MODE_BACKGROUND + EDIT_MODE_BGSWAP) で背景をマゼンタに置換
     2. PIL で マゼンタ (#FF00FF) ピクセルを透明化（閾値処理でアンチエイリアス保全）
     3. 透過 PNG を上書き保存
+    4. 透過ピクセルが実際に存在するか検証
 
     エラー時は元の不透過画像パスをそのまま返す（フェイルオープン）。
 
@@ -38,7 +39,7 @@ def _remove_background(filepath: str) -> str:
         filepath: 元画像の絶対パス。
 
     Returns:
-        透過 PNG のパス（成功時は同じパス、失敗時も同じパス）。
+        (パス, 透過成功フラグ) のタプル。成功時は (filepath, True)、失敗時は (filepath, False)。
     """
     try:
         from google import genai
@@ -88,7 +89,7 @@ def _remove_background(filepath: str) -> str:
 
         if not response.generated_images:
             logger.warning("背景置換: 生成画像なし、元画像を維持: %s", filepath)
-            return filepath
+            return filepath, False
 
         # 生成画像を取得
         edited_bytes = response.generated_images[0].image.image_bytes
@@ -107,12 +108,18 @@ def _remove_background(filepath: str) -> str:
         result = PILImage.fromarray(data)
         result.save(filepath, "PNG")
 
-        logger.info("背景透過完了: %s", filepath)
-        return filepath
+        # 透過ピクセルが実際に存在するか検証
+        transparent_count = int(np.sum(data[:, :, 3] == 0))
+        if transparent_count == 0:
+            logger.warning("背景透過: 透過ピクセルなし、背景除去は無効: %s", filepath)
+            return filepath, False
+
+        logger.info("背景透過完了: %s (透過ピクセル数: %d)", filepath, transparent_count)
+        return filepath, True
 
     except Exception as e:
         logger.warning("背景透過処理に失敗、元画像を維持: %s — %s", filepath, e)
-        return filepath
+        return filepath, False
 
 
 def generate_design_asset(
@@ -188,8 +195,8 @@ def generate_design_asset(
     # 背景透過処理（生成成功時のみ）
     if result.get("status") == "success" and result.get("filepath"):
         original_path = result["filepath"]
-        result["filepath"] = _remove_background(original_path)
-        result["transparent_background"] = True
+        result["filepath"], bg_removed = _remove_background(original_path)
+        result["transparent_background"] = bg_removed
 
     # セッション状態に累積保存
     if tool_context is not None:

--- a/tests/unit/test_render_tools.py
+++ b/tests/unit/test_render_tools.py
@@ -225,9 +225,10 @@ class TestRemoveBackground:
     """Tests for _remove_background()."""
 
     def test_returns_original_path_on_error(self):
-        """ファイルが存在しない場合、元のパスをフォールバックで返す。"""
-        result = _remove_background("/nonexistent/path.png")
-        assert result == "/nonexistent/path.png"
+        """ファイルが存在しない場合、元のパスと False をフォールバックで返す。"""
+        path, success = _remove_background("/nonexistent/path.png")
+        assert path == "/nonexistent/path.png"
+        assert success is False
 
     @patch("google.genai.Client")
     def test_replaces_magenta_with_transparency(self, mock_client_cls, tmp_path):
@@ -260,9 +261,10 @@ class TestRemoveBackground:
         mock_client.models.edit_image.return_value = mock_response
         mock_client_cls.return_value = mock_client
 
-        result = _remove_background(filepath)
+        path, success = _remove_background(filepath)
 
-        assert result == filepath
+        assert path == filepath
+        assert success is True
 
         # 結果画像を検証
         result_img = PILImage.open(filepath).convert("RGBA")
@@ -288,9 +290,10 @@ class TestRemoveBackground:
         mock_client.models.edit_image.return_value = mock_response
         mock_client_cls.return_value = mock_client
 
-        result = _remove_background(filepath)
+        path, success = _remove_background(filepath)
 
-        assert result == filepath
+        assert path == filepath
+        assert success is False
 
     @patch(_PATCH_GENERATE_IMAGE)
     @patch("alchemist_agents.tools.render_tools._remove_background")
@@ -300,7 +303,7 @@ class TestRemoveBackground:
             "status": "success",
             "filepath": "/tmp/test.png",
         })
-        mock_remove_bg.return_value = "/tmp/test.png"
+        mock_remove_bg.return_value = ("/tmp/test.png", True)
 
         result_json = generate_design_asset(
             prompt="Test", product_type="tshirt",
@@ -322,3 +325,52 @@ class TestRemoveBackground:
         generate_design_asset(prompt="Test", product_type="tshirt")
 
         mock_remove_bg.assert_not_called()
+
+    @patch(_PATCH_GENERATE_IMAGE)
+    @patch("alchemist_agents.tools.render_tools._remove_background")
+    def test_transparent_background_false_when_removal_fails(self, mock_remove_bg, mock_gen):
+        """背景透過に失敗した場合、transparent_background が False になる。"""
+        mock_gen.return_value = json.dumps({
+            "status": "success",
+            "filepath": "/tmp/test.png",
+        })
+        mock_remove_bg.return_value = ("/tmp/test.png", False)
+
+        result_json = generate_design_asset(
+            prompt="Test", product_type="tshirt",
+        )
+        result = json.loads(result_json)
+
+        mock_remove_bg.assert_called_once_with("/tmp/test.png")
+        assert result["transparent_background"] is False
+
+    @patch("google.genai.Client")
+    def test_returns_false_when_no_transparent_pixels(self, mock_client_cls, tmp_path):
+        """マゼンタなし画像では透過ピクセルが0で False を返す。"""
+        from PIL import Image as PILImage
+        import io
+
+        # マゼンタを含まない画像（全面赤）
+        img = PILImage.new("RGB", (10, 10), (255, 0, 0))
+        filepath = str(tmp_path / "no_magenta.png")
+        img.save(filepath, "PNG")
+
+        # Edit API が返す画像もマゼンタなし（同じ赤画像）
+        buf = io.BytesIO()
+        img.save(buf, "PNG")
+        edited_bytes = buf.getvalue()
+
+        mock_image = MagicMock()
+        mock_image.image_bytes = edited_bytes
+
+        mock_response = MagicMock()
+        mock_response.generated_images = [MagicMock(image=mock_image)]
+
+        mock_client = MagicMock()
+        mock_client.models.edit_image.return_value = mock_response
+        mock_client_cls.return_value = mock_client
+
+        path, success = _remove_background(filepath)
+
+        assert path == filepath
+        assert success is False


### PR DESCRIPTION
## Summary

- `_remove_background()` が成功・失敗に関わらず同じパスを返し、`generate_design_asset()` が常に `transparent_background = True` をセットしていたバグを修正
- 戻り値を `str` → `tuple[str, bool]` に変更し、透過ピクセル存在検証ステップを追加
- フェイルオープン動作は維持（パイプラインは壊れない）

## Test plan

- [x] `test_render_tools.py` 全 21 テスト合格（既存 19 + 新規 2）
- [x] 全ユニットテスト 1049 件合格（回帰なし）
- [ ] 実環境での Imagen Edit API 背景透過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)