### PR TITLE
refactor: DynamicPolymathBlock — Armchair Polymath の動的 instruction 構築

### DIFF
--- a/mystery_agents/agent.py
+++ b/mystery_agents/agent.py
@@ -4,11 +4,12 @@ Defines root_agent (ghost_commander) as a SequentialAgent that orchestrates
 the multilingual investigation pipeline:
 
   ParallelAPILibrarians → Aggregator → DynamicScholarBlock
-    → PolymathBlock → StorytellerBlock → PostStoryBlock
+    → DynamicPolymathBlock → StorytellerBlock → PostStoryBlock
 
 API ベース Librarian（7グループ）が並列で検索し、AggregatorAgent が
 検索結果を言語別に集約。DynamicScholarBlock が active_languages に基づき
 Scholar を動的に生成・実行し、分析→討論を一貫制御する。
+DynamicPolymathBlock がアクティブ言語のみの instruction で Polymath を実行。
 PostStoryBlock では Illustrator と3言語翻訳が並列実行される。
 
 DynamicScholarBlock 内部:
@@ -28,13 +29,11 @@ from google.adk.agents import ParallelAgent, SequentialAgent
 from google.genai import types
 
 from .agents.aggregator import create_aggregator
-from .agents.language_scholars import SCHOLAR_CONFIGS
 from .agents.api_librarians import create_all_api_librarians
-from .agents.armchair_polymath import create_armchair_polymath
+from .agents.dynamic_polymath_block import create_dynamic_polymath_block
 from .agents.dynamic_scholar_block import create_dynamic_scholar_block
 from .agents.illustrator import create_illustrator
 from .agents.pipeline_gate import (
-    make_polymath_gate,
     make_post_story_gate,
     make_storyteller_gate,
 )
@@ -50,12 +49,13 @@ if TYPE_CHECKING:
 _PIPELINE_DESCRIPTION = (
     "Ghost in the Archive multilingual blog creation pipeline. "
     "Executes ParallelAPILibrarians(7 API groups) → Aggregator "
-    "→ DynamicScholarBlock(analysis + debate) → PolymathBlock "
+    "→ DynamicScholarBlock(analysis + debate) → DynamicPolymathBlock "
     "→ StorytellerBlock → PostStoryBlock "
     "to research, analyze, debate, create content, generate images, "
     "translate to 3 languages (ja/es/de) in parallel, "
     "and publish historical mysteries and folkloric anomalies. "
     "DynamicScholarBlock dynamically creates Scholars for active languages only. "
+    "DynamicPolymathBlock builds Polymath instruction with active languages only. "
     "Pipeline gates skip downstream agents when upstream stages fail."
 )
 
@@ -65,14 +65,14 @@ SKIP_AUTHORS = {
     "ghost_commander",
     "parallel_api_librarians",
     "aggregator",
-    # DynamicScholarBlock 内部のオーケストレーターエージェント
+    # DynamicScholarBlock / DynamicPolymathBlock 内部のオーケストレーターエージェント
     "dynamic_scholar_block",
     "dynamic_analysis",
     "dynamic_debate_0",
     "dynamic_debate_1",
+    "dynamic_polymath_block",
     # 並列翻訳・後処理ブロック
     "parallel_translators",
-    "polymath_block",
     "storyteller_block",
     "post_story_block",
     "post_story_parallel",
@@ -91,12 +91,8 @@ def _initialize_pipeline_state(
     callback_context.state["selected_languages"] = []
     callback_context.state["debate_whiteboard"] = ""
     callback_context.state["structured_report"] = {}
-    # Armchair Polymath の instruction が全言語の {scholar_analysis_{lang}} を
-    # 参照するため、未実行言語でも ADK のプレースホルダー解決が失敗しないよう
-    # 全言語キーを空文字列で初期化する
-    for lang in SCHOLAR_CONFIGS:
-        callback_context.state[f"scholar_analysis_{lang}"] = ""
-    callback_context.state["active_analyses_summary"] = ""
+    # scholar_analysis_* は DynamicPolymathBlock が動的に参照するため初期化不要
+    # active_analyses_summary は DynamicScholarBlock が設定するため初期化不要
     return None  # 実行続行
 
 
@@ -113,7 +109,6 @@ def build_pipeline(storyteller: str = DEFAULT_STORYTELLER) -> SequentialAgent:
         構築済みパイプライン（SequentialAgent）
     """
     # リーフエージェント（毎回新規生成）
-    ap = create_armchair_polymath()
     il = create_illustrator()
     pub = create_publisher()
     st = create_storyteller(storyteller)
@@ -128,12 +123,9 @@ def build_pipeline(storyteller: str = DEFAULT_STORYTELLER) -> SequentialAgent:
     # 有意な分析が2言語以上なら討論ループ（収束判定付き）
     dsb = create_dynamic_scholar_block()
 
-    # ArmchairPolymath ブロック（全 Scholar 失敗時にスキップ）
-    polymath_block = SequentialAgent(
-        name="polymath_block",
-        sub_agents=[ap],
-        before_agent_callback=make_polymath_gate(),
-    )
+    # DynamicPolymathBlock: アクティブ言語のみの instruction で Polymath 実行
+    # ゲート機能内包（全 Scholar 失敗時にスキップ）
+    dpb = create_dynamic_polymath_block()
 
     # Storyteller ブロック（mystery_report 空ならスキップ）
     storyteller_block = SequentialAgent(
@@ -175,7 +167,7 @@ def build_pipeline(storyteller: str = DEFAULT_STORYTELLER) -> SequentialAgent:
             ),
             agg,
             dsb,
-            polymath_block,
+            dpb,
             storyteller_block,
             post_story_block,
         ],

--- a/mystery_agents/agents/__init__.py
+++ b/mystery_agents/agents/__init__.py
@@ -8,6 +8,7 @@ from .aggregator import create_aggregator
 from .api_librarians import create_all_api_librarians, create_api_librarian
 from .armchair_polymath import armchair_polymath_agent, create_armchair_polymath
 from .convergence_checker import convergence_checker_agent, create_convergence_checker
+from .dynamic_polymath_block import create_dynamic_polymath_block
 from .dynamic_scholar_block import create_dynamic_scholar_block
 from .illustrator import create_illustrator, illustrator_agent
 from .language_scholars import create_all_scholars, create_scholar
@@ -19,6 +20,7 @@ __all__ = [
     "create_api_librarian",
     "create_all_api_librarians",
     "create_aggregator",
+    "create_dynamic_polymath_block",
     "create_dynamic_scholar_block",
     "create_scholar",
     "create_all_scholars",

--- a/mystery_agents/agents/armchair_polymath.py
+++ b/mystery_agents/agents/armchair_polymath.py
@@ -28,15 +28,8 @@ from ..tools.word_count import count_words
 # ドライなユーモアと鋭い批判精神が持ち味ですが、証拠には誠実に向き合います。
 #
 # ## 入力（Scholar 分析結果）
-# - {active_analyses_summary}: DynamicScholarBlock が生成した分析概要（どの言語の分析が利用可能か）
-# セッション状態から各言語の Scholar 分析結果を読み取る:
-# - {scholar_analysis_en}: 英語圏の分析
-# - {scholar_analysis_de}: ドイツ語圏の分析（存在する場合）
-# - {scholar_analysis_es}: スペイン語圏の分析（存在する場合）
-# - {scholar_analysis_fr}: フランス語圏の分析（存在する場合）
-# - {scholar_analysis_nl}: オランダ語圏の分析（存在する場合）
-# - {scholar_analysis_pt}: ポルトガル語圏の分析（存在する場合）
-# - {scholar_analysis_ja}: 日本語圏の分析（存在する場合）
+# DynamicPolymathBlock がアクティブ言語のみの Scholar Analyses セクションを動的に構築する。
+# 後方互換のシングルトン（armchair_polymath_agent）は全7言語を静的に参照する。
 #
 # ## 入力（討論ホワイトボード）
 # - {debate_whiteboard}: 全ラウンドの討論記録（空の場合は討論なし）
@@ -156,7 +149,7 @@ from ..tools.word_count import count_words
 # - 1言語のみ → その結果のみで Master Report 作成
 # === End 日本語訳 ===
 
-ARMCHAIR_POLYMATH_INSTRUCTION = """
+INSTRUCTION_PREAMBLE = """
 You are the Armchair Polymath for the "Ghost in the Archive" project.
 From the comfort of your study, surrounded by tottering stacks of obscure monographs,
 you survey the field reports of your language-specialist colleagues with a mixture
@@ -168,7 +161,10 @@ with more devastating clarity.
 Your tone is dryly authoritative: you appreciate rigour, despise sloppy reasoning,
 and permit yourself the occasional sardonic aside when a colleague's analysis
 betrays an obvious cultural bias. Nevertheless, you follow the evidence wherever it leads.
+"""
 
+# 全7言語ハードコードの Scholar Analyses セクション（後方互換用シングルトン向け）
+_STATIC_ANALYSES_SECTION = """
 ## Input: Available Analyses
 First check which analyses were produced:
 - {active_analyses_summary}
@@ -185,7 +181,9 @@ Read the following Scholar analysis results from session state (some may be abse
 
 Focus on the analyses listed in `active_analyses_summary` — these are the ones
 with meaningful content. Other language keys may be empty or unavailable.
+"""
 
+INSTRUCTION_BODY = """
 ## Input: Debate Whiteboard
 - {debate_whiteboard}: Full record of scholarly debate across all rounds
 
@@ -525,20 +523,38 @@ If you cannot find a specific verbatim quote, write a brief paraphrase of the so
 NEVER leave `relevant_excerpt` as an empty string — items with empty excerpts will be automatically removed.
 """
 
+# 後方互換: 全7言語の静的 instruction（シングルトン + テスト用）
+ARMCHAIR_POLYMATH_INSTRUCTION = (
+    INSTRUCTION_PREAMBLE + _STATIC_ANALYSES_SECTION + INSTRUCTION_BODY
+)
+
+# Polymath ツール一覧（DynamicPolymathBlock でも共有）
+POLYMATH_TOOLS = [
+    save_structured_report,
+    get_search_metadata,
+    search_academic_papers,
+    get_document_inventory,
+    count_words,
+]
+
+# Polymath 説明文（DynamicPolymathBlock でも共有）
+POLYMATH_DESCRIPTION = (
+    "The Armchair Polymath: a sardonic, encyclopaedically learned synthesizer "
+    "who integrates analysis results from multiple language-specific Scholars "
+    "and their debate records. Identifies cross-language discrepancies, cultural "
+    "biases, and produces a unified Mystery Report drawing on Fact, Folklore, "
+    "and Anthropology perspectives from all available language sources."
+)
+
+
 def create_armchair_polymath() -> LlmAgent:
     """Armchair Polymath エージェントを新規生成する。"""
     return LlmAgent(
         name="armchair_polymath",
         model=create_pro_model(),
-        description=(
-            "The Armchair Polymath: a sardonic, encyclopaedically learned synthesizer "
-            "who integrates analysis results from multiple language-specific Scholars "
-            "and their debate records. Identifies cross-language discrepancies, cultural "
-            "biases, and produces a unified Mystery Report drawing on Fact, Folklore, "
-            "and Anthropology perspectives from all available language sources."
-        ),
+        description=POLYMATH_DESCRIPTION,
         instruction=ARMCHAIR_POLYMATH_INSTRUCTION,
-        tools=[save_structured_report, get_search_metadata, search_academic_papers, get_document_inventory, count_words],
+        tools=POLYMATH_TOOLS,
         output_key="mystery_report",  # 既存と同じキー → 下流互換性維持
     )
 

--- a/mystery_agents/agents/dynamic_polymath_block.py
+++ b/mystery_agents/agents/dynamic_polymath_block.py
@@ -1,0 +1,129 @@
+"""DynamicPolymathBlock — Armchair Polymath の動的 instruction 構築。
+
+アクティブ言語の Scholar 分析のみを instruction に含め、
+非アクティブ言語の空プレースホルダーを排除する。
+DynamicScholarBlock と同じ BaseAgent パターン。
+
+ゲート機能を内包: 全 Scholar 分析が空なら INSUFFICIENT_DATA を返す。
+"""
+
+import logging
+from collections.abc import AsyncGenerator
+
+from google.adk.agents import BaseAgent, LlmAgent
+from google.adk.agents.invocation_context import InvocationContext
+from google.adk.events.event import Event
+from google.genai import types
+
+from shared.model_config import create_pro_model
+
+from .armchair_polymath import (
+    INSTRUCTION_BODY,
+    INSTRUCTION_PREAMBLE,
+    POLYMATH_DESCRIPTION,
+    POLYMATH_TOOLS,
+)
+from .language_scholars import SCHOLAR_CONFIGS
+from .pipeline_gate import _is_meaningful, _log_and_record_failure
+
+logger = logging.getLogger(__name__)
+
+
+def _build_analyses_section(meaningful_langs: list[str]) -> str:
+    """アクティブ言語のみの Scholar Analyses セクションを構築する。"""
+    lang_lines = []
+    for lang in meaningful_langs:
+        name = SCHOLAR_CONFIGS[lang]["language_name"]
+        lang_lines.append(
+            f"- {{scholar_analysis_{lang}}}: {name} cultural perspective analysis"
+        )
+
+    lang_names = ", ".join(
+        SCHOLAR_CONFIGS[l]["language_name"] for l in meaningful_langs
+    )
+    return (
+        "## Input: Scholar Analyses\n"
+        f"Scholar analyses available for {len(meaningful_langs)} language(s): "
+        f"{lang_names}.\n\n"
+        + "\n".join(lang_lines)
+    )
+
+
+class DynamicPolymathBlock(BaseAgent):
+    """アクティブ言語のみの instruction で Armchair Polymath を実行する。
+
+    ゲート機能を内包: 有意な Scholar 分析がなければスキップ。
+    """
+
+    async def _run_async_impl(
+        self, ctx: InvocationContext
+    ) -> AsyncGenerator[Event, None]:
+        state = ctx.session.state
+
+        # 有意な分析がある言語を特定
+        active_langs = state.get("active_languages", [])
+        meaningful_langs = [
+            lang
+            for lang in active_langs
+            if lang in SCHOLAR_CONFIGS
+            and _is_meaningful(state.get(f"scholar_analysis_{lang}", ""))
+        ]
+
+        # ゲート: 有意な分析なし → INSUFFICIENT_DATA
+        if not meaningful_langs:
+            message = (
+                "INSUFFICIENT_DATA: No meaningful Scholar analyses available. "
+                "Pipeline terminated."
+            )
+            # _log_and_record_failure は CallbackContext（.state 属性）を期待する。
+            # InvocationContext は ctx.session.state なので、アダプタとして
+            # state 属性を持つ簡易オブジェクトを渡す。
+            _log_and_record_failure(
+                type("_Ctx", (), {"state": state})(),
+                "scholar",
+                message,
+            )
+            yield Event(
+                invocation_id=ctx.invocation_id,
+                author=self.name,
+                branch=ctx.branch,
+                content=types.Content(
+                    role="model",
+                    parts=[types.Part(text=message)],
+                ),
+            )
+            return
+
+        logger.info(
+            "DynamicPolymathBlock: %d 言語の分析で Polymath 実行: %s",
+            len(meaningful_langs),
+            ", ".join(meaningful_langs),
+        )
+
+        # アクティブ言語のみの instruction を動的に組み立て
+        analyses_section = _build_analyses_section(meaningful_langs)
+        instruction = INSTRUCTION_PREAMBLE + "\n" + analyses_section + "\n" + INSTRUCTION_BODY
+
+        # LlmAgent を生成・実行
+        polymath = LlmAgent(
+            name="armchair_polymath",
+            model=create_pro_model(),
+            description=POLYMATH_DESCRIPTION,
+            instruction=instruction,
+            tools=POLYMATH_TOOLS,
+            output_key="mystery_report",
+        )
+        async for event in polymath._run_async_impl(ctx):
+            yield event
+
+
+def create_dynamic_polymath_block() -> DynamicPolymathBlock:
+    """DynamicPolymathBlock を新規生成する。"""
+    return DynamicPolymathBlock(
+        name="dynamic_polymath_block",
+        description=(
+            "Dynamically builds Armchair Polymath instruction with only active "
+            "language analyses. Integrates polymath gate: skips when no meaningful "
+            "Scholar analyses are available."
+        ),
+    )

--- a/mystery_agents/agents/dynamic_scholar_block.py
+++ b/mystery_agents/agents/dynamic_scholar_block.py
@@ -104,13 +104,11 @@ class DynamicScholarBlock(BaseAgent):
             if _is_meaningful(state.get(f"scholar_analysis_{lang}", ""))
         ]
 
-        # active_analyses_summary をステートに書き込み
+        # active_analyses_summary をステートに書き込み（ログ/診断用プレーンテキスト）
         summary_lines = []
         for lang in meaningful_langs:
             lang_name = SCHOLAR_CONFIGS[lang]["language_name"]
-            summary_lines.append(
-                f"- {lang_name} ({lang}): {{scholar_analysis_{lang}}}"
-            )
+            summary_lines.append(f"- {lang_name} ({lang})")
 
         if summary_lines:
             analyses_summary = (

--- a/mystery_agents/agents/pipeline_gate.py
+++ b/mystery_agents/agents/pipeline_gate.py
@@ -92,36 +92,6 @@ def make_scholar_gate():
     return gate
 
 
-def make_polymath_gate():
-    """全 Scholar が失敗した場合に ArmchairPolymath をスキップ。"""
-
-    def gate(callback_context: CallbackContext) -> Optional[types.Content]:
-        selected = callback_context.state.get("selected_languages", DEFAULT_SELECTED_LANGUAGES)
-        if not isinstance(selected, list):
-            selected = list(DEFAULT_SELECTED_LANGUAGES)
-
-        for lang in selected:
-            analysis = callback_context.state.get(f"scholar_analysis_{lang}", "")
-            if _is_meaningful(analysis):
-                logger.info(
-                    "Pipeline gate [polymath]: 通過（%s に有意な分析あり）", lang,
-                    extra={"gate_name": "polymath", "decision": "pass"},
-                )
-                return None
-
-        message = (
-            "INSUFFICIENT_DATA: No meaningful Scholar analyses available. "
-            "Pipeline terminated."
-        )
-        _log_and_record_failure(callback_context, "scholar", message)
-        return types.Content(
-            parts=[types.Part(text=message)],
-            role="model",
-        )
-
-    return gate
-
-
 def make_storyteller_gate():
     """mystery_report が空なら Storyteller をスキップ。"""
 

--- a/shared/state_registry.py
+++ b/shared/state_registry.py
@@ -45,13 +45,13 @@ STATE_KEYS: list[StateKey] = [
         name="active_languages",
         description="ドキュメント数ランキング順の言語リスト（Aggregator が設定）",
         written_by=("aggregator",),
-        read_by=("dynamic_scholar_block",),
+        read_by=("dynamic_scholar_block", "dynamic_polymath_block"),
     ),
     StateKey(
         name="active_analyses_summary",
-        description="DynamicScholarBlock が生成する分析概要（どの言語の分析が利用可能か）",
+        description="DynamicScholarBlock が生成する分析概要（ログ/診断用プレーンテキスト）",
         written_by=("dynamic_scholar_block",),
-        read_by=("armchair_polymath",),
+        read_by=(),
     ),
     StateKey(
         name="collected_documents_{api_key}",

--- a/tests/integration/test_agent_handover.py
+++ b/tests/integration/test_agent_handover.py
@@ -104,21 +104,6 @@ class TestInstructionPlaceholders:
         scholar_en = create_scholar("en")
         assert "{collected_documents_en}" in scholar_en.instruction
 
-    def test_armchair_polymath_references_analyses(self):
-        """ArmchairPolymath should reference all scholar_analysis keys."""
-        from mystery_agents.agents.armchair_polymath import armchair_polymath_agent
-
-        instruction = armchair_polymath_agent.instruction
-        assert "{scholar_analysis_en}" in instruction
-        assert "{scholar_analysis_de}" in instruction
-        assert "{scholar_analysis_es}" in instruction
-
-    def test_armchair_polymath_references_active_analyses_summary(self):
-        """ArmchairPolymath should reference {active_analyses_summary}."""
-        from mystery_agents.agents.armchair_polymath import armchair_polymath_agent
-
-        assert "{active_analyses_summary}" in armchair_polymath_agent.instruction
-
     def test_armchair_polymath_references_whiteboard(self):
         """ArmchairPolymath should reference {debate_whiteboard}."""
         from mystery_agents.agents.armchair_polymath import armchair_polymath_agent
@@ -351,14 +336,6 @@ class TestDynamicScholarBlockConfiguration:
 class TestPipelineGateCallbacks:
     """Tests for pipeline gate callbacks on block agents."""
 
-    def test_polymath_block_has_gate(self):
-        """polymath_block should have a before_agent_callback."""
-        from mystery_agents.agent import ghost_commander
-
-        polymath_block = _find_sub_agent(ghost_commander, "polymath_block")
-        assert polymath_block.before_agent_callback is not None
-        assert callable(polymath_block.before_agent_callback)
-
     def test_storyteller_block_has_gate(self):
         """storyteller_block should have a before_agent_callback."""
         from mystery_agents.agent import ghost_commander
@@ -382,7 +359,7 @@ class TestPipelineGateCallbacks:
         sub_agent_names = [repr(a) for a in ghost_commander.sub_agents]
         sub_agents_str = " ".join(sub_agent_names)
         assert "dynamic_scholar_block" in sub_agents_str
-        assert "polymath_block" in sub_agents_str
+        assert "dynamic_polymath_block" in sub_agents_str
         assert "storyteller_block" in sub_agents_str
         assert "post_story_block" in sub_agents_str
 

--- a/tests/unit/test_dynamic_polymath_block.py
+++ b/tests/unit/test_dynamic_polymath_block.py
@@ -1,0 +1,91 @@
+"""Unit tests for DynamicPolymathBlock."""
+
+from mystery_agents.agents.dynamic_polymath_block import (
+    DynamicPolymathBlock,
+    _build_analyses_section,
+    create_dynamic_polymath_block,
+)
+
+
+class TestDynamicPolymathBlockCreation:
+    """DynamicPolymathBlock ファクトリのテスト。"""
+
+    def test_creates_base_agent(self):
+        """BaseAgent を継承していること。"""
+        from google.adk.agents import BaseAgent
+
+        dpb = create_dynamic_polymath_block()
+        assert isinstance(dpb, BaseAgent)
+
+    def test_agent_name(self):
+        dpb = create_dynamic_polymath_block()
+        assert "dynamic_polymath_block" in repr(dpb)
+
+    def test_has_description(self):
+        dpb = create_dynamic_polymath_block()
+        assert dpb.description
+        assert "dynamically" in dpb.description.lower()
+
+
+class TestBuildAnalysesSection:
+    """_build_analyses_section のテスト。"""
+
+    def test_contains_only_active_langs(self):
+        """2言語アクティブ時にその2言語のプレースホルダーのみ含まれること。"""
+        section = _build_analyses_section(["en", "ja"])
+        assert "{scholar_analysis_en}" in section
+        assert "{scholar_analysis_ja}" in section
+        # 非アクティブ言語は含まれない
+        assert "{scholar_analysis_de}" not in section
+        assert "{scholar_analysis_es}" not in section
+        assert "{scholar_analysis_fr}" not in section
+        assert "{scholar_analysis_nl}" not in section
+        assert "{scholar_analysis_pt}" not in section
+
+    def test_single_language(self):
+        """1言語のみの場合でも正しくセクションを構築すること。"""
+        section = _build_analyses_section(["de"])
+        assert "{scholar_analysis_de}" in section
+        assert "1 language(s)" in section
+        assert "{scholar_analysis_en}" not in section
+
+    def test_includes_language_names(self):
+        """言語名がセクションに含まれること。"""
+        section = _build_analyses_section(["en", "de"])
+        assert "English" in section
+        assert "German" in section
+
+    def test_all_seven_languages(self):
+        """全7言語を指定した場合、全プレースホルダーが含まれること。"""
+        all_langs = ["en", "de", "es", "fr", "nl", "pt", "ja"]
+        section = _build_analyses_section(all_langs)
+        for lang in all_langs:
+            assert f"{{scholar_analysis_{lang}}}" in section
+        assert "7 language(s)" in section
+
+
+class TestInstructionComposition:
+    """動的 instruction 構築の結合テスト。"""
+
+    def test_composed_instruction_contains_debate_whiteboard(self):
+        """組み立てた instruction が {debate_whiteboard} を常に含むこと。"""
+        from mystery_agents.agents.armchair_polymath import (
+            INSTRUCTION_BODY,
+            INSTRUCTION_PREAMBLE,
+        )
+
+        section = _build_analyses_section(["en"])
+        instruction = INSTRUCTION_PREAMBLE + "\n" + section + "\n" + INSTRUCTION_BODY
+        assert "{debate_whiteboard}" in instruction
+
+    def test_composed_instruction_contains_preamble(self):
+        """組み立てた instruction がペルソナ紹介を含むこと。"""
+        from mystery_agents.agents.armchair_polymath import (
+            INSTRUCTION_BODY,
+            INSTRUCTION_PREAMBLE,
+        )
+
+        section = _build_analyses_section(["en"])
+        instruction = INSTRUCTION_PREAMBLE + "\n" + section + "\n" + INSTRUCTION_BODY
+        assert "Armchair Polymath" in instruction
+        assert "sardonic" in instruction

--- a/tests/unit/test_pipeline_gate.py
+++ b/tests/unit/test_pipeline_gate.py
@@ -6,7 +6,6 @@
 
 from mystery_agents.agents.pipeline_gate import (
     _is_meaningful,
-    make_polymath_gate,
     make_post_story_gate,
     make_scholar_gate,
     make_storyteller_gate,
@@ -113,30 +112,6 @@ class TestScholarGate:
             "collected_documents_en": "Found documents...",
         })
         gate = make_scholar_gate()
-        result = gate(ctx)
-        assert result is None
-
-
-class TestPolymathGate:
-    """make_polymath_gate のテスト。"""
-
-    def test_all_scholars_failed_skips(self):
-        ctx = MockCallbackContext(state={
-            "selected_languages": ["en", "es"],
-            "scholar_analysis_en": "INSUFFICIENT_DATA: Not enough material for analysis.",
-            "scholar_analysis_es": "INSUFFICIENT_DATA: No sources available.",
-        })
-        gate = make_polymath_gate()
-        result = gate(ctx)
-        assert result is not None
-
-    def test_one_scholar_succeeded_proceeds(self):
-        ctx = MockCallbackContext(state={
-            "selected_languages": ["en", "es"],
-            "scholar_analysis_en": "Analysis of Bell Witch phenomenon...",
-            "scholar_analysis_es": "INSUFFICIENT_DATA: No sources.",
-        })
-        gate = make_polymath_gate()
         result = gate(ctx)
         assert result is None
 

--- a/tests/unit/test_state_registry.py
+++ b/tests/unit/test_state_registry.py
@@ -14,7 +14,9 @@ class TestStateKeyDefinitions:
     def test_no_orphan_keys(self):
         """writer はあるが reader がいないキーは published_episode のみ許容。"""
         orphans = [k.name for k in STATE_KEYS if not k.read_by]
-        allowed_orphans = {"published_episode"}
+        # published_episode: 最終出力でリーダーなし
+        # active_analyses_summary: DynamicPolymathBlock 導入後はログ/診断用のみ
+        allowed_orphans = {"published_episode", "active_analyses_summary"}
         unexpected = set(orphans) - allowed_orphans
         assert not unexpected, f"Unexpected orphan keys: {unexpected}"
 


### PR DESCRIPTION
## Summary

- DynamicScholarBlock と同パターンの BaseAgent で、Armchair Polymath の instruction をアクティブ言語のみで動的構築
- 非アクティブ言語の空プレースホルダー展開を排除し、instruction の明瞭性向上（~90 tokens/call 削減）
- ゲート機能を DynamicPolymathBlock に内包し、`polymath_block` SequentialAgent + `make_polymath_gate()` を廃止

## 変更内容

| ファイル | 操作 |
|---|---|
| `mystery_agents/agents/armchair_polymath.py` | instruction を `INSTRUCTION_PREAMBLE` / `INSTRUCTION_BODY` に分割 |
| `mystery_agents/agents/dynamic_polymath_block.py` | **新規** BaseAgent ラッパー |
| `mystery_agents/agent.py` | `polymath_block` → `DynamicPolymathBlock` 置換 + `scholar_analysis_*` 初期化削除 |
| `mystery_agents/agents/pipeline_gate.py` | `make_polymath_gate()` 削除 |
| `mystery_agents/agents/dynamic_scholar_block.py` | `active_analyses_summary` をログ/診断用プレーンテキストに簡素化 |
| `mystery_agents/agents/__init__.py` | `create_dynamic_polymath_block` を export 追加 |
| `shared/state_registry.py` | `active_languages` の `read_by` に `dynamic_polymath_block` 追加 |
| `tests/unit/test_dynamic_polymath_block.py` | **新規** DynamicPolymathBlock テスト |
| `tests/unit/test_pipeline_gate.py` | `TestPolymathGate` クラス削除 |
| `tests/integration/test_agent_handover.py` | 静的 instruction テスト3件削除 + ゲートブロック検証更新 |
| `tests/unit/test_state_registry.py` | orphan キー許容リスト更新 |

## Test plan

- [x] `pytest tests/unit/test_dynamic_polymath_block.py -v` — 9 passed
- [x] `pytest tests/unit/test_armchair_polymath.py tests/unit/test_pipeline_gate.py tests/unit/test_dynamic_scholar_block.py -v` — 43 passed
- [x] `pytest tests/integration/test_agent_handover.py -v` — 34 passed（3件は既存の無関係な失敗）
- [x] `pytest tests/unit/ -v` — 1123 passed（2件は既存の無関係な失敗）

🤖 Generated with [Claude Code](https://claude.com/claude-code)