### PR TITLE
feat: API ベース Librarian + AggregatorAgent（言語別集約）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -292,11 +292,13 @@ pending (EN原文 + 翻訳あり) → (Approve) → published
 #### ブログ作成パイプライン（`mystery_agents/`）
 
 ```
-ThemeAnalyzer → ParallelLibrarians → [ScholarGate] → ParallelScholars(分析)
+ParallelAPILibrarians(7 API groups) → Aggregator → [ScholarGate] → ParallelScholars(分析)
   → DebateLoop(LoopAgent, max_iterations=2) → [PolymathGate] → ArmchairPolymath
   → [StorytellerGate] → Storyteller(EN) → [PostStoryGate] → Parallel(Illustrator, ParallelTranslators(3言語)) → Publisher(translations map保存) → Firestore
 ```
 
+- API ベース Librarian（US Archives, Europeana, Internet Archive, DDB, NDL, Trove, Wellcome）がテーマに応じて自律検索
+- AggregatorAgent（LLM 不使用）が raw_search_results を言語別に集約 → `collected_documents_{lang}` に書き込み
 - DebateLoop は有意な分析が2言語以上ある場合のみ実行される
 - Scholar は分析モードと討論モードの2つを持つ（単一ファクトリ関数 `create_scholar(lang, mode)`）
 - 討論モードの Scholar は `append_to_whiteboard` ツールで共有ホワイトボードに発言を記録

--- a/mystery_agents/agent.py
+++ b/mystery_agents/agent.py
@@ -3,12 +3,13 @@
 Defines root_agent (ghost_commander) as a SequentialAgent that orchestrates
 the multilingual investigation pipeline:
 
-  ParallelLibrarians → ScholarBlock → DebateLoop
+  ParallelAPILibrarians → Aggregator → ScholarBlock → DebateLoop
     → PolymathBlock → StorytellerBlock → PostStoryBlock
 
-全7言語の Librarian/Scholar を常時実行し、パイプラインゲートが
-結果なしの言語を自動スキップする。DebateLoop は有意な分析が2言語以上の場合のみ実行。
-PostStoryBlock では Illustrator と6言語翻訳が並列実行される。
+API ベース Librarian（7グループ）が並列で検索し、AggregatorAgent が
+検索結果を言語別に集約。Scholar 以降は従来と同じ言語ベース処理。
+DebateLoop は有意な分析が2言語以上の場合のみ実行。
+PostStoryBlock では Illustrator と3言語翻訳が並列実行される。
 
 DebateLoop 内部は SequentialAgent(debate_round) で構成:
   parallel_debate_scholars → convergence_checker
@@ -25,11 +26,12 @@ from typing import TYPE_CHECKING, Optional
 from google.adk.agents import LoopAgent, ParallelAgent, SequentialAgent
 from google.genai import types
 
+from .agents.aggregator import create_aggregator
+from .agents.api_librarians import create_all_api_librarians
 from .agents.armchair_polymath import create_armchair_polymath
 from .agents.convergence_checker import create_convergence_checker
 from .agents.illustrator import create_illustrator
 from .agents.language_gate import make_debate_loop_gate
-from .agents.language_librarians import create_all_librarians
 from .agents.language_scholars import create_all_scholars
 from .agents.pipeline_gate import (
     make_polymath_gate,
@@ -40,7 +42,6 @@ from .agents.pipeline_gate import (
 from .agents.publisher import create_publisher
 from .agents.storyteller import create_storyteller
 from .agents.translator import create_all_translators
-from shared.constants import ALLOWED_LANGUAGES
 from shared.model_config import DEFAULT_STORYTELLER
 
 if TYPE_CHECKING:
@@ -49,8 +50,8 @@ if TYPE_CHECKING:
 # パイプライン説明文（build_pipeline 内で共有）
 _PIPELINE_DESCRIPTION = (
     "Ghost in the Archive multilingual blog creation pipeline. "
-    "Executes ParallelLibrarians(7 languages) → ScholarBlock → DebateLoop "
-    "→ PolymathBlock → StorytellerBlock → PostStoryBlock "
+    "Executes ParallelAPILibrarians(7 API groups) → Aggregator → ScholarBlock "
+    "→ DebateLoop → PolymathBlock → StorytellerBlock → PostStoryBlock "
     "to research, analyze, debate, create content, generate images, "
     "translate to 3 languages (ja/es/de) in parallel, "
     "and publish historical mysteries and folkloric anomalies. "
@@ -61,7 +62,8 @@ _PIPELINE_DESCRIPTION = (
 # 実際にテキストを生成するリーフエージェントのみ進捗表示する
 SKIP_AUTHORS = {
     "ghost_commander",
-    "parallel_librarians",
+    "parallel_api_librarians",
+    "aggregator",
     "parallel_scholars",
     "parallel_debate_scholars",
     "debate_loop",
@@ -78,12 +80,13 @@ SKIP_AUTHORS = {
 def _initialize_pipeline_state(
     callback_context: CallbackContext,
 ) -> Optional[types.Content]:
-    """パイプライン状態を初期化する（ThemeAnalyzer の代替）。
+    """パイプライン状態を初期化する。
 
-    全7言語を常時実行するため、selected_languages を全言語リストで初期化。
-    下流のゲート・討論ロジックとの互換性を維持する。
+    API ベース Librarian は言語選択不要（テーマから自律判断）。
+    selected_languages は AggregatorAgent が検索結果から動的に設定するため、
+    ここでは空リストで初期化する。
     """
-    callback_context.state["selected_languages"] = sorted(ALLOWED_LANGUAGES)
+    callback_context.state["selected_languages"] = []
     callback_context.state["debate_whiteboard"] = ""
     callback_context.state["structured_report"] = {}
     return None  # 実行続行
@@ -107,9 +110,10 @@ def build_pipeline(storyteller: str = DEFAULT_STORYTELLER) -> SequentialAgent:
     il = create_illustrator()
     pub = create_publisher()
     st = create_storyteller(storyteller)
+    agg = create_aggregator()
 
     # ファクトリエージェント（既に毎回新規生成）
-    libs = create_all_librarians()
+    api_libs = create_all_api_librarians()
     scholars_analysis = create_all_scholars(mode="analysis")
     scholars_debate = create_all_scholars(mode="debate")
     translators = create_all_translators()
@@ -188,9 +192,10 @@ def build_pipeline(storyteller: str = DEFAULT_STORYTELLER) -> SequentialAgent:
         description=_PIPELINE_DESCRIPTION,
         sub_agents=[
             ParallelAgent(
-                name="parallel_librarians",
-                sub_agents=list(libs.values()),
+                name="parallel_api_librarians",
+                sub_agents=api_libs,
             ),
+            agg,
             scholar_block,
             debate_loop,
             polymath_block,

--- a/mystery_agents/agents/__init__.py
+++ b/mystery_agents/agents/__init__.py
@@ -4,18 +4,20 @@ This module exports all specialized agents for the blog creation pipeline.
 Scriptwriter and Producer have been moved to podcast_agents package.
 """
 
+from .aggregator import create_aggregator
+from .api_librarians import create_all_api_librarians, create_api_librarian
 from .armchair_polymath import armchair_polymath_agent, create_armchair_polymath
 from .convergence_checker import convergence_checker_agent, create_convergence_checker
 from .illustrator import create_illustrator, illustrator_agent
-from .language_librarians import create_all_librarians, create_librarian
 from .language_scholars import create_all_scholars, create_scholar
 from .publisher import create_publisher, publisher_agent
 from .storyteller import create_storyteller, storyteller_agent
 from .translator import create_all_translators, create_translator, translator_agent
 
 __all__ = [
-    "create_librarian",
-    "create_all_librarians",
+    "create_api_librarian",
+    "create_all_api_librarians",
+    "create_aggregator",
     "create_scholar",
     "create_all_scholars",
     "create_armchair_polymath",

--- a/mystery_agents/agents/aggregator.py
+++ b/mystery_agents/agents/aggregator.py
@@ -1,0 +1,178 @@
+"""AggregatorAgent — API Librarian の検索結果を言語別に集約する。
+
+LLM を介さず、セッション状態の raw_search_results から
+ドキュメントを言語別にグループ化し、collected_documents_{lang} に
+Scholar が読める形式でテキストを書き込む。
+
+また active_languages（ドキュメント数ランキング）をステートに書き込み、
+後段の DynamicScholarBlock（PR 3）が参照する。
+"""
+
+import logging
+from collections import defaultdict
+from collections.abc import AsyncGenerator
+
+from google.adk.agents import BaseAgent
+from google.adk.agents.invocation_context import InvocationContext
+from google.adk.events.event import Event, EventActions
+from google.genai import types
+
+logger = logging.getLogger(__name__)
+
+# 言語名マッピング（ログ・ヘッダー表示用）
+_LANGUAGE_NAMES: dict[str, str] = {
+    "en": "English",
+    "de": "German",
+    "es": "Spanish",
+    "fr": "French",
+    "ja": "Japanese",
+    "nl": "Dutch",
+    "pt": "Portuguese",
+}
+
+# 収集対象の raw_search_results キーサフィックス
+_KNOWN_LANGUAGES = ["en", "de", "es", "fr", "ja", "nl", "pt"]
+
+
+class AggregatorAgent(BaseAgent):
+    """API Librarian 出力を言語別に集約する LLM 不使用エージェント。
+
+    raw_search_results* からドキュメントを抽出し、
+    各ドキュメントの language フィールドに基づいて言語別にグループ化する。
+    """
+
+    async def _run_async_impl(
+        self, ctx: InvocationContext
+    ) -> AsyncGenerator[Event, None]:
+        state = ctx.session.state
+
+        # 全 raw_search_results を収集（既知キーパターンを安全にチェック）
+        docs_by_lang: dict[str, list[dict]] = defaultdict(list)
+
+        keys_to_check = ["raw_search_results"] + [
+            f"raw_search_results_{lang}" for lang in _KNOWN_LANGUAGES
+        ]
+
+        for key in keys_to_check:
+            value = state.get(key)
+            if not value or not isinstance(value, list):
+                continue
+            for result_entry in value:
+                if not isinstance(result_entry, dict):
+                    continue
+                for doc in result_entry.get("documents", []):
+                    lang = doc.get("language", "en")
+                    docs_by_lang[lang].append(doc)
+
+        # 言語別ドキュメント数でランキング（降順）
+        active_languages = sorted(
+            docs_by_lang.keys(),
+            key=lambda lang: len(docs_by_lang[lang]),
+            reverse=True,
+        )
+
+        # state_delta を構築
+        state_delta: dict[str, object] = {}
+
+        for lang in active_languages:
+            docs = docs_by_lang[lang]
+            text = _format_documents(lang, docs)
+            state_delta[f"collected_documents_{lang}"] = text
+
+        state_delta["active_languages"] = active_languages
+
+        # selected_languages を active_languages で更新（Scholar/debate layer 互換）
+        if active_languages:
+            state_delta["selected_languages"] = active_languages
+
+        total_docs = sum(len(d) for d in docs_by_lang.values())
+        summary = (
+            f"Aggregated {total_docs} documents across "
+            f"{len(active_languages)} languages: "
+            f"{', '.join(f'{l}({len(docs_by_lang[l])})' for l in active_languages)}"
+        )
+        logger.info(
+            "Aggregator: %s",
+            summary,
+            extra={
+                "active_languages": active_languages,
+                "total_documents": total_docs,
+                "docs_per_language": {
+                    l: len(docs_by_lang[l]) for l in active_languages
+                },
+            },
+        )
+
+        yield Event(
+            invocation_id=ctx.invocation_id,
+            author=self.name,
+            branch=ctx.branch,
+            content=types.Content(
+                role="model", parts=[types.Part(text=summary)]
+            ),
+            actions=EventActions(state_delta=state_delta),
+        )
+
+
+def _format_documents(lang: str, docs: list[dict]) -> str:
+    """ドキュメントリストを Scholar が読める形式にフォーマットする。
+
+    重複 URL を除去し、各ドキュメントのメタデータとテキスト抜粋を
+    構造化テキストとして整形する。
+    """
+    # URL 重複除去
+    seen_urls: set[str] = set()
+    unique_docs: list[dict] = []
+    for doc in docs:
+        url = doc.get("source_url", "")
+        if url and url not in seen_urls:
+            seen_urls.add(url)
+            unique_docs.append(doc)
+        elif not url:
+            unique_docs.append(doc)
+
+    if not unique_docs:
+        lang_name = _LANGUAGE_NAMES.get(lang, lang)
+        return f"NO_DOCUMENTS_FOUND: No {lang_name}-language documents collected."
+
+    lang_name = _LANGUAGE_NAMES.get(lang, lang)
+    lines = [
+        f"# Collected Documents ({lang_name}) — {len(unique_docs)} documents\n"
+    ]
+
+    for i, doc in enumerate(unique_docs, 1):
+        lines.append(f"## [{i}] {doc.get('title', 'Untitled')}")
+        if doc.get("date"):
+            lines.append(f"- **Date**: {doc['date']}")
+        source_type = doc.get("source_type", "unknown")
+        lines.append(f"- **Archive**: {source_type}")
+        lines.append(f"- **URL**: {doc.get('source_url', 'N/A')}")
+        if doc.get("location"):
+            lines.append(f"- **Location**: {doc['location']}")
+        if doc.get("summary"):
+            lines.append(f"- **Summary**: {doc['summary']}")
+        matched = doc.get("keywords_matched")
+        if matched:
+            kw_str = ", ".join(matched) if isinstance(matched, list) else str(matched)
+            lines.append(f"- **Keywords matched**: {kw_str}")
+        if doc.get("raw_text"):
+            # テキスト抜粋は500文字に制限
+            excerpt = str(doc["raw_text"])[:500]
+            if len(str(doc["raw_text"])) > 500:
+                excerpt += "..."
+            lines.append(f"- **Excerpt**: {excerpt}")
+        lines.append("")  # ドキュメント間の空行
+
+    return "\n".join(lines)
+
+
+def create_aggregator() -> AggregatorAgent:
+    """AggregatorAgent を新規生成する。"""
+    return AggregatorAgent(
+        name="aggregator",
+        description=(
+            "Aggregates search results from all API Librarians by document language. "
+            "Writes collected_documents_{lang} for each language found. "
+            "Deterministic execution without LLM."
+        ),
+    )

--- a/mystery_agents/agents/api_librarians.py
+++ b/mystery_agents/agents/api_librarians.py
@@ -1,0 +1,385 @@
+"""API ベース Librarian エージェントファクトリ。
+
+言語ベース Librarian に代わり、API グループごとに Librarian を生成する。
+各 Librarian はテーマに応じて検索言語を自律的に判断し、
+collected_documents_{api_key} に結果を保存する。
+
+後段の AggregatorAgent が全 Librarian 出力を言語別に再集約する。
+
+全 Librarian は gemini-2.5-flash を使用（資料検索は Flash で十分）。
+モデル設定は shared/model_config.py で一元管理（429 リトライ付き）。
+"""
+
+from google.adk.agents import LlmAgent
+
+from shared.model_config import create_flash_model
+
+from ..tools.librarian_tools import search_archives, search_newspapers
+
+
+# === 日本語訳 ===
+# API ベース Librarian の共通指示テンプレート:
+# あなたは「Ghost in the Archive」プロジェクトの {api_display_name} 専門司書です。
+# {api_display_name} のデジタルアーカイブから一次資料を検索・収集します。
+# 分析は行いません。
+#
+# ## あなたのアーカイブ
+# {api_capabilities}
+#
+# ## 関連性の判断
+# 検索前に、調査テーマがあなたのアーカイブに関連するか評価する。
+# {relevance_guidance}
+# テーマが明らかに無関連な場合は NO_DOCUMENTS_FOUND を出力。
+#
+# ## 検索戦略
+# 1. テーマに基づいて適切な言語で 3-5 個のキーワードを生成
+# 2. search_archives を呼び出す（sources パラメータで対象 API を指定）
+# 3. {newspaper_note}
+# 4. ツールは1回ずつ呼び出す。リトライ不要
+#
+# ## 出力形式
+# 各ドキュメント:
+# - タイトル、日付、ソース URL
+# - 要約
+# - 言語とソースタイプ
+# - 資料タイプ（Fact/Folklore/Both）
+# - テキスト抜粋（利用可能な場合）
+#
+# ## 重要
+# - 各ツールは1回ずつ。リトライ不要
+# - テーマに適した言語でネイティブにキーワードを生成
+# - 分析は Scholar の役割 — 収集した資料を詳細に報告するのみ
+# - Fact と Folklore の両方を意識的に収集
+# === End 日本語訳 ===
+
+_BASE_INSTRUCTION = """
+You are a {api_display_name} specialist Librarian for the "Ghost in the Archive" project.
+Your job is to search {api_display_name} for primary sources related to the investigation theme.
+You do NOT perform analysis — that is the Scholar Agent's role.
+
+## Your Archive
+{api_capabilities}
+
+## Relevance Assessment
+Before searching, evaluate whether your archive is likely to contain materials
+relevant to the investigation theme.
+{relevance_guidance}
+
+If the theme is clearly unrelated to your archive's focus, output only:
+```
+NO_DOCUMENTS_FOUND: Theme not relevant to {api_display_name}.
+Search theme: [theme]
+```
+
+## Search Strategy
+{search_strategy}
+
+## Output Format
+Output search results as structured text:
+- Title, date, and source URL of each document
+- Summary (context around relevant keywords)
+- Language and source type
+- Material type (Fact/Folklore/Both)
+- Excerpts from the text (if available)
+
+## Important
+- **Call each tool only once per language. No retries are needed.**
+- Generate keywords natively in the appropriate language for your archive
+- Think about how this topic would be described in that language's sources
+- Use period-appropriate terminology
+- Include both formal/official terms and colloquial/folk terms
+- Consciously collect materials for both Fact and Folklore
+- Do NOT perform analysis — report collected materials for the Scholar
+
+## When No Documents Are Found
+If search returns no documents, output only:
+```
+NO_DOCUMENTS_FOUND: No relevant documents found in {api_display_name}.
+Search theme: [theme]
+```
+"""
+
+# ---------------------------------------------------------------------------
+# API 別設定
+# ---------------------------------------------------------------------------
+
+API_CONFIGS: dict[str, dict] = {
+    "us_archives": {
+        "api_display_name": "US Digital Archives",
+        "api_capabilities": (
+            "You manage three major US digital archives plus historical newspapers:\n"
+            "- **Library of Congress Digital Collections** (LOC): The world's largest library.\n"
+            "  US government records, manuscripts, maps, photographs, newspapers, sound recordings.\n"
+            "- **Digital Public Library of America** (DPLA): Aggregates 45M+ items from US libraries,\n"
+            "  archives, and museums. Includes Spanish-language materials from Latino communities.\n"
+            "- **NYPL Digital Collections**: 1M+ items from New York Public Library.\n"
+            "  Strong in New York City history, performing arts, and rare manuscripts.\n"
+            "- **Chronicling America** (via search_newspapers): Historical US newspapers (1690-1963).\n"
+            "  LOC-curated, full-text searchable, includes Spanish-language newspapers."
+        ),
+        "relevance_guidance": (
+            "Your archives are primarily English-language and US-focused, but DPLA and\n"
+            "Chronicling America also contain significant Spanish-language materials.\n\n"
+            "**Always search** if the theme has ANY connection to:\n"
+            "- United States history, culture, geography, or politics\n"
+            "- English-speaking world topics (British colonial era, transatlantic events)\n"
+            "- International events with US involvement or documentation\n"
+            "- Broadly applicable themes (folklore, supernatural, historical mysteries)\n"
+            "- Latin American or Spanish colonial topics (DPLA has Spanish materials)\n\n"
+            "**Skip only** if the theme is exclusively about a non-US, non-English region\n"
+            "with no plausible US archival record (e.g., purely local Japanese folklore\n"
+            "with no Western documentation)."
+        ),
+        "search_strategy": (
+            '1. Generate 3-5 focused search keywords in **English**\n'
+            '2. Call **search_archives** with:\n'
+            '   - `sources="loc, dpla, nypl"`\n'
+            '   - `language="en"`\n'
+            '   - Example: keywords="Bell Witch, Adams Tennessee, poltergeist"\n'
+            "3. Call **search_newspapers** for historical newspaper articles\n"
+            "   - The tool searches Chronicling America automatically\n"
+            "   - Use the same or similar keywords as the archive search\n"
+            "4. Date filtering is OPTIONAL. Only set `date_start` and `date_end` when\n"
+            "   the theme clearly indicates a specific time period"
+        ),
+        "has_newspapers": True,
+    },
+    "europeana": {
+        "api_display_name": "Europeana",
+        "api_capabilities": (
+            "You manage **Europeana**, the pan-European digital cultural heritage platform:\n"
+            "- Aggregates 6,000+ European cultural institutions\n"
+            "- 50M+ items: artworks, books, music, newspapers, maps, archives\n"
+            "- Supports language filtering and country-based filtering\n"
+            "- Strong for: European history, art, manuscripts, religious records\n"
+            "- Materials in all major European languages: English, German, French,\n"
+            "  Spanish, Dutch, Portuguese, Italian, and many more\n"
+            "- Historical documents often in Latin regardless of country of origin"
+        ),
+        "relevance_guidance": (
+            "Europeana covers all of Europe. **Always search** if the theme has\n"
+            "ANY connection to:\n"
+            "- European history, culture, art, or religion\n"
+            "- Colonial history (European colonial powers worldwide)\n"
+            "- Western civilization topics (philosophy, science, warfare)\n"
+            "- Christianity, Judaism, Islam in European context\n"
+            "- Maritime exploration, trade routes, diplomacy\n\n"
+            "**Skip only** if the theme is exclusively about a non-European region\n"
+            "with no European colonial, trade, or cultural connection."
+        ),
+        "search_strategy": (
+            "1. Analyze the theme and determine which European languages are relevant\n"
+            "2. Generate 3-5 keywords in the most relevant European language\n"
+            '3. Call **search_archives** with:\n'
+            '   - `sources="europeana"`\n'
+            "   - `language` set to the most relevant language code\n"
+            "   - Example: keywords=\"Geisterschiff, Nordsee, Schiffbruch\", language=\"de\"\n"
+            "4. If the theme spans multiple European cultures, prioritize the language\n"
+            "   most likely to yield results for this specific topic\n"
+            "5. Date filtering is OPTIONAL — use only when the time period is clear"
+        ),
+        "has_newspapers": False,
+    },
+    "internet_archive": {
+        "api_display_name": "Internet Archive",
+        "api_capabilities": (
+            "You manage the **Internet Archive** (archive.org):\n"
+            "- 40M+ books and texts, plus audio, video, and web archives\n"
+            "- Massive collection of digitized out-of-copyright books and periodicals\n"
+            "- Materials in virtually every language\n"
+            "- Strong for: obscure and rare publications, folklore collections,\n"
+            "  old journals, government reports, pamphlets\n"
+            "- Often hosts digitized copies of materials from other institutions"
+        ),
+        "relevance_guidance": (
+            "Internet Archive has materials on virtually any topic.\n"
+            "**Always search** — the breadth of IA's collection makes it relevant\n"
+            "to almost every investigation theme.\n\n"
+            "Focus your search on finding materials that complement what other\n"
+            "specialized archives might have — rare books, obscure periodicals,\n"
+            "and folklore collections that may not be in institutional archives."
+        ),
+        "search_strategy": (
+            "1. Generate 3-5 keywords in **English** (IA's search works best with English)\n"
+            '2. Call **search_archives** with:\n'
+            '   - `sources="internet_archive"`\n'
+            '   - `language="en"`\n'
+            "   - Example: keywords=\"vampire folklore, Eastern Europe, superstition\"\n"
+            "3. If the theme is strongly connected to a non-English culture,\n"
+            "   consider keywords in that language as well\n"
+            "4. Date filtering is OPTIONAL"
+        ),
+        "has_newspapers": False,
+    },
+    "ddb": {
+        "api_display_name": "Deutsche Digitale Bibliothek",
+        "api_capabilities": (
+            "You manage the **Deutsche Digitale Bibliothek** (DDB):\n"
+            "- Germany's central portal for digital cultural heritage\n"
+            "- 40M+ objects from 600+ German cultural and academic institutions\n"
+            "- Materials primarily in German\n"
+            "- Strong for: German history, Reformation, church records,\n"
+            "  university archives, Germanic folklore, Prussian state records\n"
+            "- Also covers Austrian and Swiss German-language materials via linked institutions"
+        ),
+        "relevance_guidance": (
+            "DDB is focused on the German-speaking world.\n\n"
+            "**Search** if the theme has ANY connection to:\n"
+            "- German, Austrian, or Swiss history and culture\n"
+            "- Central European events (Holy Roman Empire, Prussian era, WWI/WWII)\n"
+            "- Germanic folklore, mythology, or folk traditions (Grimm, Unheimliche)\n"
+            "- Reformation, church records, Protestant/Catholic conflicts\n"
+            "- German colonial history (Africa, Pacific)\n"
+            "- German emigration or diaspora communities\n\n"
+            "**Skip** if the theme has no plausible German-speaking world connection."
+        ),
+        "search_strategy": (
+            "1. Generate 3-5 keywords in **German**\n"
+            "   - Think about how this topic would be described in German academic\n"
+            "     and archival traditions\n"
+            "   - Include both Hochdeutsch and historical/dialect terms if applicable\n"
+            '2. Call **search_archives** with:\n'
+            '   - `sources="ddb"`\n'
+            '   - `language="de"`\n'
+            "   - Example: keywords=\"Spukhaus, Poltergeist, Volksglaube\"\n"
+            "3. Date filtering is OPTIONAL"
+        ),
+        "has_newspapers": False,
+    },
+    "ndl": {
+        "api_display_name": "National Diet Library (NDL Search)",
+        "api_capabilities": (
+            "You manage **NDL Search** (国立国会図書館サーチ):\n"
+            "- Japan's national library digital search service\n"
+            "- Covers books, periodicals, manuscripts, and institutional publications\n"
+            "- Materials primarily in Japanese\n"
+            "- Strong for: Edo/Meiji/Taisho/Showa era records, kaidan (怪談) collections,\n"
+            "  yokai folklore, temple and shrine records, local histories\n"
+            "- Includes government publications, academic journals, and rare manuscripts"
+        ),
+        "relevance_guidance": (
+            "NDL is focused on Japanese-language materials.\n\n"
+            "**Search** if the theme has ANY connection to:\n"
+            "- Japanese history, culture, or mythology\n"
+            "- East Asian supernatural traditions (yokai, yurei, kaidan)\n"
+            "- Japan's interactions with the West (Perry, Meiji modernization)\n"
+            "- Buddhist or Shinto religious traditions\n"
+            "- Japanese colonial history (Korea, Taiwan, Manchuria)\n"
+            "- Specific Japanese locations, events, or historical figures\n\n"
+            "**Skip** if the theme has no plausible Japanese connection."
+        ),
+        "search_strategy": (
+            "1. Generate 3-5 keywords in **Japanese**\n"
+            "   - Use appropriate kanji/hiragana for historical topics\n"
+            "   - Include both modern and historical terminology\n"
+            "   - Example: 怪談, 幽霊, 心霊現象, 民間伝承\n"
+            '2. Call **search_archives** with:\n'
+            '   - `sources="ndl_search"`\n'
+            '   - `language="ja"`\n'
+            "   - Example: keywords=\"怪談, 番町皿屋敷, 幽霊, 江戸\"\n"
+            "3. Date filtering is OPTIONAL"
+        ),
+        "has_newspapers": False,
+    },
+    "trove": {
+        "api_display_name": "Trove (National Library of Australia)",
+        "api_capabilities": (
+            "You manage **Trove** from the National Library of Australia:\n"
+            "- Australia's comprehensive discovery service for cultural heritage\n"
+            "- Digitized newspapers, books, images, maps, music, and archives\n"
+            "- Materials primarily in English\n"
+            "- Strong for: Australian and Oceanian history, Aboriginal culture,\n"
+            "  British colonial records in the Pacific, maritime history\n"
+            "- Historical newspapers from 1803 to present"
+        ),
+        "relevance_guidance": (
+            "Trove is focused on Australia and Oceania.\n\n"
+            "**Search** if the theme has ANY connection to:\n"
+            "- Australian or New Zealand history and culture\n"
+            "- Pacific Island nations and Oceanian traditions\n"
+            "- British colonial history in the Pacific\n"
+            "- Aboriginal Australian culture, Dreamtime, or sacred sites\n"
+            "- Maritime history in the Pacific and Indian Ocean\n"
+            "- Transportation of convicts, gold rush era\n\n"
+            "**Skip** if the theme has no plausible Oceanian or Pacific connection."
+        ),
+        "search_strategy": (
+            "1. Generate 3-5 keywords in **English**\n"
+            "   - Focus on Australian/Oceanian terminology and place names\n"
+            '2. Call **search_archives** with:\n'
+            '   - `sources="trove"`\n'
+            '   - `language="en"`\n'
+            "   - Example: keywords=\"ghost ship, Bass Strait, shipwreck, colonial\"\n"
+            "3. Date filtering is OPTIONAL"
+        ),
+        "has_newspapers": False,
+    },
+    "wellcome": {
+        "api_display_name": "Wellcome Collection",
+        "api_capabilities": (
+            "You manage the **Wellcome Collection**:\n"
+            "- A world-renowned collection at the intersection of medicine, life, and art\n"
+            "- Rare manuscripts, medical texts, visual materials, and archives\n"
+            "- Materials primarily in English, with significant Latin and European language holdings\n"
+            "- Strong for: medical history, plague and epidemic records, anatomy,\n"
+            "  witchcraft and superstition, mental health history, herbalism,\n"
+            "  alchemy, folk medicine, and the history of belief in the supernatural"
+        ),
+        "relevance_guidance": (
+            "Wellcome Collection specializes in medicine, health, and belief systems.\n\n"
+            "**Search** if the theme has ANY connection to:\n"
+            "- Medical history, epidemics, plague, quarantine\n"
+            "- Witchcraft, superstition, folk medicine, herbalism\n"
+            "- Mental health, asylums, hysteria, possession\n"
+            "- Alchemy, occultism, spiritual healing\n"
+            "- Death practices, burial customs, funeral rites\n"
+            "- The supernatural as understood through medical/scientific lens\n\n"
+            "**Skip** if the theme has no connection to medicine, health, belief,\n"
+            "or the supernatural."
+        ),
+        "search_strategy": (
+            "1. Generate 3-5 keywords in **English**\n"
+            "   - Focus on medical and belief-related terminology\n"
+            "   - Include historical medical terms alongside modern equivalents\n"
+            '2. Call **search_archives** with:\n'
+            '   - `sources="wellcome_collection"`\n'
+            '   - `language="en"`\n'
+            "   - Example: keywords=\"witchcraft trial, possession, exorcism, folk remedy\"\n"
+            "3. Date filtering is OPTIONAL"
+        ),
+        "has_newspapers": False,
+    },
+}
+
+
+def create_api_librarian(api_key: str) -> LlmAgent:
+    """指定された API グループの Librarian エージェントを生成する。
+
+    Args:
+        api_key: API_CONFIGS のキー（例: "us_archives", "europeana"）
+
+    Returns:
+        LlmAgent インスタンス
+    """
+    config = API_CONFIGS[api_key]
+    instruction = _BASE_INSTRUCTION.format(**config)
+    tools = [search_archives]
+    if config.get("has_newspapers"):
+        tools.append(search_newspapers)
+
+    return LlmAgent(
+        name=f"librarian_{api_key}",
+        model=create_flash_model(),
+        description=(
+            f"{config['api_display_name']} specialist librarian. "
+            f"Searches {config['api_display_name']} for primary sources."
+        ),
+        instruction=instruction,
+        tools=tools,
+        output_key=f"collected_documents_{api_key}",
+    )
+
+
+def create_all_api_librarians() -> list[LlmAgent]:
+    """全 API グループの Librarian エージェントをリストで返す。"""
+    return [create_api_librarian(key) for key in API_CONFIGS]

--- a/mystery_agents/tools/source_registry.py
+++ b/mystery_agents/tools/source_registry.py
@@ -23,6 +23,7 @@ _registry: dict[str, ArchiveSource] = {}
 _all_loaded = False
 
 # 登録対象の API ツールモジュール（パッケージ内の相対パス）
+# Delpher は公開言語削減（PR #328）に伴い除外
 _SOURCE_MODULES = [
     "mystery_agents.tools.loc_digital",
     "mystery_agents.tools.dpla",
@@ -32,7 +33,6 @@ _SOURCE_MODULES = [
     "mystery_agents.tools.europeana",
     "mystery_agents.tools.chronicling_america",
     "mystery_agents.tools.trove",
-    "mystery_agents.tools.delpher",
     "mystery_agents.tools.ndl_search",
     "mystery_agents.tools.wellcome_collection",
 ]

--- a/shared/state_registry.py
+++ b/shared/state_registry.py
@@ -37,14 +37,26 @@ class StateKey:
 STATE_KEYS: list[StateKey] = [
     StateKey(
         name="selected_languages",
-        description="調査対象言語リスト（パイプライン初期化で全言語セット）",
-        written_by=("pipeline_init",),
+        description="調査対象言語リスト（Aggregator が検索結果から動的に設定）",
+        written_by=("pipeline_init", "aggregator"),
         read_by=("language_gate", "pipeline_gate"),
     ),
     StateKey(
+        name="active_languages",
+        description="ドキュメント数ランキング順の言語リスト（Aggregator が設定）",
+        written_by=("aggregator",),
+        read_by=(),
+    ),
+    StateKey(
+        name="collected_documents_{api_key}",
+        description="API Librarian の検索結果テキスト（API グループ別）",
+        written_by=("librarian_{api_key}",),
+        read_by=("aggregator",),
+    ),
+    StateKey(
         name="collected_documents_{lang}",
-        description="Librarian が収集した資料（言語別）",
-        written_by=("librarian_{lang}",),
+        description="Aggregator が集約した資料（言語別、Scholar が参照）",
+        written_by=("aggregator",),
         read_by=("scholar_{lang}", "pipeline_gate", "publisher_tools"),
     ),
     StateKey(

--- a/tests/integration/test_agent_handover.py
+++ b/tests/integration/test_agent_handover.py
@@ -22,13 +22,14 @@ def _registry_output_keys() -> set[str]:
 class TestSessionStateKeys:
     """Tests for session state key conventions."""
 
-    def test_librarian_output_keys(self):
-        """Language-specific Librarian agents should use 'collected_documents_{lang}' output keys."""
-        from mystery_agents.agents.language_librarians import create_all_librarians
+    def test_api_librarian_output_keys(self):
+        """API-based Librarian agents should use 'collected_documents_{api_key}' output keys."""
+        from mystery_agents.agents.api_librarians import API_CONFIGS, create_all_api_librarians
 
-        librarians = create_all_librarians()
-        for lang, agent in librarians.items():
-            assert agent.output_key == f"collected_documents_{lang}"
+        librarians = create_all_api_librarians()
+        expected_keys = [f"collected_documents_{key}" for key in API_CONFIGS]
+        actual_keys = [agent.output_key for agent in librarians]
+        assert sorted(actual_keys) == sorted(expected_keys)
 
     def test_scholar_output_keys(self):
         """Language-specific Scholar agents should use 'scholar_analysis_{lang}' output keys."""
@@ -190,15 +191,12 @@ class TestRootAgentConfiguration:
 class TestLanguageGateCallbacks:
     """Tests for before_agent_callback on language agents."""
 
-    def test_librarians_have_gate_callback(self):
-        """All librarians should have a before_agent_callback."""
-        from mystery_agents.agents.language_librarians import create_all_librarians
+    def test_api_librarian_count(self):
+        """API-based Librarians should match the number of API configs."""
+        from mystery_agents.agents.api_librarians import API_CONFIGS, create_all_api_librarians
 
-        librarians = create_all_librarians()
-        for lang, agent in librarians.items():
-            assert agent.before_agent_callback is not None, (
-                f"librarian_{lang} should have before_agent_callback"
-            )
+        librarians = create_all_api_librarians()
+        assert len(librarians) == len(API_CONFIGS)
 
     def test_scholars_have_gate_callback(self):
         """All scholars should have a before_agent_callback."""
@@ -405,3 +403,12 @@ class TestPipelineGateCallbacks:
         assert "polymath_block" in sub_agents_str
         assert "storyteller_block" in sub_agents_str
         assert "post_story_block" in sub_agents_str
+
+    def test_ghost_commander_contains_aggregator(self):
+        """ghost_commander should contain the aggregator agent after parallel librarians."""
+        from mystery_agents.agent import ghost_commander
+
+        sub_agent_names = [repr(a) for a in ghost_commander.sub_agents]
+        sub_agents_str = " ".join(sub_agent_names)
+        assert "parallel_api_librarians" in sub_agents_str
+        assert "aggregator" in sub_agents_str

--- a/tests/unit/test_aggregator.py
+++ b/tests/unit/test_aggregator.py
@@ -1,0 +1,125 @@
+"""AggregatorAgent のユニットテスト。
+
+raw_search_results からの言語別集約ロジックを検証する。
+"""
+
+import pytest
+
+from mystery_agents.agents.aggregator import _format_documents, create_aggregator
+
+
+class TestFormatDocuments:
+    """_format_documents のテスト。"""
+
+    def test_empty_docs_returns_no_documents_found(self):
+        """空のドキュメントリストで NO_DOCUMENTS_FOUND を返す。"""
+        result = _format_documents("en", [])
+        assert "NO_DOCUMENTS_FOUND" in result
+
+    def test_formats_single_document(self):
+        """単一ドキュメントが正しくフォーマットされる。"""
+        docs = [
+            {
+                "title": "Test Document",
+                "date": "1842-03-15",
+                "source_url": "https://example.com/doc1",
+                "summary": "A test summary",
+                "language": "en",
+                "location": "Boston, MA",
+                "source_type": "loc_digital",
+                "keywords_matched": ["ghost", "mystery"],
+            }
+        ]
+        result = _format_documents("en", docs)
+        assert "Test Document" in result
+        assert "1842-03-15" in result
+        assert "loc_digital" in result
+        assert "Boston, MA" in result
+        assert "ghost, mystery" in result
+        assert "1 documents" in result
+
+    def test_deduplicates_by_url(self):
+        """同一 URL のドキュメントが重複除去される。"""
+        docs = [
+            {
+                "title": "Doc A",
+                "source_url": "https://example.com/same",
+                "summary": "First",
+                "language": "en",
+                "source_type": "loc_digital",
+            },
+            {
+                "title": "Doc B",
+                "source_url": "https://example.com/same",
+                "summary": "Duplicate",
+                "language": "en",
+                "source_type": "loc_digital",
+            },
+        ]
+        result = _format_documents("en", docs)
+        assert "Doc A" in result
+        assert "Doc B" not in result
+        assert "1 documents" in result
+
+    def test_truncates_long_excerpt(self):
+        """raw_text が長い場合 500 文字 + ... に切り詰める。"""
+        long_text = "x" * 1000
+        docs = [
+            {
+                "title": "Long Doc",
+                "source_url": "https://example.com/long",
+                "summary": "Has long text",
+                "language": "en",
+                "source_type": "internet_archive",
+                "raw_text": long_text,
+            }
+        ]
+        result = _format_documents("en", docs)
+        assert "..." in result
+        # 500文字 + "..." が含まれる
+        assert "x" * 500 in result
+
+    def test_language_name_in_header(self):
+        """ヘッダーに言語名が含まれる。"""
+        docs = [
+            {
+                "title": "Dokument",
+                "source_url": "https://example.com/de",
+                "summary": "Ein Test",
+                "language": "de",
+                "source_type": "ddb",
+            }
+        ]
+        result = _format_documents("de", docs)
+        assert "German" in result
+
+    def test_japanese_language_name(self):
+        """日本語ドキュメントのヘッダーに Japanese が含まれる。"""
+        docs = [
+            {
+                "title": "テスト文書",
+                "source_url": "https://example.com/ja",
+                "summary": "テスト",
+                "language": "ja",
+                "source_type": "ndl",
+            }
+        ]
+        result = _format_documents("ja", docs)
+        assert "Japanese" in result
+
+
+class TestCreateAggregator:
+    """create_aggregator ファクトリのテスト。"""
+
+    def test_creates_base_agent(self):
+        """AggregatorAgent が BaseAgent インスタンスとして生成される。"""
+        from google.adk.agents import BaseAgent
+
+        agg = create_aggregator()
+        assert isinstance(agg, BaseAgent)
+
+    def test_agent_name(self):
+        """エージェント名が 'aggregator' である。"""
+        agg = create_aggregator()
+        # BaseAgent の name プロパティは直接比較可能
+        assert "aggregator" in repr(agg)

--- a/tests/unit/test_api_librarians.py
+++ b/tests/unit/test_api_librarians.py
@@ -1,0 +1,78 @@
+"""API ベース Librarian エージェントファクトリのユニットテスト。"""
+
+import pytest
+
+from mystery_agents.agents.api_librarians import (
+    API_CONFIGS,
+    create_all_api_librarians,
+    create_api_librarian,
+)
+
+
+class TestAPILibrarianFactory:
+    """API Librarian ファクトリ関数のテスト。"""
+
+    def test_create_all_returns_correct_count(self):
+        """全 API Librarian が生成される。"""
+        librarians = create_all_api_librarians()
+        assert len(librarians) == len(API_CONFIGS)
+
+    def test_all_have_unique_names(self):
+        """全 Librarian のエージェント名がユニーク。"""
+        librarians = create_all_api_librarians()
+        names = [agent.name for agent in librarians]
+        assert len(names) == len(set(names))
+
+    def test_all_have_unique_output_keys(self):
+        """全 Librarian の output_key がユニーク。"""
+        librarians = create_all_api_librarians()
+        keys = [agent.output_key for agent in librarians]
+        assert len(keys) == len(set(keys))
+
+    def test_output_key_format(self):
+        """output_key が collected_documents_{api_key} 形式。"""
+        for api_key in API_CONFIGS:
+            agent = create_api_librarian(api_key)
+            assert agent.output_key == f"collected_documents_{api_key}"
+
+    def test_us_archives_has_newspaper_tool(self):
+        """USArchivesLibrarian は search_newspapers ツールを持つ。"""
+        from mystery_agents.tools.librarian_tools import search_newspapers
+
+        agent = create_api_librarian("us_archives")
+        assert search_newspapers in agent.tools
+
+    def test_non_us_lacks_newspaper_tool(self):
+        """US 以外の Librarian は search_newspapers を持たない。"""
+        from mystery_agents.tools.librarian_tools import search_newspapers
+
+        for api_key in ["europeana", "internet_archive", "ddb", "ndl", "trove", "wellcome"]:
+            agent = create_api_librarian(api_key)
+            assert search_newspapers not in agent.tools
+
+    def test_all_have_search_archives_tool(self):
+        """全 Librarian が search_archives ツールを持つ。"""
+        from mystery_agents.tools.librarian_tools import search_archives
+
+        librarians = create_all_api_librarians()
+        for agent in librarians:
+            assert search_archives in agent.tools
+
+    def test_invalid_api_key_raises(self):
+        """存在しない API キーで KeyError が発生する。"""
+        with pytest.raises(KeyError):
+            create_api_librarian("nonexistent_api")
+
+    @pytest.mark.parametrize("api_key", list(API_CONFIGS.keys()))
+    def test_instruction_contains_api_name(self, api_key):
+        """各 Librarian の instruction に API 名が含まれる。"""
+        agent = create_api_librarian(api_key)
+        display_name = API_CONFIGS[api_key]["api_display_name"]
+        assert display_name in agent.instruction
+
+    def test_agent_name_format(self):
+        """エージェント名が librarian_{api_key} 形式。"""
+        for api_key in API_CONFIGS:
+            agent = create_api_librarian(api_key)
+            # MagicMock 環境では .name がモックされるため repr で検証
+            assert f"librarian_{api_key}" in repr(agent)

--- a/tests/unit/test_source_registry.py
+++ b/tests/unit/test_source_registry.py
@@ -165,10 +165,10 @@ class TestEnsureAllLoaded:
         """実際のモジュールがロードされ、ソースが登録される。"""
         all_sources = get_all_sources()
 
-        # 全 API ツールが登録されていること
+        # 全 API ツールが登録されていること（Delpher は除外済み）
         expected_keys = {
             "loc", "dpla", "nypl", "internet_archive",
-            "ddb", "europeana", "chronicling_america", "trove", "delpher",
+            "ddb", "europeana", "chronicling_america", "trove",
             "ndl", "wellcome",
         }
         assert expected_keys.issubset(set(all_sources.keys()))

--- a/tests/unit/test_state_registry.py
+++ b/tests/unit/test_state_registry.py
@@ -14,7 +14,8 @@ class TestStateKeyDefinitions:
     def test_no_orphan_keys(self):
         """writer はあるが reader がいないキーは published_episode のみ許容。"""
         orphans = [k.name for k in STATE_KEYS if not k.read_by]
-        allowed_orphans = {"published_episode"}
+        # active_languages は PR 3 の DynamicScholarBlock が reader になる予定
+        allowed_orphans = {"published_episode", "active_languages"}
         unexpected = set(orphans) - allowed_orphans
         assert not unexpected, f"Unexpected orphan keys: {unexpected}"
 


### PR DESCRIPTION
## Summary

言語ベース Librarian（7言語）を **API ベース Librarian（7グループ）** に再構築し、テーマに応じた自律的な検索判断を実現。

- **API Librarian（7グループ）**: USArchives / Europeana / Internet Archive / DDB / NDL / Trove / Wellcome
  - 各 Librarian がテーマとの関連性を自律判断し、無関連なら検索をスキップ
  - API 特性に最適化されたキーワード生成（DDB→ドイツ語、NDL→日本語 等）
- **AggregatorAgent（BaseAgent, LLM 不使用）**: raw_search_results を言語別に集約
  - ドキュメントの `language` フィールドに基づく確実なグルーピング
  - `collected_documents_{lang}` に Scholar が読める形式で書き込み
  - `active_languages`（ドキュメント数ランキング）で動的な言語選択
- **Scholar 以降は完全互換**: `collected_documents_{lang}` 形式が維持されるため変更なし

### パイプライン変更

```
Before: ParallelLibrarians(7 langs) → ScholarBlock → ...
After:  ParallelAPILibrarians(7 APIs) → Aggregator → ScholarBlock → ...
```

### 変更ファイル
- 新規: `api_librarians.py`, `aggregator.py`, `test_api_librarians.py`, `test_aggregator.py`
- 変更: `agent.py`, `__init__.py`, `source_registry.py`, `state_registry.py`, `CLAUDE.md`
- テスト更新: `test_agent_handover.py`, `test_source_registry.py`, `test_state_registry.py`
- Delpher をソースレジストリから除外

## Test plan
- [x] 新規ユニットテスト 25 件（API Librarian 17 + Aggregator 8）
- [x] 既存テスト 1063 件の互換性確認
- [x] 全 1088 テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)