### PR TITLE
fix: DPLA API に api_key パラメータを追加（403 Forbidden 修正）

### DIFF
--- a/mystery_agents/tools/dpla.py
+++ b/mystery_agents/tools/dpla.py
@@ -3,6 +3,8 @@
 DPLA の集約コレクション（全米の図書館・アーカイブ・博物館）を検索する。
 """
 
+import os
+
 import requests
 
 from ..schemas.document import ArchiveDocument, SourceLanguage
@@ -34,7 +36,7 @@ class DPLASource(ArchiveSource):
     supports_language_filter = True
     is_newspaper_source = False
     expected_domains = []  # パートナー機関ドメインが多様
-    env_var_key = None
+    env_var_key = "DPLA_API_KEY"
 
     def _search_impl(
         self,
@@ -48,7 +50,9 @@ class DPLASource(ArchiveSource):
         if not search_text:
             return ArchiveSearchResult(error="No keywords provided")
 
+        api_key = os.environ.get("DPLA_API_KEY", "")
         params = {
+            "api_key": api_key,
             "q": search_text,
             "page_size": min(max_results, 100),
         }


### PR DESCRIPTION
## Summary

- DPLA API v2 は全リクエストに `api_key` パラメータが必須だが、`env_var_key = None`（NYPL パターンの誤適用）で API キーが送信されず 403 Forbidden になっていた
- `env_var_key = "DPLA_API_KEY"` を設定し、基底クラスの起動時 API キー検証を有効化
- `_search_impl()` のリクエストパラメータに `api_key` を追加

## Test plan

- [x] 既存ユニットテスト通過（`pytest tests/unit/ -v -k dpla` — 2件パス）
- [ ] ローカルパイプライン実行で DPLA が 200 を返すことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)