### PR TITLE
Storyteller 正常応答時にもモデル情報・トークン使用量をログ記録

### DIFF
--- a/mystery_agents/agents/storyteller.py
+++ b/mystery_agents/agents/storyteller.py
@@ -19,7 +19,11 @@ from google.adk.agents import LlmAgent
 from google.adk.agents.callback_context import CallbackContext
 from google.adk.models.llm_response import LlmResponse
 
-from shared.model_config import DEFAULT_STORYTELLER, create_storyteller_model
+from shared.model_config import (
+    DEFAULT_STORYTELLER,
+    STORYTELLER_MODELS,
+    create_storyteller_model,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -363,8 +367,7 @@ def _storyteller_after_model(
     callback_context: CallbackContext,
     llm_response: LlmResponse,
 ) -> LlmResponse | None:
-    """Storyteller の LLM 応答メタデータを記録し、異常応答を検出する。"""
-    # 正常応答（テキストあり + エラーなし）はスルー
+    """Storyteller の LLM 応答メタデータを記録する。"""
     has_text = (
         llm_response.content
         and llm_response.content.parts
@@ -373,11 +376,42 @@ def _storyteller_after_model(
             for p in llm_response.content.parts
         )
     )
+
+    # モデル情報をセッション状態から取得
+    storyteller_key = callback_context.state.get("storyteller", DEFAULT_STORYTELLER)
+    model_config = STORYTELLER_MODELS.get(storyteller_key, {})
+
     if has_text and not llm_response.error_code:
+        # 正常応答: モデル情報 + トークン使用量をログ
+        metadata = {
+            "storyteller": storyteller_key,
+            "display_name": model_config.get("display_name", "unknown"),
+            "model_id": model_config.get("model_id", "unknown"),
+            "model_version": getattr(llm_response, "model_version", None),
+            "prompt_tokens": (
+                llm_response.usage_metadata.prompt_token_count
+                if llm_response.usage_metadata else None
+            ),
+            "output_tokens": (
+                llm_response.usage_metadata.candidates_token_count
+                if llm_response.usage_metadata else None
+            ),
+        }
+        logger.info(
+            "Storyteller 応答完了: model=%s (%s), tokens=%s/%s",
+            metadata["display_name"],
+            metadata["model_id"],
+            metadata["prompt_tokens"],
+            metadata["output_tokens"],
+        )
+        callback_context.state["storyteller_llm_metadata"] = metadata
         return None
 
     # 異常応答: メタデータをログ + セッション状態に記録
     metadata = {
+        "storyteller": storyteller_key,
+        "display_name": model_config.get("display_name", "unknown"),
+        "model_id": model_config.get("model_id", "unknown"),
         "finish_reason": str(llm_response.finish_reason) if llm_response.finish_reason else None,
         "error_code": llm_response.error_code,
         "error_message": llm_response.error_message,


### PR DESCRIPTION
## Summary

- `_storyteller_after_model` が正常応答時に即 `return None` していたため、どのモデルで生成されたかの確認手段がなかった
- 正常応答時にもモデル名・model_id・トークン使用量を `logger.info` で出力し、`storyteller_llm_metadata` としてセッション状態に保存するよう修正
- 異常応答メタデータにも `storyteller` / `display_name` / `model_id` フィールドを追加し、正常・異常で統一的なメタデータ構造に

## Test plan

- [x] `python -m pytest tests/unit/test_reporter_selection.py -v` — 全 21 テスト通過
- [ ] 実際のパイプライン実行で Cloud Run ログに `Storyteller 応答完了: model=...` が出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)