### PR TITLE
fix: evidence_a/evidence_b 空 excerpt にフォールバック文を挿入

### DIFF
--- a/mystery_agents/tools/publisher_tools.py
+++ b/mystery_agents/tools/publisher_tools.py
@@ -494,12 +494,14 @@ def publish_mystery(
         data.setdefault("additional_evidence", [])
         data["additional_evidence"] = data["additional_evidence"][:5]
 
-        # evidence_a / evidence_b の空 excerpt 警告（除外はしない）
+        # evidence_a / evidence_b: 空 excerpt にはフォールバック文を挿入
         for key in ("evidence_a", "evidence_b"):
             ev = data.get(key)
             if ev and isinstance(ev, dict):
                 if not ev.get("relevant_excerpt", "").strip():
-                    logger.warning("%s has empty relevant_excerpt, title=%s", key, ev.get("source_title", "unknown"))
+                    source_title = ev.get("source_title", "unknown source")
+                    ev["relevant_excerpt"] = f"[See original source: {source_title}]"
+                    logger.warning("%s: empty relevant_excerpt replaced with fallback, title=%s", key, source_title)
 
         # additional_evidence の source_url 欠落チェック + 空 excerpt フィルタリング
         filtered_additional = []

--- a/mystery_agents/tools/scholar_tools.py
+++ b/mystery_agents/tools/scholar_tools.py
@@ -589,7 +589,7 @@ def save_structured_report(
     - get_document_inventory が事前に呼ばれていること（_inventory_consulted フラグ）
 
     evidence バリデーション:
-    - evidence_a / evidence_b: 空 excerpt は警告のみ（構造上必須のため除外しない）
+    - evidence_a / evidence_b: 空 excerpt にはフォールバック文を挿入（構造上必須のため除外しない）
     - additional_evidence: 空 excerpt の項目はフィルタリング（除外）
 
     証拠グラウンディング:
@@ -641,10 +641,14 @@ def save_structured_report(
     # evidence バリデーション
     warnings: list[str] = []
 
-    # evidence_a / evidence_b: 警告のみ（構造上必須のため除外しない）
+    # evidence_a / evidence_b: 空 excerpt にはフォールバック文を挿入
     for key in ("evidence_a", "evidence_b"):
         ev = report_data.get(key)
         if ev and isinstance(ev, dict):
+            if not ev.get("relevant_excerpt", "").strip():
+                source_title = ev.get("source_title", "unknown source")
+                ev["relevant_excerpt"] = f"[See original source: {source_title}]"
+                warnings.append(f"{key}: empty relevant_excerpt replaced with fallback")
             warnings.extend(_validate_evidence(ev, key))
 
     # additional_evidence: 空 excerpt の項目をフィルタリング

--- a/tests/unit/test_publisher_tools.py
+++ b/tests/unit/test_publisher_tools.py
@@ -716,10 +716,10 @@ class TestPublishMysteryEvidenceFiltering:
 
     @patch("mystery_agents.tools.publisher_tools.get_storage_bucket")
     @patch("mystery_agents.tools.publisher_tools.get_firestore_client")
-    def test_empty_excerpt_evidence_a_warns_but_saves(
+    def test_empty_excerpt_evidence_a_gets_fallback(
         self, mock_get_db, mock_get_bucket, caplog
     ):
-        """evidence_a の excerpt が空でも警告のみで保存される。"""
+        """evidence_a の excerpt が空 → フォールバック文が挿入されて保存される。"""
         mock_db = MagicMock()
         mock_get_db.return_value = mock_db
         mock_bucket = MagicMock()
@@ -744,10 +744,10 @@ class TestPublishMysteryEvidenceFiltering:
         assert result_data["status"] == "success"
 
         saved = mock_db.collection.return_value.document.return_value.set.call_args[0][0]
-        # evidence_a は除外されない
-        assert "evidence_a" in saved
+        # フォールバック文が挿入されている
+        assert saved["evidence_a"]["relevant_excerpt"] == "[See original source: Test]"
         # 警告ログが出力されている
-        assert any("evidence_a" in r.message and "relevant_excerpt" in r.message for r in caplog.records)
+        assert any("replaced with fallback" in r.message for r in caplog.records)
 
 
 class TestPublishMysteryStateWriteback:

--- a/tests/unit/test_scholar_tools.py
+++ b/tests/unit/test_scholar_tools.py
@@ -28,8 +28,8 @@ class TestSaveStructuredReport:
         report_data = {
             "title": "The Vanishing Ship",
             "summary": "A ship disappeared",
-            "evidence_a": {"source_url": "https://example.com", "source_date": "1842-03-15"},
-            "evidence_b": {"source_url": "https://example.com/es", "source_date": "1842-03-20"},
+            "evidence_a": {"source_url": "https://example.com", "source_date": "1842-03-15", "relevant_excerpt": "The ship vanished"},
+            "evidence_b": {"source_url": "https://example.com/es", "source_date": "1842-03-20", "relevant_excerpt": "El barco desapareció"},
             "hypothesis": "The ship faked its sinking",
             "alternative_hypotheses": ["Mistaken identity"],
             "classification": "OCC",
@@ -216,12 +216,13 @@ class TestValidateEvidence:
 class TestSaveStructuredReportEvidenceValidation:
     """Tests for evidence validation in save_structured_report()."""
 
-    def test_empty_excerpt_in_evidence_a_warns_but_saves(self):
-        """evidence_a の excerpt が空 → 警告付きで保存される。"""
+    def test_empty_excerpt_in_evidence_a_gets_fallback(self):
+        """evidence_a の excerpt が空 → フォールバック文が挿入される。"""
         report_data = {
             "title": "Test",
             "evidence_a": {
                 "source_url": "https://example.com",
+                "source_title": "Boston Globe",
                 "relevant_excerpt": "",
             },
             "evidence_b": {
@@ -235,9 +236,33 @@ class TestSaveStructuredReportEvidenceValidation:
         result_data = json.loads(result)
 
         assert result_data["status"] == "success"
-        assert len(result_data["warnings"]) > 0
-        # evidence_a は除外されない（構造上必須）
-        assert "evidence_a" in mock_ctx.state["structured_report"]
+        saved = mock_ctx.state["structured_report"]
+        assert saved["evidence_a"]["relevant_excerpt"] == "[See original source: Boston Globe]"
+        assert any("replaced with fallback" in w for w in result_data["warnings"])
+
+    def test_empty_excerpt_in_evidence_b_gets_fallback(self):
+        """evidence_b の excerpt が空 → フォールバック文が挿入される。"""
+        report_data = {
+            "title": "Test",
+            "evidence_a": {
+                "source_url": "https://example.com",
+                "relevant_excerpt": "Valid excerpt",
+            },
+            "evidence_b": {
+                "source_url": "https://example.com/b",
+                "source_title": "Le Monde",
+                "relevant_excerpt": "   ",
+            },
+        }
+        mock_ctx = _make_ctx()
+
+        result = save_structured_report(json.dumps(report_data), mock_ctx)
+        result_data = json.loads(result)
+
+        assert result_data["status"] == "success"
+        saved = mock_ctx.state["structured_report"]
+        assert saved["evidence_b"]["relevant_excerpt"] == "[See original source: Le Monde]"
+        assert any("evidence_b" in w and "replaced with fallback" in w for w in result_data["warnings"])
 
     def test_empty_excerpt_in_additional_evidence_filtered_out(self):
         """additional_evidence の excerpt が空 → フィルタリングされる。"""


### PR DESCRIPTION
## Summary

- `evidence_a`/`evidence_b` の `relevant_excerpt` が空文字のまま Firestore に保存されると、web-public で空の blockquote（日付バッジと出典リンクのみ）が表示される問題を修正
- `save_structured_report`（Scholar 側）と `publish_mystery`（Publisher 側）の2箇所で空 excerpt 検出時に `[See original source: {source_title}]` フォールバック文を挿入する二重防御を実装
- `additional_evidence` は従来通り空 excerpt をフィルタリング（除外）、`evidence_a`/`evidence_b` は構造上必須のためフォールバック挿入で対応

## Test plan

- [x] `pytest tests/unit/test_scholar_tools.py -v -k "evidence"` — evidence_a/evidence_b フォールバック + additional_evidence フィルタリング
- [x] `pytest tests/unit/test_publisher_tools.py -v -k "evidence"` — Publisher 側フォールバック
- [x] `pytest tests/unit/ -v` — 全ユニットテスト回帰確認（79 passed in scholar/publisher, 既存の archive_source_base 2件のみ pre-existing failure）

🤖 Generated with [Claude Code](https://claude.com/claude-code)