### PR TITLE
fix: アーカイブ画像の水平中央配置を flexbox に変更

### DIFF
--- a/web-admin/src/app/(main)/preview/[id]/preview-content.tsx
+++ b/web-admin/src/app/(main)/preview/[id]/preview-content.tsx
@@ -40,7 +40,7 @@ function PreviewArchiveImage({ src, alt }: { src?: string; alt?: string }) {
   const [hasError, setHasError] = useState(false)
   if (!src || hasError) return null
   return (
-    <figure className="not-prose my-8 mx-auto w-fit max-w-3xl">
+    <figure className="not-prose my-8 flex flex-col items-center">
       <img
         src={src}
         alt={alt || "Archival Image"}

--- a/web-public/src/components/mystery/archive-image.tsx
+++ b/web-public/src/components/mystery/archive-image.tsx
@@ -24,7 +24,7 @@ export function ArchiveImage({ src, alt, lang }: ArchiveImageProps) {
   const label = IMAGE_LABEL[lang] || IMAGE_LABEL.en
 
   return (
-    <figure className="not-prose my-8 mx-auto w-fit max-w-3xl">
+    <figure className="not-prose my-8 flex flex-col items-center">
       <img
         src={src}
         alt={alt || label}


### PR DESCRIPTION
## Summary

- Tailwind CSS v4 の `prose` コンテキスト内で `w-fit mx-auto` が意図通りに機能しない問題を修正
- `flex flex-col items-center` による明示的な flexbox 中央配置に変更
- web-public（`ArchiveImage`）と web-admin（`PreviewArchiveImage`）の両方を修正

## 変更内容

| ファイル | 変更 |
|---------|------|
| `web-public/src/components/mystery/archive-image.tsx` | `w-fit mx-auto max-w-3xl` → `flex flex-col items-center` |
| `web-admin/src/app/(main)/preview/[id]/preview-content.tsx` | 同上 |

## Test plan

- [ ] web-public で記事詳細ページを開き、本文中のアーカイブ画像が水平中央に表示されることを確認
- [ ] web-admin でプレビューページを開き、同様に確認
- [ ] 画像幅がコンテナ幅より狭い場合と広い場合の両方で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)