### PR TITLE
fix: OpenRouter モデル ID を最新版に更新（API 実検証済み）

### DIFF
--- a/packages/shared/src/types/mystery.ts
+++ b/packages/shared/src/types/mystery.ts
@@ -545,10 +545,10 @@ export const AGENT_NAME_LABELS: Record<string, string> = {
  * ストーリーテラー（LLM）の表示名マッピング
  */
 export const STORYTELLER_DISPLAY_NAMES: Record<string, string> = {
-  claude: "Claude Sonnet 4.5",
+  claude: "Claude Sonnet 4.6",
   gemini: "Gemini 3 Pro",
-  gpt: "GPT-4o",
+  gpt: "GPT-4.1",
   llama: "Llama 4 Maverick",
-  deepseek: "DeepSeek V3",
+  deepseek: "DeepSeek V3.2",
   mistral: "Mistral Large",
 };

--- a/shared/model_config.py
+++ b/shared/model_config.py
@@ -34,9 +34,9 @@ MODEL_FLASH = "gemini-2.5-flash"
 # === End 日本語訳 ===
 STORYTELLER_MODELS: dict[str, dict] = {
     "claude": {
-        "model_id": "openrouter/anthropic/claude-sonnet-4.5",
+        "model_id": "openrouter/anthropic/claude-sonnet-4.6",
         "provider": "litellm",
-        "display_name": "Claude Sonnet 4.5",
+        "display_name": "Claude Sonnet 4.6",
         "openrouter_provider_order": ["anthropic"],
     },
     "gemini": {
@@ -45,9 +45,9 @@ STORYTELLER_MODELS: dict[str, dict] = {
         "display_name": "Gemini 3 Pro",
     },
     "gpt": {
-        "model_id": "openrouter/openai/gpt-4o",
+        "model_id": "openrouter/openai/gpt-4.1",
         "provider": "litellm",
-        "display_name": "GPT-4o",
+        "display_name": "GPT-4.1",
         "openrouter_provider_order": ["openai"],
     },
     "llama": {
@@ -57,10 +57,10 @@ STORYTELLER_MODELS: dict[str, dict] = {
         "openrouter_provider_order": ["deepinfra"],
     },
     "deepseek": {
-        "model_id": "openrouter/deepseek/deepseek-chat",
+        "model_id": "openrouter/deepseek/deepseek-v3.2",
         "provider": "litellm",
-        "display_name": "DeepSeek V3",
-        "openrouter_provider_order": ["deepinfra"],
+        "display_name": "DeepSeek V3.2",
+        "openrouter_provider_order": ["ionstream"],
     },
     "mistral": {
         "model_id": "openrouter/mistralai/mistral-large-2512",

--- a/tests/unit/test_reporter_selection.py
+++ b/tests/unit/test_reporter_selection.py
@@ -65,7 +65,7 @@ class TestCreateStorytellerModel:
         create_storyteller_model("claude")
         last_call = LiteLlm.call_args
         assert last_call is not None
-        assert last_call.kwargs.get("model") == "openrouter/anthropic/claude-sonnet-4.5"
+        assert last_call.kwargs.get("model") == "openrouter/anthropic/claude-sonnet-4.6"
 
     def test_gpt_returns_litellm(self):
         """gpt ストーリーテラーは LiteLlm アダプタを返すこと。"""
@@ -75,7 +75,7 @@ class TestCreateStorytellerModel:
         create_storyteller_model("gpt")
         last_call = LiteLlm.call_args
         assert last_call is not None
-        assert last_call.kwargs.get("model") == "openrouter/openai/gpt-4o"
+        assert last_call.kwargs.get("model") == "openrouter/openai/gpt-4.1"
 
     def test_llama_returns_litellm(self):
         """llama ストーリーテラーは LiteLlm アダプタを返すこと。"""
@@ -95,7 +95,7 @@ class TestCreateStorytellerModel:
         create_storyteller_model("deepseek")
         last_call = LiteLlm.call_args
         assert last_call is not None
-        assert last_call.kwargs.get("model") == "openrouter/deepseek/deepseek-chat"
+        assert last_call.kwargs.get("model") == "openrouter/deepseek/deepseek-v3.2"
 
     def test_mistral_returns_litellm(self):
         """mistral ストーリーテラーは LiteLlm アダプタを返すこと。"""

--- a/web-admin/src/components/investigation-form.tsx
+++ b/web-admin/src/components/investigation-form.tsx
@@ -6,11 +6,11 @@ import {
 } from "lucide-react"
 
 const STORYTELLER_OPTIONS = [
-  { value: "claude", label: "Claude Sonnet 4.5" },
+  { value: "claude", label: "Claude Sonnet 4.6" },
   { value: "gemini", label: "Gemini 3 Pro" },
-  { value: "gpt", label: "GPT-4o" },
+  { value: "gpt", label: "GPT-4.1" },
   { value: "llama", label: "Llama 4 Maverick" },
-  { value: "deepseek", label: "DeepSeek V3" },
+  { value: "deepseek", label: "DeepSeek V3.2" },
   { value: "mistral", label: "Mistral Large" },
 ] as const
 


### PR DESCRIPTION
## Summary

- OpenRouter API (`GET /api/v1/models`) で全モデルの存在を検証し、LiteLLM 経由での動作も確認済み
- 3モデルを最新版に更新:
  - **Claude**: `sonnet-4.5` → `sonnet-4.6`（anthropic プロバイダ）
  - **GPT**: `4o` → `4.1`（openai プロバイダ、1M コンテキスト）
  - **DeepSeek**: `deepseek-chat` (V3) → `deepseek-v3.2`（ionstream プロバイダ）
- Llama 4 Maverick / Mistral Large 2512 は最新のため変更なし
- フロントエンド（web-admin, packages/shared）の表示名も同期更新
- テスト 21/21 PASS

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `shared/model_config.py` | STORYTELLER_MODELS レジストリのモデル ID・表示名・プロバイダ更新 |
| `web-admin/src/components/investigation-form.tsx` | Storyteller 選択 UI のラベル更新 |
| `packages/shared/src/types/mystery.ts` | STORYTELLER_DISPLAY_NAMES 更新 |
| `tests/unit/test_reporter_selection.py` | モデル ID アサーション値を更新 |

## 検証方法

```bash
# OpenRouter API でモデル存在を確認
curl -s https://openrouter.ai/api/v1/models | python3 -c "..."

# LiteLLM 経由で各モデルの動作を確認
litellm.completion(model="openrouter/anthropic/claude-sonnet-4.6", ...)  # OK
litellm.completion(model="openrouter/openai/gpt-4.1", ...)              # OK
litellm.completion(model="openrouter/deepseek/deepseek-v3.2", ...)      # OK

# ユニットテスト
pytest tests/unit/test_reporter_selection.py -v  # 21 passed
```

## Test plan

- [x] `pytest tests/unit/test_reporter_selection.py -v` — 21 PASS
- [x] OpenRouter API で全モデル ID の存在を確認
- [x] LiteLLM 経由で Claude 4.6 / GPT-4.1 / DeepSeek V3.2 の動作を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)