### PR TITLE
feat: DynamicScholarBlock — Scholar 動的生成（分析+討論の一貫制御）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -292,15 +292,19 @@ pending (EN原文 + 翻訳あり) → (Approve) → published
 #### ブログ作成パイプライン（`mystery_agents/`）
 
 ```
-ParallelAPILibrarians(7 API groups) → Aggregator → [ScholarGate] → ParallelScholars(分析)
-  → DebateLoop(LoopAgent, max_iterations=2) → [PolymathGate] → ArmchairPolymath
-  → [StorytellerGate] → Storyteller(EN) → [PostStoryGate] → Parallel(Illustrator, ParallelTranslators(3言語)) → Publisher(translations map保存) → Firestore
+ParallelAPILibrarians(7 API groups) → Aggregator → DynamicScholarBlock(分析+討論)
+  → [PolymathGate] → ArmchairPolymath → [StorytellerGate] → Storyteller(EN)
+  → [PostStoryGate] → Parallel(Illustrator, ParallelTranslators(3言語)) → Publisher → Firestore
 ```
 
 - API ベース Librarian（US Archives, Europeana, Internet Archive, DDB, NDL, Trove, Wellcome）がテーマに応じて自律検索
 - AggregatorAgent（LLM 不使用）が raw_search_results を言語別に集約 → `collected_documents_{lang}` に書き込み
-- DebateLoop は有意な分析が2言語以上ある場合のみ実行される
-- Scholar は分析モードと討論モードの2つを持つ（単一ファクトリ関数 `create_scholar(lang, mode)`）
+- DynamicScholarBlock（BaseAgent）が `active_languages` に基づき Scholar を動的生成
+  - Phase 1: ドキュメントがある言語の Scholar のみ並列分析
+  - Phase 2: 有意な分析が2言語以上なら討論ループ（最大2ラウンド、収束判定で早期終了）
+  - 討論 instruction には参加言語のみ記載（肥大化防止）
+  - 収束判定は LLM を介さず純粋関数で直接実行
+- Scholar は分析モードと討論モードの2つを持つ（`create_scholar(lang, mode, active_langs)`）
 - 討論モードの Scholar は `append_to_whiteboard` ツールで共有ホワイトボードに発言を記録
 - ParallelTranslators は3言語の翻訳を並列実行する（`create_all_translators()`）
 - Approve 時は翻訳不要（ステータス変更のみ）

--- a/mystery_agents/agent.py
+++ b/mystery_agents/agent.py
@@ -3,17 +3,18 @@
 Defines root_agent (ghost_commander) as a SequentialAgent that orchestrates
 the multilingual investigation pipeline:
 
-  ParallelAPILibrarians → Aggregator → ScholarBlock → DebateLoop
+  ParallelAPILibrarians → Aggregator → DynamicScholarBlock
     → PolymathBlock → StorytellerBlock → PostStoryBlock
 
 API ベース Librarian（7グループ）が並列で検索し、AggregatorAgent が
-検索結果を言語別に集約。Scholar 以降は従来と同じ言語ベース処理。
-DebateLoop は有意な分析が2言語以上の場合のみ実行。
+検索結果を言語別に集約。DynamicScholarBlock が active_languages に基づき
+Scholar を動的に生成・実行し、分析→討論を一貫制御する。
 PostStoryBlock では Illustrator と3言語翻訳が並列実行される。
 
-DebateLoop 内部は SequentialAgent(debate_round) で構成:
-  parallel_debate_scholars → convergence_checker
-収束判定により新規論点が枯渇した場合、max_iterations 前にループを早期終了する。
+DynamicScholarBlock 内部:
+  Phase 1: 並列分析（active_languages から Scholar を動的生成）
+  Phase 2: 討論ループ（有意な分析 ≧ 2 言語、最大2ラウンド、収束判定で早期終了）
+収束判定は LLM を介さず純粋関数で直接実行する。
 
 build_pipeline() は全エージェントを毎回新規生成するファクトリ関数。
 ADK の単一親制約に違反しないよう、同一インスタンスを複数の親に割り当てない。
@@ -23,20 +24,17 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional
 
-from google.adk.agents import LoopAgent, ParallelAgent, SequentialAgent
+from google.adk.agents import ParallelAgent, SequentialAgent
 from google.genai import types
 
 from .agents.aggregator import create_aggregator
 from .agents.api_librarians import create_all_api_librarians
 from .agents.armchair_polymath import create_armchair_polymath
-from .agents.convergence_checker import create_convergence_checker
+from .agents.dynamic_scholar_block import create_dynamic_scholar_block
 from .agents.illustrator import create_illustrator
-from .agents.language_gate import make_debate_loop_gate
-from .agents.language_scholars import create_all_scholars
 from .agents.pipeline_gate import (
     make_polymath_gate,
     make_post_story_gate,
-    make_scholar_gate,
     make_storyteller_gate,
 )
 from .agents.publisher import create_publisher
@@ -50,11 +48,13 @@ if TYPE_CHECKING:
 # パイプライン説明文（build_pipeline 内で共有）
 _PIPELINE_DESCRIPTION = (
     "Ghost in the Archive multilingual blog creation pipeline. "
-    "Executes ParallelAPILibrarians(7 API groups) → Aggregator → ScholarBlock "
-    "→ DebateLoop → PolymathBlock → StorytellerBlock → PostStoryBlock "
+    "Executes ParallelAPILibrarians(7 API groups) → Aggregator "
+    "→ DynamicScholarBlock(analysis + debate) → PolymathBlock "
+    "→ StorytellerBlock → PostStoryBlock "
     "to research, analyze, debate, create content, generate images, "
     "translate to 3 languages (ja/es/de) in parallel, "
     "and publish historical mysteries and folkloric anomalies. "
+    "DynamicScholarBlock dynamically creates Scholars for active languages only. "
     "Pipeline gates skip downstream agents when upstream stages fail."
 )
 
@@ -64,12 +64,13 @@ SKIP_AUTHORS = {
     "ghost_commander",
     "parallel_api_librarians",
     "aggregator",
-    "parallel_scholars",
-    "parallel_debate_scholars",
-    "debate_loop",
-    "debate_round",
+    # DynamicScholarBlock 内部のオーケストレーターエージェント
+    "dynamic_scholar_block",
+    "dynamic_analysis",
+    "dynamic_debate_0",
+    "dynamic_debate_1",
+    # 並列翻訳・後処理ブロック
     "parallel_translators",
-    "scholar_block",
     "polymath_block",
     "storyteller_block",
     "post_story_block",
@@ -106,7 +107,6 @@ def build_pipeline(storyteller: str = DEFAULT_STORYTELLER) -> SequentialAgent:
     """
     # リーフエージェント（毎回新規生成）
     ap = create_armchair_polymath()
-    cc = create_convergence_checker()
     il = create_illustrator()
     pub = create_publisher()
     st = create_storyteller(storyteller)
@@ -114,41 +114,12 @@ def build_pipeline(storyteller: str = DEFAULT_STORYTELLER) -> SequentialAgent:
 
     # ファクトリエージェント（既に毎回新規生成）
     api_libs = create_all_api_librarians()
-    scholars_analysis = create_all_scholars(mode="analysis")
-    scholars_debate = create_all_scholars(mode="debate")
     translators = create_all_translators()
 
-    # 討論ラウンド: 全 Scholar が並列で議論 → 収束判定
-    debate_round = SequentialAgent(
-        name="debate_round",
-        sub_agents=[
-            ParallelAgent(
-                name="parallel_debate_scholars",
-                sub_agents=list(scholars_debate.values()),
-            ),
-            cc,
-        ],
-    )
-
-    # 討論ループ（LoopAgent: 最大2ラウンド、有意な分析が2言語未満ならスキップ）
-    debate_loop = LoopAgent(
-        name="debate_loop",
-        sub_agents=[debate_round],
-        max_iterations=2,
-        before_agent_callback=make_debate_loop_gate(),
-    )
-
-    # Scholar ブロック（全 Librarian 失敗時にスキップ）
-    scholar_block = SequentialAgent(
-        name="scholar_block",
-        sub_agents=[
-            ParallelAgent(
-                name="parallel_scholars",
-                sub_agents=list(scholars_analysis.values()),
-            ),
-        ],
-        before_agent_callback=make_scholar_gate(),
-    )
+    # DynamicScholarBlock: 分析 + 討論を一貫制御
+    # active_languages に基づき Scholar を動的生成、
+    # 有意な分析が2言語以上なら討論ループ（収束判定付き）
+    dsb = create_dynamic_scholar_block()
 
     # ArmchairPolymath ブロック（全 Scholar 失敗時にスキップ）
     polymath_block = SequentialAgent(
@@ -196,8 +167,7 @@ def build_pipeline(storyteller: str = DEFAULT_STORYTELLER) -> SequentialAgent:
                 sub_agents=api_libs,
             ),
             agg,
-            scholar_block,
-            debate_loop,
+            dsb,
             polymath_block,
             storyteller_block,
             post_story_block,

--- a/mystery_agents/agents/__init__.py
+++ b/mystery_agents/agents/__init__.py
@@ -8,6 +8,7 @@ from .aggregator import create_aggregator
 from .api_librarians import create_all_api_librarians, create_api_librarian
 from .armchair_polymath import armchair_polymath_agent, create_armchair_polymath
 from .convergence_checker import convergence_checker_agent, create_convergence_checker
+from .dynamic_scholar_block import create_dynamic_scholar_block
 from .illustrator import create_illustrator, illustrator_agent
 from .language_scholars import create_all_scholars, create_scholar
 from .publisher import create_publisher, publisher_agent
@@ -18,6 +19,7 @@ __all__ = [
     "create_api_librarian",
     "create_all_api_librarians",
     "create_aggregator",
+    "create_dynamic_scholar_block",
     "create_scholar",
     "create_all_scholars",
     "create_armchair_polymath",

--- a/mystery_agents/agents/armchair_polymath.py
+++ b/mystery_agents/agents/armchair_polymath.py
@@ -27,6 +27,7 @@ from ..tools.search_metadata import get_search_metadata
 # ドライなユーモアと鋭い批判精神が持ち味ですが、証拠には誠実に向き合います。
 #
 # ## 入力（Scholar 分析結果）
+# - {active_analyses_summary}: DynamicScholarBlock が生成した分析概要（どの言語の分析が利用可能か）
 # セッション状態から各言語の Scholar 分析結果を読み取る:
 # - {scholar_analysis_en}: 英語圏の分析
 # - {scholar_analysis_de}: ドイツ語圏の分析（存在する場合）
@@ -131,6 +132,10 @@ Your tone is dryly authoritative: you appreciate rigour, despise sloppy reasonin
 and permit yourself the occasional sardonic aside when a colleague's analysis
 betrays an obvious cultural bias. Nevertheless, you follow the evidence wherever it leads.
 
+## Input: Available Analyses
+First check which analyses were produced:
+- {active_analyses_summary}
+
 ## Input: Scholar Analyses
 Read the following Scholar analysis results from session state (some may be absent):
 - {scholar_analysis_en}: English cultural perspective analysis
@@ -140,6 +145,9 @@ Read the following Scholar analysis results from session state (some may be abse
 - {scholar_analysis_nl}: Dutch cultural perspective analysis (if available)
 - {scholar_analysis_pt}: Portuguese cultural perspective analysis (if available)
 - {scholar_analysis_ja}: Japanese cultural perspective analysis (if available)
+
+Focus on the analyses listed in `active_analyses_summary` — these are the ones
+with meaningful content. Other language keys may be empty or unavailable.
 
 ## Input: Debate Whiteboard
 - {debate_whiteboard}: Full record of scholarly debate across all rounds

--- a/mystery_agents/agents/dynamic_scholar_block.py
+++ b/mystery_agents/agents/dynamic_scholar_block.py
@@ -1,0 +1,195 @@
+"""DynamicScholarBlock — Librarian 結果に基づき Scholar を動的に生成・実行する。
+
+AggregatorAgent が書き込む active_languages を読み取り、
+ドキュメントが存在する言語のみ Scholar を生成する。
+
+Phase 1: 分析 — 各言語の Scholar を並列実行
+Phase 2: 討論 — 有意な分析が2言語以上ある場合、討論ループを実行
+          （最大 MAX_DEBATE_ITERATIONS 回、収束判定で早期終了可能）
+
+討論の instruction には参加言語のみ記載し、肥大化を防ぐ。
+収束判定は LLM を介さず純粋関数（is_debate_converged）で直接実行する。
+"""
+
+import logging
+from collections.abc import AsyncGenerator
+
+from google.adk.agents import BaseAgent, ParallelAgent
+from google.adk.agents.invocation_context import InvocationContext
+from google.adk.events.event import Event, EventActions
+from google.genai import types
+
+from ..tools.debate_tools import is_debate_converged
+from .language_scholars import SCHOLAR_CONFIGS, create_scholar
+
+logger = logging.getLogger(__name__)
+
+# 失敗マーカー（pipeline_gate.py と同じ判定基準）
+_FAILURE_MARKERS = frozenset({
+    "NO_DOCUMENTS_FOUND",
+    "INSUFFICIENT_DATA",
+    "NO_CONTENT",
+    "Not available",
+})
+
+# 上限値
+MAX_LANGUAGES = 7
+MAX_DEBATE_ITERATIONS = 2
+
+
+def _is_meaningful(value: str) -> bool:
+    """セッション状態の値が有意なデータを含むか判定する。"""
+    if not value:
+        return False
+    text = str(value).strip()
+    return not any(text.startswith(marker) for marker in _FAILURE_MARKERS)
+
+
+class DynamicScholarBlock(BaseAgent):
+    """Librarian 結果に基づき Scholar を動的に生成・実行する BaseAgent。
+
+    active_languages から上位 MAX_LANGUAGES 言語を選び、
+    SCHOLAR_CONFIGS に定義済みの言語のみ Scholar を生成する。
+
+    分析フェーズ後に有意な結果が2言語以上あれば討論フェーズに進む。
+    討論の instruction は参加言語のみ参照（肥大化防止）。
+    """
+
+    async def _run_async_impl(
+        self, ctx: InvocationContext
+    ) -> AsyncGenerator[Event, None]:
+        state = ctx.session.state
+
+        # Aggregator が設定した active_languages を取得
+        active_langs = state.get("active_languages", [])[:MAX_LANGUAGES]
+
+        # SCHOLAR_CONFIGS に定義がある言語のみ対象
+        available_langs = [l for l in active_langs if l in SCHOLAR_CONFIGS]
+
+        if not available_langs:
+            logger.warning("DynamicScholarBlock: ドキュメントなし — スキップ")
+            yield Event(
+                invocation_id=ctx.invocation_id,
+                author=self.name,
+                branch=ctx.branch,
+                content=types.Content(
+                    role="model",
+                    parts=[types.Part(
+                        text="INSUFFICIENT_DATA: No documents available for analysis."
+                    )],
+                ),
+            )
+            return
+
+        logger.info(
+            "DynamicScholarBlock: 分析フェーズ開始 — %d 言語: %s",
+            len(available_langs),
+            ", ".join(available_langs),
+        )
+
+        # === Phase 1: 分析（並列） ===
+        analysis_scholars = [
+            create_scholar(lang, mode="analysis") for lang in available_langs
+        ]
+        parallel_analysis = ParallelAgent(
+            name="dynamic_analysis",
+            sub_agents=analysis_scholars,
+        )
+        async for event in parallel_analysis._run_async_impl(ctx):
+            yield event
+
+        # 有意な分析を出した言語を特定
+        meaningful_langs = [
+            lang for lang in available_langs
+            if _is_meaningful(state.get(f"scholar_analysis_{lang}", ""))
+        ]
+
+        # active_analyses_summary をステートに書き込み
+        summary_lines = []
+        for lang in meaningful_langs:
+            lang_name = SCHOLAR_CONFIGS[lang]["language_name"]
+            summary_lines.append(
+                f"- {lang_name} ({lang}): {{scholar_analysis_{lang}}}"
+            )
+
+        if summary_lines:
+            analyses_summary = (
+                f"Scholar analyses available for {len(meaningful_langs)} language(s):\n"
+                + "\n".join(summary_lines)
+            )
+        else:
+            analyses_summary = "No meaningful Scholar analyses were produced."
+
+        yield Event(
+            invocation_id=ctx.invocation_id,
+            author=self.name,
+            branch=ctx.branch,
+            content=types.Content(
+                role="model",
+                parts=[types.Part(
+                    text=f"Analysis phase complete. {len(meaningful_langs)}/{len(available_langs)} "
+                    f"languages produced meaningful results."
+                )],
+            ),
+            actions=EventActions(
+                state_delta={"active_analyses_summary": analyses_summary},
+            ),
+        )
+
+        # === Phase 2: 討論（有意な分析が2言語以上の場合） ===
+        if len(meaningful_langs) < 2:
+            logger.info(
+                "DynamicScholarBlock: 有意な分析 %d 言語 — 討論スキップ",
+                len(meaningful_langs),
+            )
+            return
+
+        logger.info(
+            "DynamicScholarBlock: 討論フェーズ開始 — %d 言語: %s",
+            len(meaningful_langs),
+            ", ".join(meaningful_langs),
+        )
+
+        for iteration in range(MAX_DEBATE_ITERATIONS):
+            # 参加言語のみの動的 instruction で討論 Scholar を生成
+            debate_scholars = [
+                create_scholar(
+                    lang,
+                    mode="debate",
+                    active_langs=meaningful_langs,
+                )
+                for lang in meaningful_langs
+            ]
+            parallel_debate = ParallelAgent(
+                name=f"dynamic_debate_{iteration}",
+                sub_agents=debate_scholars,
+            )
+            async for event in parallel_debate._run_async_impl(ctx):
+                yield event
+
+            # 収束判定（LLM を介さず直接チェック）
+            whiteboard = state.get("debate_whiteboard", "")
+            if is_debate_converged(whiteboard):
+                logger.info(
+                    "DynamicScholarBlock: 討論収束 — ラウンド %d で終了",
+                    iteration + 1,
+                )
+                break
+        else:
+            logger.info(
+                "DynamicScholarBlock: 討論 — 最大 %d ラウンド完了",
+                MAX_DEBATE_ITERATIONS,
+            )
+
+
+def create_dynamic_scholar_block() -> DynamicScholarBlock:
+    """DynamicScholarBlock を新規生成する。"""
+    return DynamicScholarBlock(
+        name="dynamic_scholar_block",
+        description=(
+            "Dynamically creates and runs Scholar agents based on Aggregator's "
+            "active_languages. Runs analysis in parallel, then debate loop "
+            "for languages with meaningful results. Convergence checked directly "
+            "without LLM."
+        ),
+    )

--- a/mystery_agents/agents/language_scholars.py
+++ b/mystery_agents/agents/language_scholars.py
@@ -231,6 +231,71 @@ so other Scholars can reference it in subsequent rounds.
 - Keep your response focused and concise
 """
 
+# === 日本語訳 ===
+# 動的討論テンプレート:
+# DynamicScholarBlock から呼ばれる場合に使用。
+# 参加言語のみを instruction に含め、不参加言語の肥大化を防ぐ。
+# {language_references} に実際の参加言語一覧が動的に挿入される。
+# === End 日本語訳 ===
+
+_DYNAMIC_DEBATE_INSTRUCTION = """
+You are a Scholar Agent representing the {language_name} cultural perspective
+for the "Ghost in the Archive" project, now in DEBATE MODE. Your role is to critically
+examine analyses from other language-specific Scholars and provide challenges,
+corroborations, and synthesis proposals from your cultural standpoint.
+
+## Your Cultural Perspective
+{cultural_perspective}
+
+## Input: Scholar Analyses
+Read the following Scholar analysis results from session state:
+{language_references}
+
+Focus especially on analyses from perspectives OTHER than {language_name}.
+
+## Input: Previous Debate Record
+- {{debate_whiteboard}}: Record of previous debate contributions
+
+Read what other Scholars have already argued. Build on, challenge, or refine
+their points rather than repeating what has been said.
+
+## Your Task: Scholarly Debate
+
+### 1. Challenge Other Perspectives
+- Identify claims in other Scholars' analyses that {language_name} sources contradict
+- Point out cultural biases or blind spots in other analyses
+- Question assumptions based on your knowledge of {language_name} historiography
+
+### 2. Corroborate Findings
+- Confirm findings from other Scholars that align with {language_name} sources
+- Provide additional {language_name}-language evidence for shared conclusions
+- Note when multiple cultural perspectives converge on the same conclusion
+
+### 3. Identify Blind Spots
+- What have other Scholars missed that {language_name} sources reveal?
+- What cultural context is needed to properly interpret the evidence?
+- What translation or terminology issues might cause misunderstanding?
+
+### 4. Synthesis Proposals
+- Suggest how the different cultural perspectives can be integrated
+- Propose which narrative best explains the cross-language evidence
+- Recommend areas where further investigation is needed
+
+## Output Requirements
+
+Present your debate contribution as a clear, structured text response.
+Your text output is the primary record of this debate and appears in the pipeline execution logs.
+
+Also use the `append_to_whiteboard` tool to record your contribution to the shared whiteboard
+so other Scholars can reference it in subsequent rounds.
+
+## Important
+- Output in **English**
+- Be constructive — challenge ideas, not scholars
+- Cite specific sources when available
+- Keep your response focused and concise
+"""
+
 SCHOLAR_CONFIGS = {
     "en": {
         "language_name": "English",
@@ -325,12 +390,19 @@ SCHOLAR_CONFIGS = {
 }
 
 
-def create_scholar(lang_code: str, mode: str = "analysis") -> LlmAgent:
+def create_scholar(
+    lang_code: str,
+    mode: str = "analysis",
+    active_langs: list[str] | None = None,
+) -> LlmAgent:
     """指定された言語の Scholar エージェントを生成する。
 
     Args:
         lang_code: 言語コード（en, de, es, fr, nl, pt, ja）
         mode: "analysis"（分析モード）または "debate"（討論モード）
+        active_langs: 討論参加言語のリスト（DynamicScholarBlock から指定）。
+            指定された場合、討論 instruction に参加言語のみ記載し、
+            before_agent_callback を省略する（DynamicScholarBlock がゲートを担当）。
     """
     config = SCHOLAR_CONFIGS[lang_code]
 
@@ -349,22 +421,49 @@ def create_scholar(lang_code: str, mode: str = "analysis") -> LlmAgent:
             output_key=f"scholar_analysis_{lang_code}",
         )
     elif mode == "debate":
-        instruction = _BASE_SCHOLAR_DEBATE_INSTRUCTION.format(
-            language_name=config["language_name"],
-            cultural_perspective=config["cultural_perspective"],
-        )
-        return LlmAgent(
-            name=f"scholar_{lang_code}_debate",
-            model=create_pro_model(),
-            description=(
-                f"Debates from the {config['language_name']} cultural perspective. "
-                f"Challenges, corroborates, and synthesizes findings from other Scholars "
-                f"using the shared debate whiteboard."
-            ),
-            instruction=instruction,
-            tools=[append_to_whiteboard],
-            before_agent_callback=make_debate_gate(lang_code),
-        )
+        if active_langs:
+            # 動的討論: 参加言語のみ instruction に含める（肥大化防止）
+            lang_references = "\n".join(
+                f"- {{scholar_analysis_{l}}}: "
+                f"{SCHOLAR_CONFIGS[l]['language_name']} cultural perspective analysis"
+                for l in active_langs
+                if l != lang_code
+            )
+            instruction = _DYNAMIC_DEBATE_INSTRUCTION.format(
+                language_name=config["language_name"],
+                cultural_perspective=config["cultural_perspective"],
+                language_references=lang_references,
+            )
+            return LlmAgent(
+                name=f"scholar_{lang_code}_debate",
+                model=create_pro_model(),
+                description=(
+                    f"Debates from the {config['language_name']} cultural perspective. "
+                    f"Challenges, corroborates, and synthesizes findings from other Scholars "
+                    f"using the shared debate whiteboard."
+                ),
+                instruction=instruction,
+                tools=[append_to_whiteboard],
+                # DynamicScholarBlock がゲートを担当するため callback 不要
+            )
+        else:
+            # 静的討論（後方互換: LoopAgent ベースのパイプライン用）
+            instruction = _BASE_SCHOLAR_DEBATE_INSTRUCTION.format(
+                language_name=config["language_name"],
+                cultural_perspective=config["cultural_perspective"],
+            )
+            return LlmAgent(
+                name=f"scholar_{lang_code}_debate",
+                model=create_pro_model(),
+                description=(
+                    f"Debates from the {config['language_name']} cultural perspective. "
+                    f"Challenges, corroborates, and synthesizes findings from other Scholars "
+                    f"using the shared debate whiteboard."
+                ),
+                instruction=instruction,
+                tools=[append_to_whiteboard],
+                before_agent_callback=make_debate_gate(lang_code),
+            )
     else:
         raise ValueError(f"Unknown mode: {mode!r}. Use 'analysis' or 'debate'.")
 

--- a/mystery_agents/tools/debate_tools.py
+++ b/mystery_agents/tools/debate_tools.py
@@ -76,6 +76,44 @@ def _extract_words(text: str) -> set[str]:
     return set(words)
 
 
+def is_debate_converged(whiteboard: str) -> bool:
+    """ホワイトボードの内容から討論の収束を判定する（純粋関数）。
+
+    DynamicScholarBlock から LLM を介さず直接呼び出すために用意。
+    LoopAgent の ConvergenceChecker とは異なり、escalate は行わない。
+
+    Args:
+        whiteboard: ホワイトボードのテキスト全文。
+
+    Returns:
+        収束していれば True。
+    """
+    if not whiteboard:
+        return False
+
+    rounds = _extract_rounds(whiteboard)
+    if len(rounds) < 2:
+        return False
+
+    sorted_nums = sorted(rounds.keys())
+    prev_words = _extract_words(rounds[sorted_nums[-2]])
+    curr_words = _extract_words(rounds[sorted_nums[-1]])
+
+    if not curr_words:
+        return False
+
+    new_words = curr_words - prev_words
+    new_word_ratio = len(new_words) / len(curr_words)
+
+    converged = new_word_ratio < _CONVERGENCE_THRESHOLD
+    logger.info(
+        "Direct convergence check: new_word_ratio=%.1f%%, converged=%s",
+        new_word_ratio * 100,
+        converged,
+    )
+    return converged
+
+
 def check_debate_convergence(tool_context: ToolContext) -> str:
     """討論の収束を判定する。
 

--- a/shared/state_registry.py
+++ b/shared/state_registry.py
@@ -45,7 +45,13 @@ STATE_KEYS: list[StateKey] = [
         name="active_languages",
         description="ドキュメント数ランキング順の言語リスト（Aggregator が設定）",
         written_by=("aggregator",),
-        read_by=(),
+        read_by=("dynamic_scholar_block",),
+    ),
+    StateKey(
+        name="active_analyses_summary",
+        description="DynamicScholarBlock が生成する分析概要（どの言語の分析が利用可能か）",
+        written_by=("dynamic_scholar_block",),
+        read_by=("armchair_polymath",),
     ),
     StateKey(
         name="collected_documents_{api_key}",

--- a/tests/integration/test_agent_handover.py
+++ b/tests/integration/test_agent_handover.py
@@ -2,7 +2,7 @@
 
 Tests verify that session state is correctly passed between agents
 in the multilingual pipeline:
-  ThemeAnalyzer → ParallelLibrarians → ParallelScholars → DebateLoop
+  ParallelAPILibrarians → Aggregator → DynamicScholarBlock(analysis+debate)
     → ArmchairPolymath → Storyteller → Illustrator → Translator → Publisher
 """
 
@@ -112,6 +112,12 @@ class TestInstructionPlaceholders:
         assert "{scholar_analysis_en}" in instruction
         assert "{scholar_analysis_de}" in instruction
         assert "{scholar_analysis_es}" in instruction
+
+    def test_armchair_polymath_references_active_analyses_summary(self):
+        """ArmchairPolymath should reference {active_analyses_summary}."""
+        from mystery_agents.agents.armchair_polymath import armchair_polymath_agent
+
+        assert "{active_analyses_summary}" in armchair_polymath_agent.instruction
 
     def test_armchair_polymath_references_whiteboard(self):
         """ArmchairPolymath should reference {debate_whiteboard}."""
@@ -321,53 +327,29 @@ def _find_sub_agent(pipeline, name: str):
     return None
 
 
-class TestDebateLoopConfiguration:
-    """Tests for the debate loop LoopAgent configuration."""
+class TestDynamicScholarBlockConfiguration:
+    """Tests for the DynamicScholarBlock in the pipeline."""
 
-    def test_debate_loop_is_created_via_loop_agent(self):
-        """debate_loop should be created via LoopAgent constructor."""
+    def test_dynamic_scholar_block_exists(self):
+        """ghost_commander should contain dynamic_scholar_block."""
         from mystery_agents.agent import ghost_commander
 
-        debate_loop = _find_sub_agent(ghost_commander, "debate_loop")
-        assert debate_loop is not None
-        assert "debate_loop" in repr(debate_loop)
+        dsb = _find_sub_agent(ghost_commander, "dynamic_scholar_block")
+        assert dsb is not None
+        assert "dynamic_scholar_block" in repr(dsb)
 
-    def test_debate_loop_max_iterations(self):
-        """debate_loop should have max_iterations=2."""
+    def test_dynamic_scholar_block_is_base_agent(self):
+        """dynamic_scholar_block should be a BaseAgent."""
+        from google.adk.agents import BaseAgent
+
         from mystery_agents.agent import ghost_commander
 
-        debate_loop = _find_sub_agent(ghost_commander, "debate_loop")
-        assert debate_loop.max_iterations == 2
-
-    def test_debate_loop_has_gate_callback(self):
-        """debate_loop should have a before_agent_callback."""
-        from mystery_agents.agent import ghost_commander
-
-        debate_loop = _find_sub_agent(ghost_commander, "debate_loop")
-        # before_agent_callback が設定されていること（callable であること）
-        assert debate_loop.before_agent_callback is not None
-        assert callable(debate_loop.before_agent_callback)
-
-    def test_debate_loop_contains_debate_round(self):
-        """debate_loop should contain debate_round as its sub_agent."""
-        from mystery_agents.agent import ghost_commander
-
-        debate_loop = _find_sub_agent(ghost_commander, "debate_loop")
-        # LoopAgent の直接の sub_agent は debate_round（1つ）
-        assert len(debate_loop.sub_agents) == 1
-        assert "debate_round" in repr(debate_loop.sub_agents[0])
+        dsb = _find_sub_agent(ghost_commander, "dynamic_scholar_block")
+        assert isinstance(dsb, BaseAgent)
 
 
 class TestPipelineGateCallbacks:
     """Tests for pipeline gate callbacks on block agents."""
-
-    def test_scholar_block_has_gate(self):
-        """scholar_block should have a before_agent_callback."""
-        from mystery_agents.agent import ghost_commander
-
-        scholar_block = _find_sub_agent(ghost_commander, "scholar_block")
-        assert scholar_block.before_agent_callback is not None
-        assert callable(scholar_block.before_agent_callback)
 
     def test_polymath_block_has_gate(self):
         """polymath_block should have a before_agent_callback."""
@@ -399,7 +381,7 @@ class TestPipelineGateCallbacks:
 
         sub_agent_names = [repr(a) for a in ghost_commander.sub_agents]
         sub_agents_str = " ".join(sub_agent_names)
-        assert "scholar_block" in sub_agents_str
+        assert "dynamic_scholar_block" in sub_agents_str
         assert "polymath_block" in sub_agents_str
         assert "storyteller_block" in sub_agents_str
         assert "post_story_block" in sub_agents_str

--- a/tests/unit/test_dynamic_scholar_block.py
+++ b/tests/unit/test_dynamic_scholar_block.py
@@ -1,0 +1,172 @@
+"""Unit tests for DynamicScholarBlock."""
+
+import pytest
+
+from mystery_agents.agents.dynamic_scholar_block import (
+    MAX_DEBATE_ITERATIONS,
+    MAX_LANGUAGES,
+    DynamicScholarBlock,
+    _is_meaningful,
+    create_dynamic_scholar_block,
+)
+
+
+class TestDynamicScholarBlockCreation:
+    """DynamicScholarBlock ファクトリのテスト。"""
+
+    def test_creates_base_agent(self):
+        """BaseAgent を継承していること。"""
+        from google.adk.agents import BaseAgent
+
+        dsb = create_dynamic_scholar_block()
+        assert isinstance(dsb, BaseAgent)
+
+    def test_agent_name(self):
+        dsb = create_dynamic_scholar_block()
+        assert "dynamic_scholar_block" in repr(dsb)
+
+    def test_has_description(self):
+        dsb = create_dynamic_scholar_block()
+        assert dsb.description
+        assert "dynamically" in dsb.description.lower()
+
+
+class TestIsMeaningful:
+    """_is_meaningful ヘルパー関数のテスト。"""
+
+    def test_empty_string_not_meaningful(self):
+        assert not _is_meaningful("")
+
+    def test_none_not_meaningful(self):
+        assert not _is_meaningful(None)
+
+    def test_insufficient_data_not_meaningful(self):
+        assert not _is_meaningful("INSUFFICIENT_DATA: No documents")
+
+    def test_no_documents_found_not_meaningful(self):
+        assert not _is_meaningful("NO_DOCUMENTS_FOUND: Nothing here")
+
+    def test_no_content_not_meaningful(self):
+        assert not _is_meaningful("NO_CONTENT: Nothing produced")
+
+    def test_not_available_not_meaningful(self):
+        assert not _is_meaningful("Not available")
+
+    def test_normal_text_is_meaningful(self):
+        assert _is_meaningful("Analysis of English sources reveals...")
+
+    def test_marker_in_middle_is_meaningful(self):
+        """失敗マーカーが中間にある場合は有意と判定。"""
+        assert _is_meaningful("Analysis notes that INSUFFICIENT_DATA was found in...")
+
+
+class TestConstants:
+    """定数のテスト。"""
+
+    def test_max_languages(self):
+        assert MAX_LANGUAGES == 7
+
+    def test_max_debate_iterations(self):
+        assert MAX_DEBATE_ITERATIONS == 2
+
+
+class TestDynamicDebateInstruction:
+    """動的討論 instruction のテスト。"""
+
+    def test_dynamic_debate_only_includes_active_langs(self):
+        """active_langs 指定時は参加言語のみ instruction に含まれること。"""
+        from mystery_agents.agents.language_scholars import create_scholar
+
+        scholar = create_scholar("en", mode="debate", active_langs=["en", "de", "ja"])
+        # 自分以外の2言語が参照されていること
+        assert "{scholar_analysis_de}" in scholar.instruction
+        assert "{scholar_analysis_ja}" in scholar.instruction
+        # 不参加言語は参照されていないこと
+        assert "{scholar_analysis_es}" not in scholar.instruction
+        assert "{scholar_analysis_fr}" not in scholar.instruction
+        assert "{scholar_analysis_nl}" not in scholar.instruction
+        assert "{scholar_analysis_pt}" not in scholar.instruction
+
+    def test_dynamic_debate_excludes_self(self):
+        """自分自身の分析結果は instruction に含まれないこと。"""
+        from mystery_agents.agents.language_scholars import create_scholar
+
+        scholar = create_scholar("de", mode="debate", active_langs=["en", "de"])
+        assert "{scholar_analysis_en}" in scholar.instruction
+        assert "{scholar_analysis_de}" not in scholar.instruction
+
+    def test_dynamic_debate_uses_dynamic_template(self):
+        """active_langs 指定時は動的テンプレートが使用されること。"""
+        from mystery_agents.agents.language_scholars import create_scholar
+
+        scholar = create_scholar("en", mode="debate", active_langs=["en", "de"])
+        # 動的テンプレートは全7言語のハードコード参照を含まない
+        # 静的テンプレートにのみ存在する French/Dutch/Portuguese の参照がないことを確認
+        assert "{scholar_analysis_fr}" not in scholar.instruction
+        assert "{scholar_analysis_nl}" not in scholar.instruction
+        assert "{scholar_analysis_pt}" not in scholar.instruction
+
+    def test_static_debate_uses_static_template(self):
+        """active_langs 未指定時は静的テンプレート（全7言語参照）が使用されること。"""
+        from mystery_agents.agents.language_scholars import create_scholar
+
+        scholar = create_scholar("en", mode="debate")
+        # 静的テンプレートは全7言語の参照をハードコードで含む
+        assert "{scholar_analysis_fr}" in scholar.instruction
+        assert "{scholar_analysis_nl}" in scholar.instruction
+        assert "{scholar_analysis_pt}" in scholar.instruction
+
+    def test_dynamic_debate_has_whiteboard_reference(self):
+        """動的討論の instruction が debate_whiteboard を参照すること。"""
+        from mystery_agents.agents.language_scholars import create_scholar
+
+        scholar = create_scholar("en", mode="debate", active_langs=["en", "de"])
+        assert "{debate_whiteboard}" in scholar.instruction
+
+    def test_dynamic_debate_has_whiteboard_tool(self):
+        """動的討論の Scholar が append_to_whiteboard ツールを持つこと。"""
+        from mystery_agents.agents.language_scholars import create_scholar
+        from mystery_agents.tools.debate_tools import append_to_whiteboard
+
+        scholar = create_scholar("en", mode="debate", active_langs=["en", "de"])
+        assert append_to_whiteboard in scholar.tools
+
+
+class TestIsDebateConverged:
+    """is_debate_converged 関数のテスト。"""
+
+    def test_empty_whiteboard_not_converged(self):
+        from mystery_agents.tools.debate_tools import is_debate_converged
+
+        assert not is_debate_converged("")
+
+    def test_single_round_not_converged(self):
+        from mystery_agents.tools.debate_tools import is_debate_converged
+
+        whiteboard = "### [Round 1] English Perspective\n\nSome unique analysis.\n\n"
+        assert not is_debate_converged(whiteboard)
+
+    def test_identical_rounds_converged(self):
+        """同じ内容のラウンドは収束と判定。"""
+        from mystery_agents.tools.debate_tools import is_debate_converged
+
+        whiteboard = (
+            "### [Round 1] English Perspective\n\n"
+            "The evidence shows anomalies in the historical records.\n\n"
+            "### [Round 2] English Perspective\n\n"
+            "The evidence shows anomalies in the historical records.\n\n"
+        )
+        assert is_debate_converged(whiteboard)
+
+    def test_very_different_rounds_not_converged(self):
+        """大きく異なるラウンドは収束しないと判定。"""
+        from mystery_agents.tools.debate_tools import is_debate_converged
+
+        whiteboard = (
+            "### [Round 1] English Perspective\n\n"
+            "The primary documents reveal significant discrepancies.\n\n"
+            "### [Round 2] German Perspective\n\n"
+            "Completely different analysis with entirely new vocabulary and arguments about "
+            "folklore traditions cultural anthropology manuscript evidence.\n\n"
+        )
+        assert not is_debate_converged(whiteboard)

--- a/tests/unit/test_state_registry.py
+++ b/tests/unit/test_state_registry.py
@@ -14,8 +14,7 @@ class TestStateKeyDefinitions:
     def test_no_orphan_keys(self):
         """writer はあるが reader がいないキーは published_episode のみ許容。"""
         orphans = [k.name for k in STATE_KEYS if not k.read_by]
-        # active_languages は PR 3 の DynamicScholarBlock が reader になる予定
-        allowed_orphans = {"published_episode", "active_languages"}
+        allowed_orphans = {"published_episode"}
         unexpected = set(orphans) - allowed_orphans
         assert not unexpected, f"Unexpected orphan keys: {unexpected}"
 


### PR DESCRIPTION
## Summary

検索アーキテクチャ再設計 PR 3/3。Aggregator が設定する `active_languages` に基づき、ドキュメントが存在する言語のみ Scholar を動的生成する `DynamicScholarBlock`（BaseAgent）を導入。

- **DynamicScholarBlock**: 分析並列実行 → 有意な分析2言語以上で討論ループ（最大2ラウンド、収束判定付き）
- **動的討論 instruction**: 参加言語のみ記載（不参加言語の肥大化防止）
- **LLM 不使用の収束判定**: `is_debate_converged()` 純粋関数で直接判定（ConvergenceChecker LLM 不要）
- **active_analyses_summary**: DynamicScholarBlock が生成し、Armchair Polymath が参照
- **パイプライン簡素化**: 静的 `scholar_block` + `debate_loop` を `DynamicScholarBlock` に統合

### パイプライン全体像（PR 1〜3 完了後）

```
ParallelAPILibrarians(7 API groups)
         ↓
AggregatorAgent（LLM不使用、言語別集約）
         ↓
DynamicScholarBlock（BaseAgent）
  Phase 1: 並列分析（active_languages から Scholar 動的生成）
  Phase 2: 討論ループ（有意な分析≧2言語、最大2ラウンド、収束判定）
         ↓
ArmchairPolymath → Storyteller(EN)
         ↓
Parallel(Illustrator + Translators(3)) → Publisher → Firestore
```

## Test plan

- [x] 新規テスト 23件全パス（`test_dynamic_scholar_block.py`）
- [x] 既存ユニットテスト 1111件全パス
- [x] 統合テスト（変更分）全パス
- [x] State registry orphan/duplicate チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)