### PR TITLE
fix: Armchair Polymath の未存在セッション状態キーエラー修正

### DIFF
--- a/mystery_agents/agent.py
+++ b/mystery_agents/agent.py
@@ -28,6 +28,7 @@ from google.adk.agents import ParallelAgent, SequentialAgent
 from google.genai import types
 
 from .agents.aggregator import create_aggregator
+from .agents.language_scholars import SCHOLAR_CONFIGS
 from .agents.api_librarians import create_all_api_librarians
 from .agents.armchair_polymath import create_armchair_polymath
 from .agents.dynamic_scholar_block import create_dynamic_scholar_block
@@ -90,6 +91,12 @@ def _initialize_pipeline_state(
     callback_context.state["selected_languages"] = []
     callback_context.state["debate_whiteboard"] = ""
     callback_context.state["structured_report"] = {}
+    # Armchair Polymath の instruction が全言語の {scholar_analysis_{lang}} を
+    # 参照するため、未実行言語でも ADK のプレースホルダー解決が失敗しないよう
+    # 全言語キーを空文字列で初期化する
+    for lang in SCHOLAR_CONFIGS:
+        callback_context.state[f"scholar_analysis_{lang}"] = ""
+    callback_context.state["active_analyses_summary"] = ""
     return None  # 実行続行
 
 


### PR DESCRIPTION
## Summary
- DynamicScholarBlock が一部言語のみ分析した場合、未実行言語の `scholar_analysis_{lang}` がセッション状態に存在せず、Armchair Polymath の instruction 内プレースホルダー解決時に ADK エラー（`Context variable not found`）が発生していた
- `_initialize_pipeline_state` で `SCHOLAR_CONFIGS` の全7言語キーを空文字列で初期化し、未実行言語でもプレースホルダー解決が正常に動作するよう修正
- `active_analyses_summary` も同様に空文字列で初期化（DynamicScholarBlock 早期終了時の防御）

## 変更ファイル
| ファイル | 変更内容 |
|---|---|
| `mystery_agents/agent.py` | `_initialize_pipeline_state` に `scholar_analysis_{lang}` × 7 + `active_analyses_summary` の初期化追加 |

## Test plan
- [x] `pytest tests/unit/ -v -k "scholar or polymath or pipeline_gate or dynamic_scholar"` — 93 passed
- [x] `pytest tests/unit/ -v` — 全ユニットテスト通過（1件の既存失敗は PR #333 関連で本変更と無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)