### PR TITLE
アーカイブ画像: セクション4追加 + 原寸大表示 + URL重複排除

### DIFF
--- a/mystery_agents/agents/storyteller.py
+++ b/mystery_agents/agents/storyteller.py
@@ -126,11 +126,11 @@ load_dotenv(Path(__file__).parent.parent / ".env")
 # 各エントリには title, source_url, thumbnail_url, image_url, source_type, date が含まれる。
 #
 # ### ルール
-# 1. ナラティブのセクション1〜3に最も関連する画像を最大3枚選ぶ。
-# 2. 各画像はそのセクションの末尾、次の ## 見出しの直前に配置する。
+# 1. ナラティブのセクション1〜4に最も関連する画像を最大4枚選ぶ。
+# 2. 各画像はそのセクションの末尾、次の ## 見出しの直前（またはドキュメント末尾）に配置する。
 # 3. Markdown 画像構文を使用: ![説明的なキャプション — Source: アーカイブ名](url)
 # 4. thumbnail_url があればそれを使い、なければ image_url を使う。どちらもないエントリはスキップ。
-# 5. セクション4（結び）には画像を配置しない。
+# 5. 同じURLの画像を複数回使用しない。ユニークな画像が不足する場合は無理に配置しない。
 # 6. {archive_images} が空または使える画像がない場合、画像なしで通常通り記事を書く。
 # 7. URL を捏造しない。{archive_images} のURLのみを使用する。
 # 8. 視覚的多様性のため、異なるアーカイブの画像を優先する。
@@ -309,11 +309,11 @@ Real archival images from the digital archives are available in {archive_images}
 Each entry contains: title, source_url, thumbnail_url, image_url, source_type, date.
 
 ### Rules
-1. Select up to 3 images most relevant to sections 1-3 of your narrative.
-2. Place each image at the END of its section, just BEFORE the next ## heading.
+1. Select up to 4 images most relevant to sections 1-4 of your narrative.
+2. Place each image at the END of its section, just BEFORE the next ## heading (or at the end of the document for section 4).
 3. Use Markdown image syntax: ![descriptive caption — Source: Archive Name](url)
 4. Use thumbnail_url if available; otherwise image_url. Skip entries with neither.
-5. Do NOT place images in section 4 (Conclusion).
+5. Do NOT use the same image URL more than once. If fewer unique images are available than sections, leave some sections without images.
 6. If {archive_images} is empty or has no usable images, write normally without images.
 7. NEVER fabricate URLs. Only use URLs from {archive_images}.
 8. Prefer images from different archives for visual variety.

--- a/packages/shared/src/lib/normalize-image-placement.ts
+++ b/packages/shared/src/lib/normalize-image-placement.ts
@@ -2,30 +2,44 @@
  * Markdown テキスト内の画像行をプログラム的に各セクション末尾に再配置する。
  *
  * Storyteller が出力した画像（![alt](url)）の位置に依存せず、
- * H2 セクション 1〜3 の末尾に最大1枚ずつ均等配置する。
- * セクション4（結び）には画像を配置しない。
+ * H2 セクション 1〜4 の末尾に最大1枚ずつ均等配置する（最大4枚）。
+ * 同一 URL の画像は重複排除し、ユニークな画像のみ配置する。
  */
 
 /** 行頭が `![` で始まる独立した画像行にマッチ */
 const IMAGE_LINE_RE = /^!\[.*?\]\(.*?\)\s*$/
 
+/** 画像行から URL を抽出する */
+const IMAGE_URL_RE = /!\[.*?\]\((.*?)\)/
+
 export function normalizeImagePlacement(markdown: string): string {
   const lines = markdown.split("\n")
 
   // 1. 全画像行を抽出し、元の位置から除去
-  const images: string[] = []
+  const rawImages: string[] = []
   const filteredLines: string[] = []
 
   for (const line of lines) {
     if (IMAGE_LINE_RE.test(line)) {
-      images.push(line.trim())
+      rawImages.push(line.trim())
     } else {
       filteredLines.push(line)
     }
   }
 
   // 画像がなければそのまま返す
-  if (images.length === 0) return markdown
+  if (rawImages.length === 0) return markdown
+
+  // URL ベースの重複排除
+  const seenUrls = new Set<string>()
+  const images: string[] = []
+  for (const img of rawImages) {
+    const match = IMAGE_URL_RE.exec(img)
+    const url = match?.[1] ?? ""
+    if (url && seenUrls.has(url)) continue
+    if (url) seenUrls.add(url)
+    images.push(img)
+  }
 
   // 2. H2 見出しの行インデックスを特定
   const h2Indices: number[] = []
@@ -40,14 +54,16 @@ export function normalizeImagePlacement(markdown: string): string {
     return filteredLines.join("\n").replace(/\n{3,}/g, "\n\n")
   }
 
-  // 3. セクション1〜3の末尾（= 次の H2 の直前）に画像を1枚ずつ挿入
-  // 最後のセクション（結び）には入れない
-  const placementSlots = Math.min(h2Indices.length - 1, 3)
+  // 3. セクション1〜4の末尾に画像を1枚ずつ挿入（最大4枚）
+  // 最終セクション（次の H2 なし）はドキュメント末尾に挿入
+  const placementSlots = Math.min(h2Indices.length, 4)
   const imageCount = Math.min(images.length, placementSlots)
 
   // 後ろから挿入してインデックスのずれを防ぐ
   for (let i = imageCount - 1; i >= 0; i--) {
-    const insertBefore = h2Indices[i + 1]
+    const insertBefore = (i + 1 < h2Indices.length)
+      ? h2Indices[i + 1]
+      : filteredLines.length
     filteredLines.splice(insertBefore, 0, "", images[i], "")
   }
 

--- a/web-admin/src/app/(main)/preview/[id]/preview-content.tsx
+++ b/web-admin/src/app/(main)/preview/[id]/preview-content.tsx
@@ -40,14 +40,14 @@ function PreviewArchiveImage({ src, alt }: { src?: string; alt?: string }) {
   const [hasError, setHasError] = useState(false)
   if (!src || hasError) return null
   return (
-    <figure className="not-prose my-8 mx-auto max-w-xl">
+    <figure className="not-prose my-8 mx-auto w-fit max-w-3xl">
       <div className="aged-card letterpress-border rounded-sm overflow-hidden">
         <img
           src={src}
           alt={alt || "Archival Image"}
           loading="lazy"
           onError={() => setHasError(true)}
-          className="w-full h-auto"
+          className="h-auto max-w-full"
         />
       </div>
       {alt && (

--- a/web-public/src/components/mystery/archive-image.tsx
+++ b/web-public/src/components/mystery/archive-image.tsx
@@ -27,14 +27,14 @@ export function ArchiveImage({ src, alt, lang }: ArchiveImageProps) {
   const label = IMAGE_LABEL[lang] || IMAGE_LABEL.en
 
   return (
-    <figure className="not-prose my-8 mx-auto max-w-xl">
+    <figure className="not-prose my-8 mx-auto w-fit max-w-3xl">
       <div className="aged-card letterpress-border rounded-sm overflow-hidden">
         <img
           src={src}
           alt={alt || label}
           loading="lazy"
           onError={() => setHasError(true)}
-          className="w-full h-auto"
+          className="h-auto max-w-full"
         />
       </div>
       {alt && (


### PR DESCRIPTION
## Summary

- **normalize-image-placement.ts**: セクション1〜4に最大4枚配置（従来は1〜3の3枚まで）+ URL ベースの重複排除
- **storyteller.py**: Storyteller プロンプトを最大4枚・重複禁止に更新（日本語コメント + 英語 instruction 両方）
- **archive-image.tsx / preview-content.tsx**: `w-fit` + `max-w-3xl` で原寸大表示（小さい画像は拡大せず、大きい画像は 768px 上限）

## Test plan

- [ ] 公開済み記事を web-public で確認し、セクション4にも画像が配置されることを確認
- [ ] 小さい画像（< 400px 幅）が原寸表示されることを確認
- [ ] 大きい画像が 768px を超えないことを確認
- [ ] 同一 URL の画像が複数配置されないことを確認
- [ ] 画像3枚以下の記事で、存在する分だけ配置されることを確認
- [ ] web-admin プレビューでも同じ表示になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)