### PR TITLE
fix: 背景透過処理のスタイル適応型クロマキー色選択（リトライ付き）

### DIFF
--- a/alchemist_agents/tools/render_tools.py
+++ b/alchemist_agents/tools/render_tools.py
@@ -17,6 +17,29 @@ from google.adk.tools.tool_context import ToolContext
 
 logger = logging.getLogger(__name__)
 
+# クロマキー色定義
+CHROMA_COLORS = {
+    "green": {
+        "prompt": "solid bright green screen background #00FF00, chroma key green, uniform flat color",
+        "detect": lambda r, g, b: (r < 50) & (g > 200) & (b < 50),
+    },
+    "blue": {
+        "prompt": "solid bright blue screen background #0000FF, chroma key blue, uniform flat color",
+        "detect": lambda r, g, b: (r < 50) & (g < 50) & (b > 200),
+    },
+    "magenta": {
+        "prompt": "solid pure magenta #FF00FF background, uniform flat color",
+        "detect": lambda r, g, b: (r > 200) & (g < 50) & (b > 200),
+    },
+}
+
+# スタイル → クロマキー色の優先順（最大2回試行）
+STYLE_CHROMA_ORDER = {
+    "folklore": ["green", "blue"],     # 木版画・イラスト系はグリーンバック優先
+    "fact": ["magenta", "green"],      # 写真・アーカイブ系はマゼンタ優先
+    "auto": ["magenta", "green"],      # デフォルト
+}
+
 # product_type → aspect_ratio のマッピング
 PRODUCT_ASPECT_RATIOS = {
     "tshirt": "1:1",
@@ -24,19 +47,25 @@ PRODUCT_ASPECT_RATIOS = {
 }
 
 
-def _remove_background(filepath: str) -> tuple[str, bool]:
-    """Imagen Edit API でマゼンタ背景置換 → PIL クロマキーで透過 PNG に変換する。
+def _remove_background(filepath: str, style: str = "auto", region: str = "EU") -> tuple[str, bool]:
+    """Imagen Edit API でクロマキー背景置換 → PIL で透過 PNG に変換する。
+
+    スタイルに応じてクロマキー色を選択し、最大2色まで試行する。
 
     処理フロー:
-    1. Imagen Edit API (MASK_MODE_BACKGROUND + EDIT_MODE_BGSWAP) で背景をマゼンタに置換
-    2. PIL で マゼンタ (#FF00FF) ピクセルを透明化（閾値処理でアンチエイリアス保全）
-    3. 透過 PNG を上書き保存
-    4. 透過ピクセルが実際に存在するか検証
+    1. スタイルからクロマキー色の優先順を決定
+    2. 各色について:
+       a. Imagen Edit API (MASK_MODE_BACKGROUND + EDIT_MODE_BGSWAP) で背景を置換
+       b. PIL でクロマキー色ピクセルを透明化（閾値処理でアンチエイリアス保全）
+       c. 透過ピクセルが存在すれば成功、なければ次の色へリトライ
+    3. 全色失敗 → 元画像を維持
 
     エラー時は元の不透過画像パスをそのまま返す（フェイルオープン）。
 
     Args:
         filepath: 元画像の絶対パス。
+        style: 画像スタイル — "folklore" / "fact" / "auto"。
+        region: ISO 3166-1 alpha-2 国コード（未使用、将来拡張用）。
 
     Returns:
         (パス, 透過成功フラグ) のタプル。成功時は (filepath, True)、失敗時は (filepath, False)。
@@ -46,6 +75,7 @@ def _remove_background(filepath: str) -> tuple[str, bool]:
         from google.genai import types
         from PIL import Image as PILImage
         import numpy as np
+        import io
 
         # genai クライアント取得（illustrator_tools と同じロジック）
         if os.environ.get("GOOGLE_GENAI_USE_VERTEXAI", "").upper() == "TRUE":
@@ -77,45 +107,60 @@ def _remove_background(filepath: str) -> tuple[str, bool]:
             ),
         )
 
-        # Imagen Edit API で背景をマゼンタに置換
-        response = client.models.edit_image(
-            model="imagen-3.0-capability-001",
-            prompt="solid pure magenta #FF00FF background, uniform flat color",
-            reference_images=[raw_ref, mask_ref],
-            config=types.EditImageConfig(
-                edit_mode="EDIT_MODE_BGSWAP",
-            ),
-        )
+        # スタイルに応じたクロマキー色の優先順を取得
+        chroma_order = STYLE_CHROMA_ORDER.get(style, STYLE_CHROMA_ORDER["auto"])
 
-        if not response.generated_images:
-            logger.warning("背景置換: 生成画像なし、元画像を維持: %s", filepath)
-            return filepath, False
+        for color_name in chroma_order:
+            chroma = CHROMA_COLORS[color_name]
 
-        # 生成画像を取得
-        edited_bytes = response.generated_images[0].image.image_bytes
+            # Imagen Edit API で背景をクロマキー色に置換
+            response = client.models.edit_image(
+                model="imagen-3.0-capability-001",
+                prompt=chroma["prompt"],
+                reference_images=[raw_ref, mask_ref],
+                config=types.EditImageConfig(
+                    edit_mode="EDIT_MODE_BGSWAP",
+                ),
+            )
 
-        # PIL でマゼンタ → 透明に変換
-        import io
-        img = PILImage.open(io.BytesIO(edited_bytes)).convert("RGBA")
-        data = np.array(img)
+            if not response.generated_images:
+                logger.warning(
+                    "背景置換(%s): 生成画像なし、次の色へ: %s", color_name, filepath,
+                )
+                continue
 
-        # マゼンタ (#FF00FF) の許容範囲検出（アンチエイリアス対応）
-        r, g, b = data[:, :, 0], data[:, :, 1], data[:, :, 2]
-        magenta_mask = (r > 200) & (g < 50) & (b > 200)
+            # 生成画像を取得
+            edited_bytes = response.generated_images[0].image.image_bytes
 
-        # 透明化
-        data[magenta_mask, 3] = 0
-        result = PILImage.fromarray(data)
-        result.save(filepath, "PNG")
+            # PIL でクロマキー色 → 透明に変換
+            img = PILImage.open(io.BytesIO(edited_bytes)).convert("RGBA")
+            data = np.array(img)
 
-        # 透過ピクセルが実際に存在するか検証
-        transparent_count = int(np.sum(data[:, :, 3] == 0))
-        if transparent_count == 0:
-            logger.warning("背景透過: 透過ピクセルなし、背景除去は無効: %s", filepath)
-            return filepath, False
+            # クロマキー色の許容範囲検出（アンチエイリアス対応）
+            r, g, b = data[:, :, 0], data[:, :, 1], data[:, :, 2]
+            color_mask = chroma["detect"](r, g, b)
 
-        logger.info("背景透過完了: %s (透過ピクセル数: %d)", filepath, transparent_count)
-        return filepath, True
+            # 透明化
+            data[color_mask, 3] = 0
+            result = PILImage.fromarray(data)
+            result.save(filepath, "PNG")
+
+            # 透過ピクセルが実際に存在するか検証
+            transparent_count = int(np.sum(data[:, :, 3] == 0))
+            if transparent_count > 0:
+                logger.info(
+                    "背景透過完了(%s): %s (透過ピクセル数: %d)",
+                    color_name, filepath, transparent_count,
+                )
+                return filepath, True
+
+            logger.warning(
+                "背景透過(%s): 透過ピクセルなし、次の色へ: %s", color_name, filepath,
+            )
+
+        # 全色失敗
+        logger.warning("背景透過: 全色で失敗、元画像を維持: %s", filepath)
+        return filepath, False
 
     except Exception as e:
         logger.warning("背景透過処理に失敗、元画像を維持: %s — %s", filepath, e)
@@ -195,7 +240,7 @@ def generate_design_asset(
     # 背景透過処理（生成成功時のみ）
     if result.get("status") == "success" and result.get("filepath"):
         original_path = result["filepath"]
-        result["filepath"], bg_removed = _remove_background(original_path)
+        result["filepath"], bg_removed = _remove_background(original_path, style=style, region=region)
         result["transparent_background"] = bg_removed
 
     # セッション状態に累積保存

--- a/tests/unit/test_render_tools.py
+++ b/tests/unit/test_render_tools.py
@@ -7,6 +7,8 @@ from alchemist_agents.tools.render_tools import (
     generate_design_asset,
     _remove_background,
     PRODUCT_ASPECT_RATIOS,
+    CHROMA_COLORS,
+    STYLE_CHROMA_ORDER,
 )
 from tests.fakes import make_tool_context
 
@@ -277,7 +279,7 @@ class TestRemoveBackground:
 
     @patch("google.genai.Client")
     def test_returns_original_on_empty_response(self, mock_client_cls, tmp_path):
-        """Edit API が空レスポンスを返した場合、元画像を維持する。"""
+        """Edit API が全色で空レスポンスを返した場合、元画像を維持する。"""
         from PIL import Image as PILImage
 
         filepath = str(tmp_path / "test.png")
@@ -294,11 +296,13 @@ class TestRemoveBackground:
 
         assert path == filepath
         assert success is False
+        # 空レスポンスでも2色分試行する
+        assert mock_client.models.edit_image.call_count == 2
 
     @patch(_PATCH_GENERATE_IMAGE)
     @patch("alchemist_agents.tools.render_tools._remove_background")
     def test_generate_calls_remove_background_on_success(self, mock_remove_bg, mock_gen):
-        """generate_design_asset が成功時に _remove_background を呼び出す。"""
+        """generate_design_asset が成功時に _remove_background を style/region 付きで呼び出す。"""
         mock_gen.return_value = json.dumps({
             "status": "success",
             "filepath": "/tmp/test.png",
@@ -310,7 +314,7 @@ class TestRemoveBackground:
         )
         result = json.loads(result_json)
 
-        mock_remove_bg.assert_called_once_with("/tmp/test.png")
+        mock_remove_bg.assert_called_once_with("/tmp/test.png", style="auto", region="EU")
         assert result["transparent_background"] is True
 
     @patch(_PATCH_GENERATE_IMAGE)
@@ -341,21 +345,21 @@ class TestRemoveBackground:
         )
         result = json.loads(result_json)
 
-        mock_remove_bg.assert_called_once_with("/tmp/test.png")
+        mock_remove_bg.assert_called_once_with("/tmp/test.png", style="auto", region="EU")
         assert result["transparent_background"] is False
 
     @patch("google.genai.Client")
     def test_returns_false_when_no_transparent_pixels(self, mock_client_cls, tmp_path):
-        """マゼンタなし画像では透過ピクセルが0で False を返す。"""
+        """全色でクロマキー検出が0ピクセルの場合 False を返す（2色リトライ後に失敗）。"""
         from PIL import Image as PILImage
         import io
 
-        # マゼンタを含まない画像（全面赤）
+        # クロマキー色を含まない画像（全面赤）
         img = PILImage.new("RGB", (10, 10), (255, 0, 0))
-        filepath = str(tmp_path / "no_magenta.png")
+        filepath = str(tmp_path / "no_chroma.png")
         img.save(filepath, "PNG")
 
-        # Edit API が返す画像もマゼンタなし（同じ赤画像）
+        # Edit API が返す画像もクロマキー色なし（同じ赤画像）
         buf = io.BytesIO()
         img.save(buf, "PNG")
         edited_bytes = buf.getvalue()
@@ -374,3 +378,111 @@ class TestRemoveBackground:
 
         assert path == filepath
         assert success is False
+        # デフォルト(auto)は2色試行するため、edit_image が2回呼ばれる
+        assert mock_client.models.edit_image.call_count == 2
+
+    @patch("google.genai.Client")
+    def test_folklore_style_uses_green_prompt(self, mock_client_cls, tmp_path):
+        """style="folklore" で Imagen API がグリーンバックプロンプトで呼ばれる。"""
+        from PIL import Image as PILImage
+        import numpy as np
+        import io
+
+        # グリーン背景 + 赤い前景のテスト画像を作成
+        img = PILImage.new("RGB", (10, 10), (0, 255, 0))  # 全面グリーン
+        for x in range(4, 6):
+            for y in range(4, 6):
+                img.putpixel((x, y), (255, 0, 0))
+        filepath = str(tmp_path / "folklore.png")
+        img.save(filepath, "PNG")
+
+        buf = io.BytesIO()
+        img.save(buf, "PNG")
+        edited_bytes = buf.getvalue()
+
+        mock_image = MagicMock()
+        mock_image.image_bytes = edited_bytes
+
+        mock_response = MagicMock()
+        mock_response.generated_images = [MagicMock(image=mock_image)]
+
+        mock_client = MagicMock()
+        mock_client.models.edit_image.return_value = mock_response
+        mock_client_cls.return_value = mock_client
+
+        path, success = _remove_background(filepath, style="folklore")
+
+        assert success is True
+        # 1回目の呼び出しがグリーンバックプロンプト
+        first_call = mock_client.models.edit_image.call_args_list[0]
+        assert "green screen" in first_call[1]["prompt"]
+        assert "chroma key green" in first_call[1]["prompt"]
+
+    @patch("google.genai.Client")
+    def test_retries_with_next_color_on_zero_transparent(self, mock_client_cls, tmp_path):
+        """1色目が透過0ピクセルで失敗し、2色目で成功する。"""
+        from PIL import Image as PILImage
+        import io
+
+        filepath = str(tmp_path / "retry.png")
+        PILImage.new("RGB", (10, 10), (128, 128, 128)).save(filepath, "PNG")
+
+        # 1回目: マゼンタなし画像（全面赤 → 透過0ピクセル）
+        img_red = PILImage.new("RGB", (10, 10), (255, 0, 0))
+        buf1 = io.BytesIO()
+        img_red.save(buf1, "PNG")
+
+        # 2回目: グリーン画像（全面グリーン → 透過成功）
+        img_green = PILImage.new("RGB", (10, 10), (0, 255, 0))
+        buf2 = io.BytesIO()
+        img_green.save(buf2, "PNG")
+
+        mock_img1 = MagicMock()
+        mock_img1.image_bytes = buf1.getvalue()
+        mock_resp1 = MagicMock()
+        mock_resp1.generated_images = [MagicMock(image=mock_img1)]
+
+        mock_img2 = MagicMock()
+        mock_img2.image_bytes = buf2.getvalue()
+        mock_resp2 = MagicMock()
+        mock_resp2.generated_images = [MagicMock(image=mock_img2)]
+
+        mock_client = MagicMock()
+        # style="auto" → ["magenta", "green"]: 1回目マゼンタ失敗、2回目グリーン成功
+        mock_client.models.edit_image.side_effect = [mock_resp1, mock_resp2]
+        mock_client_cls.return_value = mock_client
+
+        path, success = _remove_background(filepath, style="auto")
+
+        assert success is True
+        assert mock_client.models.edit_image.call_count == 2
+
+    @patch("google.genai.Client")
+    def test_returns_false_after_all_retries_exhausted(self, mock_client_cls, tmp_path):
+        """全色でリトライしても透過0ピクセルの場合 (filepath, False) を返す。"""
+        from PIL import Image as PILImage
+        import io
+
+        filepath = str(tmp_path / "exhausted.png")
+        PILImage.new("RGB", (10, 10), (128, 128, 128)).save(filepath, "PNG")
+
+        # 全回: 赤画像（どのクロマキー色にもマッチしない）
+        img_red = PILImage.new("RGB", (10, 10), (255, 0, 0))
+        buf = io.BytesIO()
+        img_red.save(buf, "PNG")
+
+        mock_image = MagicMock()
+        mock_image.image_bytes = buf.getvalue()
+        mock_response = MagicMock()
+        mock_response.generated_images = [MagicMock(image=mock_image)]
+
+        mock_client = MagicMock()
+        mock_client.models.edit_image.return_value = mock_response
+        mock_client_cls.return_value = mock_client
+
+        path, success = _remove_background(filepath, style="folklore")
+
+        assert path == filepath
+        assert success is False
+        # folklore は ["green", "blue"] の2色
+        assert mock_client.models.edit_image.call_count == 2


### PR DESCRIPTION
## Summary

- スタイルに応じてクロマキー色を切り替え、最大2色まで試行する仕組みを導入
- 木版画のような高コントラスト画像でマゼンタクロマキーが衝突する問題を解消
- 「green screen」「chroma key」等の映像業界用語をプロンプトに使い、Imagen の背景検出精度を向上

## 変更内容

### `alchemist_agents/tools/render_tools.py`
- `CHROMA_COLORS`: green/blue/magenta の3色定義（プロンプト + 検出 lambda）
- `STYLE_CHROMA_ORDER`: folklore → グリーンバック優先、fact/auto → マゼンタ優先
- `_remove_background()`: `style`/`region` パラメータ追加 + 色リトライループ
- `generate_design_asset()`: `style`/`region` を `_remove_background()` に伝搬

### `tests/unit/test_render_tools.py`
- 既存テスト4件を新シグネチャに更新
- 新規テスト3件追加（folklore green prompt / リトライ成功 / 全色失敗）

## Test plan

- [x] `python -m pytest tests/unit/test_render_tools.py -v` — 全24テスト合格

🤖 Generated with [Claude Code](https://claude.com/claude-code)