### PR TITLE
fix: 非英語 API への英語キーワード不一致を自動翻訳で補正

### DIFF
--- a/mystery_agents/tools/librarian_tools.py
+++ b/mystery_agents/tools/librarian_tools.py
@@ -439,6 +439,50 @@ def _get_expansion_languages(tool_context: Optional[ToolContext], current_lang: 
     return [lang for lang in selected if lang != current_lang]
 
 
+def _translate_keywords_for_source(
+    keyword_list: list[str],
+    source_obj,
+) -> list[str] | None:
+    """単一言語非英語ソースに英語キーワードが渡された場合、自動翻訳する。
+
+    対象: supported_languages が単一言語かつ非英語のソース（DDB=de, NDL=ja）
+    条件: 全キーワードが ASCII のみ（英語と推定）
+
+    Returns:
+        翻訳成功 → 翻訳キーワードリスト
+        対象外・翻訳失敗 → None（元キーワードで続行）
+    """
+    # 英語ソースまたは多言語ソースはスキップ
+    supported = source_obj.supported_languages
+    if len(supported) != 1:
+        return None
+    primary_lang = next(iter(supported))
+    if primary_lang == "en":
+        return None
+
+    # 非 ASCII キーワードが1つでもあればネイティブ言語が既に含まれている
+    if not all(_is_likely_english(kw) for kw in keyword_list):
+        return None
+
+    # 英語キーワードをソースのネイティブ言語に翻訳
+    logger.warning(
+        "キーワード言語不一致を検出: ソース=%s (言語=%s) に英語キーワードのみ → 自動翻訳を試行: %s",
+        source_obj.source_key,
+        primary_lang,
+        keyword_list,
+        extra={
+            "source_key": source_obj.source_key,
+            "source_lang": primary_lang,
+            "keywords": keyword_list,
+        },
+    )
+    translated = translate_keywords(keyword_list, "en", [primary_lang])
+    native_kws = translated.get(primary_lang)
+    if not native_kws:
+        return None
+    return native_kws
+
+
 def search_archives(
     keywords: str,
     date_start: Optional[str] = None,
@@ -535,6 +579,12 @@ def search_archives(
                 groups_for_source = keyword_groups
             else:
                 groups_for_source = [keyword_groups[0]]
+
+            # 単一言語非英語ソースへの英語キーワード不一致を自動翻訳で補正
+            native_kws = _translate_keywords_for_source(keyword_list, source_obj)
+            if native_kws:
+                groups_for_source = [native_kws] + groups_for_source
+
             futures[executor.submit(
                 _search_single_source,
                 source_obj,

--- a/shared/keyword_translator.py
+++ b/shared/keyword_translator.py
@@ -28,7 +28,7 @@ def _get_client():
 
         _client = translate.Client()
     except Exception:
-        logger.debug("Translation API クライアント初期化失敗", exc_info=True)
+        logger.warning("Translation API クライアント初期化失敗", exc_info=True)
         _client = None
     return _client
 
@@ -55,7 +55,7 @@ def _translate_single(text: str, source_lang: str, target_lang: str) -> Optional
             return None
         return translated
     except Exception:
-        logger.debug(
+        logger.warning(
             "翻訳失敗: %s (%s→%s)", text, source_lang, target_lang,
             exc_info=True,
         )

--- a/tests/unit/test_keyword_translator.py
+++ b/tests/unit/test_keyword_translator.py
@@ -129,3 +129,41 @@ class TestTranslateKeywords:
 
         # translate は1回しか呼ばれない（キャッシュヒット）
         assert mock_client.translate.call_count == 1
+
+
+class TestTranslationFailureWarningLogs:
+    """翻訳失敗時のログレベルが WARNING であることを検証。"""
+
+    def test_client_init_failure_logs_warning(self, caplog):
+        """_get_client() 初期化失敗時に WARNING ログが出力される。"""
+        import logging
+
+        with patch(
+            "shared.keyword_translator.translate",
+            side_effect=ImportError("No module"),
+            create=True,
+        ):
+            # _client_initialized をリセットして再初期化を強制
+            kt._client = None
+            kt._client_initialized = False
+
+            with patch.dict("sys.modules", {"google.cloud.translate_v2": None}):
+                with caplog.at_level(logging.WARNING):
+                    kt._get_client()
+
+        assert "Translation API クライアント初期化失敗" in caplog.text
+
+    @patch("shared.keyword_translator._get_client")
+    def test_translate_single_failure_logs_warning(self, mock_get_client, caplog):
+        """_translate_single() 翻訳失敗時に WARNING ログが出力される。"""
+        import logging
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.translate.side_effect = Exception("Translation API error")
+
+        with caplog.at_level(logging.WARNING):
+            result = kt._translate_single("ghost", "en", "de")
+
+        assert result is None
+        assert "翻訳失敗" in caplog.text

--- a/tests/unit/test_librarian_tools.py
+++ b/tests/unit/test_librarian_tools.py
@@ -830,14 +830,18 @@ class TestGetExpansionLanguages:
 class TestMultilingualKeywordExpansion:
     """search_archives の多言語キーワード展開テスト。"""
 
+    @patch("mystery_agents.tools.librarian_tools._translate_keywords_for_source")
     @patch("mystery_agents.tools.librarian_tools.translate_keywords")
     @patch("mystery_agents.tools.librarian_tools.validate_documents")
     @patch("mystery_agents.tools.librarian_tools.get_all_sources")
     def test_expansion_sent_to_multilingual_sources_only(
-        self, mock_get_all, mock_validate, mock_translate
+        self, mock_get_all, mock_validate, mock_translate, mock_per_source
     ):
         """展開キーワードは多言語ソースのみに渡される。"""
         from tests.fakes import make_tool_context
+
+        # ソース別自動翻訳を無効化してテスト対象を限定
+        mock_per_source.return_value = None
 
         # 多言語ソース（Europeana: 6言語対応）
         multi_source = _make_mock_source(
@@ -933,3 +937,104 @@ class TestMultilingualKeywordExpansion:
         )
 
         mock_translate.assert_not_called()
+
+
+class TestTranslateKeywordsForSource:
+    """_translate_keywords_for_source のテスト。"""
+
+    def test_ddb_english_keywords_triggers_translation(self):
+        """DDB（de 単一言語）に英語キーワード → 翻訳が呼ばれる。"""
+        from mystery_agents.tools.librarian_tools import _translate_keywords_for_source
+
+        ddb_source = _make_mock_source(
+            source_key="ddb", supported_languages={"de"},
+        )
+        with patch(
+            "mystery_agents.tools.librarian_tools.translate_keywords",
+            return_value={"de": ["Geist", "Spuk"]},
+        ) as mock_translate:
+            result = _translate_keywords_for_source(["ghost", "haunting"], ddb_source)
+
+        assert result == ["Geist", "Spuk"]
+        mock_translate.assert_called_once_with(["ghost", "haunting"], "en", ["de"])
+
+    def test_ndl_english_keywords_triggers_translation(self):
+        """NDL（ja 単一言語）に英語キーワード → 翻訳が呼ばれる。"""
+        from mystery_agents.tools.librarian_tools import _translate_keywords_for_source
+
+        ndl_source = _make_mock_source(
+            source_key="ndl", supported_languages={"ja"},
+        )
+        with patch(
+            "mystery_agents.tools.librarian_tools.translate_keywords",
+            return_value={"ja": ["幽霊", "怪奇"]},
+        ) as mock_translate:
+            result = _translate_keywords_for_source(["ghost", "haunting"], ndl_source)
+
+        assert result == ["幽霊", "怪奇"]
+        mock_translate.assert_called_once_with(["ghost", "haunting"], "en", ["ja"])
+
+    def test_english_source_skipped(self):
+        """英語ソース（LOC 等）→ None（スキップ）。"""
+        from mystery_agents.tools.librarian_tools import _translate_keywords_for_source
+
+        loc_source = _make_mock_source(
+            source_key="loc", supported_languages={"en"},
+        )
+        result = _translate_keywords_for_source(["ghost"], loc_source)
+        assert result is None
+
+    def test_multilingual_source_skipped(self):
+        """多言語ソース（Europeana 等）→ None（既存展開ロジックが担当）。"""
+        from mystery_agents.tools.librarian_tools import _translate_keywords_for_source
+
+        europeana_source = _make_mock_source(
+            source_key="europeana",
+            supported_languages={"en", "de", "es", "fr"},
+        )
+        result = _translate_keywords_for_source(["ghost"], europeana_source)
+        assert result is None
+
+    def test_non_ascii_keywords_skipped(self):
+        """非 ASCII キーワードが含まれる場合 → None（既にネイティブ言語あり）。"""
+        from mystery_agents.tools.librarian_tools import _translate_keywords_for_source
+
+        ddb_source = _make_mock_source(
+            source_key="ddb", supported_languages={"de"},
+        )
+        # ドイツ語キーワードが混在
+        result = _translate_keywords_for_source(["ghost", "Alpträume"], ddb_source)
+        assert result is None
+
+    def test_translation_failure_returns_none(self):
+        """翻訳失敗時 → None（元キーワードで続行）。"""
+        from mystery_agents.tools.librarian_tools import _translate_keywords_for_source
+
+        ddb_source = _make_mock_source(
+            source_key="ddb", supported_languages={"de"},
+        )
+        with patch(
+            "mystery_agents.tools.librarian_tools.translate_keywords",
+            return_value={},
+        ):
+            result = _translate_keywords_for_source(["ghost"], ddb_source)
+
+        assert result is None
+
+    def test_mismatch_warning_logged(self, caplog):
+        """不一致検出 + 自動翻訳成功時に WARNING ログが出力される。"""
+        import logging
+
+        from mystery_agents.tools.librarian_tools import _translate_keywords_for_source
+
+        ddb_source = _make_mock_source(
+            source_key="ddb", supported_languages={"de"},
+        )
+        with patch(
+            "mystery_agents.tools.librarian_tools.translate_keywords",
+            return_value={"de": ["Geist"]},
+        ):
+            with caplog.at_level(logging.WARNING):
+                _translate_keywords_for_source(["ghost"], ddb_source)
+
+        assert "キーワード言語不一致" in caplog.text or "自動翻訳" in caplog.text


### PR DESCRIPTION
## Summary

- 非英語 API（DDB/ドイツ語、NDL/日本語）に英語キーワードのみで検索が続行される問題を修正
- `_translate_keywords_for_source()` で単一言語非英語ソースへの英語キーワード不一致を検出し、Cloud Translation API で自動翻訳
- 翻訳キーワードを先頭グループ、英語を fallback として保持（両方の結果が得られる）
- `keyword_translator` の翻訳失敗ログを DEBUG → WARNING に引き上げ（サイレント障害防止）

## 変更内容

| ファイル | 変更 |
|---------|------|
| `mystery_agents/tools/librarian_tools.py` | `_translate_keywords_for_source()` 新関数 + 検索ディスパッチループ修正 |
| `shared/keyword_translator.py` | ログレベル DEBUG → WARNING（2箇所） |
| `tests/unit/test_librarian_tools.py` | 自動翻訳テスト 7件追加 |
| `tests/unit/test_keyword_translator.py` | WARNING ログレベルテスト 2件追加 |

## Test plan

- [x] `_translate_keywords_for_source` 7テスト（DDB/NDL翻訳、英語/多言語スキップ、非ASCIIスキップ、翻訳失敗、WARNINGログ）
- [x] `keyword_translator` WARNING ログテスト 2件
- [x] 既存テスト全パス（1135/1136、1件は既知の flaky test）

🤖 Generated with [Claude Code](https://claude.com/claude-code)