### PR TITLE
fix: エラー時の進捗停止 + OpenRouter LLM コールリトライ

### DIFF
--- a/shared/model_config.py
+++ b/shared/model_config.py
@@ -104,6 +104,13 @@ _FLASH_RETRY_OPTIONS = HttpRetryOptions(
     jitter=1.0,
 )
 
+# === 日本語訳 ===
+# OpenRouter / LiteLLM 用リトライ設定。
+# litellm → OpenAI クライアント経由で指数バックオフ付きリトライ。
+# HTTP 429, 500-599 が対象。パイプライン全体ではなく LLM コール単位でリトライされる。
+# === End 日本語訳 ===
+_LITELLM_MAX_RETRIES = 3
+
 
 def create_pro_model() -> Gemini:
     """gemini-3-pro-preview のリトライ付きモデルアダプタを生成する。"""
@@ -152,4 +159,4 @@ def create_storyteller_model(storyteller: str = DEFAULT_STORYTELLER):
             }
         }
 
-    return LiteLlm(model=config["model_id"], **kwargs)
+    return LiteLlm(model=config["model_id"], max_retries=_LITELLM_MAX_RETRIES, **kwargs)

--- a/shared/orchestrator.py
+++ b/shared/orchestrator.py
@@ -166,6 +166,17 @@ class PipelineResult:
     session_state: dict = field(default_factory=dict)
 
 
+def _error_remaining_agents(
+    pipeline_logger: PipelineLogger,
+    agent_texts: dict[str, list[str]],
+    error_message: str,
+) -> None:
+    """エラー発生時に残存エージェントをエラーマークする。"""
+    for name in list(agent_texts.keys()):
+        pipeline_logger.error_agent(name, error_message)
+    agent_texts.clear()
+
+
 def _complete_agent(
     pipeline_logger: PipelineLogger,
     run_id: str | None,
@@ -472,9 +483,11 @@ async def run_pipeline(
             )
 
         except TimeoutError:
+            _error_remaining_agents(pipeline_logger, agent_texts, f"Pipeline timed out after {timeout_seconds}s")
             error_pipeline_run(run_id, f"Pipeline timed out after {timeout_seconds}s", error_detail={
                 "error_type": "timeout",
                 "timeout_seconds": timeout_seconds,
+                "pipeline_log": pipeline_logger.get_logs(),
             })
             raise
         except Exception as e:
@@ -499,6 +512,7 @@ async def run_pipeline(
                 continue
 
             error_message = _format_exception_group(e)
+            _error_remaining_agents(pipeline_logger, agent_texts, error_message)
             logger.error(
                 "Pipeline failed: %s", error_message, exc_info=True,
                 extra={"status": "error", "exception_class": type(e).__name__},
@@ -506,6 +520,7 @@ async def run_pipeline(
             error_pipeline_run(run_id, error_message, error_detail={
                 "error_type": "exception",
                 "exception_class": type(e).__name__,
+                "pipeline_log": pipeline_logger.get_logs(),
             })
             raise
 

--- a/tests/unit/test_model_config.py
+++ b/tests/unit/test_model_config.py
@@ -12,9 +12,11 @@ from shared.model_config import (
     MODEL_FLASH,
     MODEL_PRO,
     _FLASH_RETRY_OPTIONS,
+    _LITELLM_MAX_RETRIES,
     _PRO_RETRY_OPTIONS,
     create_flash_model,
     create_pro_model,
+    create_storyteller_model,
 )
 
 
@@ -58,3 +60,14 @@ class TestCreateFlashModel:
         last_call = Gemini.call_args
         # retry_options 引数が _FLASH_RETRY_OPTIONS と同一オブジェクトであること
         assert last_call.kwargs.get("retry_options") is _FLASH_RETRY_OPTIONS
+
+
+class TestCreateStorytellerModel:
+    """create_storyteller_model() の LiteLLM リトライ設定テスト。"""
+
+    def test_litellm_storyteller_has_max_retries(self):
+        """OpenRouter モデル生成時に max_retries が設定されること。"""
+        from google.adk.models.lite_llm import LiteLlm
+        create_storyteller_model("claude")
+        last_call = LiteLlm.call_args
+        assert last_call.kwargs.get("max_retries") == _LITELLM_MAX_RETRIES

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1,5 +1,6 @@
 """Unit tests for shared/orchestrator.py"""
 
+import asyncio
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -222,7 +223,11 @@ class TestRunPipeline:
 
         mock_error.assert_called_once_with(
             "run-005", "Something went wrong",
-            error_detail={"error_type": "exception", "exception_class": "RuntimeError"},
+            error_detail={
+                "error_type": "exception",
+                "exception_class": "RuntimeError",
+                "pipeline_log": [],
+            },
         )
 
     @pytest.mark.asyncio
@@ -836,6 +841,117 @@ class TestExceptionGroupInPipeline:
         error_detail = mock_error.call_args[1]["error_detail"]
         assert error_detail["error_type"] == "exception"
         assert error_detail["exception_class"] == "ExceptionGroup"
+
+
+class TestErrorRemainingAgents:
+    """エラー発生時に running エージェントがエラーマークされるテスト"""
+
+    @pytest.mark.asyncio
+    @patch("shared.orchestrator.error_pipeline_run")
+    @patch("shared.orchestrator.update_agent_started", return_value=0)
+    @patch("shared.orchestrator.create_pipeline_run", return_value="run-500")
+    async def test_running_agents_marked_error_on_exception(
+        self, mock_create, mock_started, mock_error
+    ):
+        """例外発生時に running 中のエージェントが status: "error" になること。"""
+        async def error_after_events(**kwargs):
+            yield _make_event(author="librarian", text="Searching...")
+            yield _make_event(author="scholar", text="Analyzing...")
+            raise RuntimeError("OpenRouter API failed")
+            yield
+
+        runner = MagicMock()
+        runner.run_async = error_after_events
+        fake_session = FakeInMemorySessionService()
+
+        with patch("shared.orchestrator.Runner", return_value=runner), \
+             patch("shared.orchestrator.InMemorySessionService", return_value=fake_session):
+            with pytest.raises(RuntimeError, match="OpenRouter API failed"):
+                await run_pipeline(
+                    agent=MagicMock(),
+                    app_name="test_app",
+                    user_message="test",
+                    initial_state={},
+                )
+
+        # error_pipeline_run の error_detail に pipeline_log が含まれる
+        mock_error.assert_called_once()
+        error_detail = mock_error.call_args[1]["error_detail"]
+        pipeline_log = error_detail["pipeline_log"]
+
+        # librarian と scholar が error ステータスになっている
+        error_agents = [log for log in pipeline_log if log["status"] == "error"]
+        error_names = {log["agent_name"] for log in error_agents}
+        assert {"librarian", "scholar"} == error_names
+
+    @pytest.mark.asyncio
+    @patch("shared.orchestrator.error_pipeline_run")
+    @patch("shared.orchestrator.update_agent_started", return_value=0)
+    @patch("shared.orchestrator.create_pipeline_run", return_value="run-501")
+    async def test_running_agents_marked_error_on_timeout(
+        self, mock_create, mock_started, mock_error
+    ):
+        """タイムアウト時に running 中のエージェントが status: "error" になること。"""
+        async def slow_events(**kwargs):
+            yield _make_event(author="storyteller", text="Writing...")
+            await asyncio.sleep(10)
+            yield
+
+        runner = MagicMock()
+        runner.run_async = slow_events
+        fake_session = FakeInMemorySessionService()
+
+        with patch("shared.orchestrator.Runner", return_value=runner), \
+             patch("shared.orchestrator.InMemorySessionService", return_value=fake_session):
+            with pytest.raises(TimeoutError):
+                await run_pipeline(
+                    agent=MagicMock(),
+                    app_name="test_app",
+                    user_message="test",
+                    initial_state={},
+                    timeout_seconds=0.01,
+                )
+
+        # error_pipeline_run の error_detail に pipeline_log が含まれる
+        mock_error.assert_called_once()
+        error_detail = mock_error.call_args[1]["error_detail"]
+        pipeline_log = error_detail["pipeline_log"]
+
+        # storyteller が error ステータスになっている
+        error_agents = [log for log in pipeline_log if log["status"] == "error"]
+        assert len(error_agents) == 1
+        assert error_agents[0]["agent_name"] == "storyteller"
+
+    @pytest.mark.asyncio
+    @patch("shared.orchestrator.error_pipeline_run")
+    @patch("shared.orchestrator.update_agent_started", return_value=0)
+    @patch("shared.orchestrator.create_pipeline_run", return_value="run-502")
+    async def test_error_detail_includes_pipeline_log(
+        self, mock_create, mock_started, mock_error
+    ):
+        """error_detail に pipeline_log キーが含まれること。"""
+        async def error_run_async(**kwargs):
+            yield _make_event(author="librarian", text="Found docs")
+            raise RuntimeError("Unexpected error")
+            yield
+
+        runner = MagicMock()
+        runner.run_async = error_run_async
+        fake_session = FakeInMemorySessionService()
+
+        with patch("shared.orchestrator.Runner", return_value=runner), \
+             patch("shared.orchestrator.InMemorySessionService", return_value=fake_session):
+            with pytest.raises(RuntimeError):
+                await run_pipeline(
+                    agent=MagicMock(),
+                    app_name="test_app",
+                    user_message="test",
+                    initial_state={},
+                )
+
+        error_detail = mock_error.call_args[1]["error_detail"]
+        assert "pipeline_log" in error_detail
+        assert isinstance(error_detail["pipeline_log"], list)
 
 
 class TestBuildStateSummary:


### PR DESCRIPTION
## Summary

- エラー発生時に running 中のエージェントを error ステータスにマーク（進捗表示の停止）
- `error_detail` に `pipeline_log` を追加（エラー時のエージェント状態を記録）
- OpenRouter/LiteLLM に `max_retries=3` を追加（LLM コール単位で指数バックオフ付きリトライ）

## 変更内容

| ファイル | 変更 |
|---------|------|
| `shared/orchestrator.py` | `_error_remaining_agents()` ヘルパー追加、TimeoutError/Exception ハンドラに組み込み |
| `shared/model_config.py` | `_LITELLM_MAX_RETRIES=3` 定数追加、`LiteLlm` に `max_retries` パススルー |
| `tests/unit/test_orchestrator.py` | エラーパスのテスト 3 件追加 |
| `tests/unit/test_model_config.py` | `max_retries` パススルーのテスト 1 件追加 |

## Test plan

- [x] `pytest tests/unit/test_orchestrator.py tests/unit/test_model_config.py -v` — 47 テスト全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)