### PR TITLE
fix: OpenRouter プロバイダルーティングで 32K コンテキスト制限を回避

### DIFF
--- a/shared/model_config.py
+++ b/shared/model_config.py
@@ -29,12 +29,15 @@ MODEL_FLASH = "gemini-2.5-flash"
 # Storyteller エージェントが使用する LLM を「語り部（ストーリーテラー）」として選択可能にする。
 # - native_gemini: 既存の Gemini Pro（Vertex AI）を使用
 # - litellm: OpenRouter 経由で各プロバイダーのモデルにアクセス（API キー: OPENROUTER_API_KEY 1つで一元管理）
+# - openrouter_provider_order: OpenRouter のプロバイダルーティング優先順位（小文字スラッグ）
+#   32K コンテキスト制限のサードパーティバックエンドへのルーティングを防止する
 # === End 日本語訳 ===
 STORYTELLER_MODELS: dict[str, dict] = {
     "claude": {
         "model_id": "openrouter/anthropic/claude-sonnet-4.5",
         "provider": "litellm",
         "display_name": "Claude Sonnet 4.5",
+        "openrouter_provider_order": ["anthropic"],
     },
     "gemini": {
         "model_id": MODEL_PRO,
@@ -45,21 +48,25 @@ STORYTELLER_MODELS: dict[str, dict] = {
         "model_id": "openrouter/openai/gpt-4o",
         "provider": "litellm",
         "display_name": "GPT-4o",
+        "openrouter_provider_order": ["openai"],
     },
     "llama": {
         "model_id": "openrouter/meta-llama/llama-4-maverick",
         "provider": "litellm",
         "display_name": "Llama 4 Maverick",
+        "openrouter_provider_order": ["deepinfra"],
     },
     "deepseek": {
         "model_id": "openrouter/deepseek/deepseek-chat",
         "provider": "litellm",
         "display_name": "DeepSeek V3",
+        "openrouter_provider_order": ["deepinfra"],
     },
     "mistral": {
         "model_id": "openrouter/mistralai/mistral-large-2512",
         "provider": "litellm",
         "display_name": "Mistral Large",
+        "openrouter_provider_order": ["mistral"],
     },
 }
 
@@ -133,4 +140,16 @@ def create_storyteller_model(storyteller: str = DEFAULT_STORYTELLER):
     # OpenRouter 経由（LiteLLM アダプタ）
     from google.adk.models.lite_llm import LiteLlm
 
-    return LiteLlm(model=config["model_id"])
+    kwargs = {}
+    provider_order = config.get("openrouter_provider_order")
+    if provider_order:
+        # OpenRouter のプロバイダルーティングで公式プロバイダを優先指定し、
+        # 32K コンテキスト制限のサードパーティバックエンドへのルーティングを防止する
+        kwargs["extra_body"] = {
+            "provider": {
+                "order": provider_order,
+                "allow_fallbacks": True,
+            }
+        }
+
+    return LiteLlm(model=config["model_id"], **kwargs)

--- a/tests/unit/test_reporter_selection.py
+++ b/tests/unit/test_reporter_selection.py
@@ -33,6 +33,18 @@ class TestStorytellerModelsRegistry:
         expected = {"claude", "gemini", "gpt", "llama", "deepseek", "mistral"}
         assert set(STORYTELLER_MODELS.keys()) == expected
 
+    def test_openrouter_models_have_provider_order(self):
+        """OpenRouter 経由の全ストーリーテラーに openrouter_provider_order が設定されていること。"""
+        for name, config in STORYTELLER_MODELS.items():
+            if config["provider"] == "litellm":
+                assert "openrouter_provider_order" in config, (
+                    f"{name} に openrouter_provider_order がない"
+                )
+                order = config["openrouter_provider_order"]
+                assert isinstance(order, list) and len(order) > 0, (
+                    f"{name} の openrouter_provider_order が空"
+                )
+
 
 class TestCreateStorytellerModel:
     """create_storyteller_model() のテスト。"""
@@ -94,6 +106,35 @@ class TestCreateStorytellerModel:
         last_call = LiteLlm.call_args
         assert last_call is not None
         assert last_call.kwargs.get("model") == "openrouter/mistralai/mistral-large-2512"
+
+    def test_openrouter_models_pass_provider_routing(self):
+        """OpenRouter 経由モデルが extra_body にプロバイダルーティング設定を渡すこと。"""
+        from google.adk.models.lite_llm import LiteLlm
+
+        for name, config in STORYTELLER_MODELS.items():
+            if config["provider"] != "litellm":
+                continue
+            LiteLlm.reset_mock()
+            create_storyteller_model(name)
+            last_call = LiteLlm.call_args
+            assert last_call is not None, f"{name} の LiteLlm 呼び出しがない"
+            extra_body = last_call.kwargs.get("extra_body")
+            assert extra_body is not None, f"{name} に extra_body がない"
+            provider = extra_body.get("provider")
+            assert provider is not None, f"{name} の extra_body に provider がない"
+            assert "order" in provider, f"{name} の provider に order がない"
+            assert provider["order"] == config["openrouter_provider_order"]
+            assert provider["allow_fallbacks"] is True
+
+    def test_gemini_does_not_pass_extra_body(self):
+        """Gemini（native）モデルは extra_body を渡さないこと。"""
+        from google.adk.models.google_llm import Gemini
+
+        Gemini.reset_mock()
+        create_storyteller_model("gemini")
+        last_call = Gemini.call_args
+        assert last_call is not None
+        assert "extra_body" not in last_call.kwargs
 
     def test_unknown_storyteller_raises_value_error(self):
         """不正なストーリーテラー名で ValueError が発生すること。"""


### PR DESCRIPTION
## Summary

- OpenRouter が 32K コンテキスト制限のサードパーティバックエンドにリクエストをルーティングし、80K トークンのプロンプトで `max_num_tokens (32768)` エラーが発生する問題を修正
- 各 OpenRouter モデルに `openrouter_provider_order` を追加し、`extra_body` 経由で公式プロバイダ（`anthropic`, `openai`, `deepinfra`, `mistral`）を優先指定
- `allow_fallbacks: true` で一時障害時のフォールバックも維持

## 変更内容

| ファイル | 変更 |
|---------|------|
| `shared/model_config.py` | `STORYTELLER_MODELS` に `openrouter_provider_order` フィールド追加 + `create_storyteller_model()` で `extra_body` にプロバイダルーティング設定を渡す |
| `tests/unit/test_reporter_selection.py` | プロバイダルーティング設定の検証テスト3件追加（レジストリ構造 + extra_body 渡し + Gemini 非適用） |

## プロバイダスラッグ（OpenRouter 公式ドキュメント準拠）

| ストーリーテラー | モデル | 優先プロバイダ |
|-----------------|--------|--------------|
| claude | Claude Sonnet 4.5 | `anthropic` |
| gpt | GPT-4o | `openai` |
| llama | Llama 4 Maverick | `deepinfra` |
| deepseek | DeepSeek V3 | `deepinfra` |
| mistral | Mistral Large | `mistral` |

## Test plan

- [x] `python -m pytest tests/unit/test_reporter_selection.py -v` — 全21件通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)