### PR TITLE
fix: アーカイブ画像の装飾枠を除去して中央配置のみに簡素化

### DIFF
--- a/web-admin/src/app/(main)/preview/[id]/preview-content.tsx
+++ b/web-admin/src/app/(main)/preview/[id]/preview-content.tsx
@@ -41,15 +41,13 @@ function PreviewArchiveImage({ src, alt }: { src?: string; alt?: string }) {
   if (!src || hasError) return null
   return (
     <figure className="not-prose my-8 mx-auto w-fit max-w-3xl">
-      <div className="aged-card letterpress-border rounded-sm overflow-hidden">
-        <img
-          src={src}
-          alt={alt || "Archival Image"}
-          loading="lazy"
-          onError={() => setHasError(true)}
-          className="h-auto max-w-full"
-        />
-      </div>
+      <img
+        src={src}
+        alt={alt || "Archival Image"}
+        loading="lazy"
+        onError={() => setHasError(true)}
+        className="h-auto max-w-full"
+      />
       {alt && (
         <figcaption className="mt-2 text-center text-xs font-mono text-muted-foreground/70 leading-relaxed">
           <span className="uppercase tracking-wider text-gold/60">Archival Image</span>

--- a/web-public/src/components/mystery/archive-image.tsx
+++ b/web-public/src/components/mystery/archive-image.tsx
@@ -25,15 +25,13 @@ export function ArchiveImage({ src, alt, lang }: ArchiveImageProps) {
 
   return (
     <figure className="not-prose my-8 mx-auto w-fit max-w-3xl">
-      <div className="aged-card letterpress-border rounded-sm overflow-hidden">
-        <img
-          src={src}
-          alt={alt || label}
-          loading="lazy"
-          onError={() => setHasError(true)}
-          className="h-auto max-w-full"
-        />
-      </div>
+      <img
+        src={src}
+        alt={alt || label}
+        loading="lazy"
+        onError={() => setHasError(true)}
+        className="h-auto max-w-full"
+      />
       {alt && (
         <figcaption className="mt-2 text-center text-xs font-mono text-muted-foreground/70 leading-relaxed">
           <span className="uppercase tracking-wider text-gold/60">{label}</span>


### PR DESCRIPTION
## Summary
- 本文中のアーカイブ画像から `aged-card letterpress-border` 装飾枠を除去
- `<img>` を `<figure>` 直下に直接配置（中央配置は `mx-auto w-fit` で維持）
- web-public / web-admin 両方に適用

## 変更しないもの
- ヒーロー画像（ページ上部）の枠はスコープ外
- `aged-card` / `letterpress-border` の CSS 定義自体（他コンポーネントで使用中）
- `<figcaption>` のスタイル
- 背景色

## Test plan
- [ ] 公開サイトの記事詳細ページでアーカイブ画像が枠なし・中央配置で表示されること
- [ ] 管理画面のプレビューページでも同様の表示になること
- [ ] ヒーロー画像の枠が変わっていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)