### PR TITLE
fix: Polymath レポート語数検証を save_structured_report で強制化

### DIFF
--- a/mystery_agents/tools/scholar_tools.py
+++ b/mystery_agents/tools/scholar_tools.py
@@ -630,6 +630,18 @@ def save_structured_report(
             ensure_ascii=False,
         )
 
+    # 語数検証チェック
+    if not tool_context.state.get("_word_count_verified"):
+        return json.dumps(
+            {
+                "status": "error",
+                "error": "count_words must be called with min_words=5000, max_words=10000 "
+                "and the report must be within range before saving. "
+                "Call count_words first, then revise if needed.",
+            },
+            ensure_ascii=False,
+        )
+
     try:
         report_data = json.loads(report_json)
     except json.JSONDecodeError as e:

--- a/mystery_agents/tools/word_count.py
+++ b/mystery_agents/tools/word_count.py
@@ -9,12 +9,20 @@ from __future__ import annotations
 
 import json
 
+from google.adk.tools import ToolContext
 
-def count_words(text: str, min_words: int = 0, max_words: int = 0) -> str:
+
+def count_words(
+    text: str,
+    tool_context: ToolContext = None,
+    min_words: int = 0,
+    max_words: int = 0,
+) -> str:
     """テキストの語数をカウントし、指定範囲との比較結果を返す。
 
     Args:
         text: 語数をカウントするテキスト
+        tool_context: ADK ToolContext（エージェント経由で自動注入、直接呼び出し時は省略可）
         min_words: 最小語数（0 の場合はチェックしない）
         max_words: 最大語数（0 の場合はチェックしない）
 
@@ -26,9 +34,13 @@ def count_words(text: str, min_words: int = 0, max_words: int = 0) -> str:
     result: dict = {"word_count": count}
 
     if min_words > 0 and max_words > 0:
+        within_range = min_words <= count <= max_words
         result["min_words"] = min_words
         result["max_words"] = max_words
-        result["within_range"] = min_words <= count <= max_words
+        result["within_range"] = within_range
+        # 語数検証フラグをセッション状態に設定
+        if tool_context is not None:
+            tool_context.state["_word_count_verified"] = within_range
         if count < min_words:
             result["message"] = (
                 f"Too short by {min_words - count} words. "

--- a/tests/unit/test_scholar_tools.py
+++ b/tests/unit/test_scholar_tools.py
@@ -14,9 +14,13 @@ from mystery_agents.tools.scholar_tools import (
 
 
 def _make_ctx(state: dict | None = None) -> MagicMock:
-    """inventory 参照済みフラグ付きのモック ToolContext を作成する。"""
+    """事前チェックフラグ付きのモック ToolContext を作成する。"""
     ctx = MagicMock()
-    ctx.state = {"_inventory_consulted": True, **(state or {})}
+    ctx.state = {
+        "_inventory_consulted": True,
+        "_word_count_verified": True,
+        **(state or {}),
+    }
     return ctx
 
 
@@ -425,9 +429,12 @@ class TestInventoryConsultedCheck:
         assert result_data["status"] == "success"
 
     def test_invalid_json_error_takes_priority_over_inventory(self):
-        """不正 JSON のエラーは inventory チェックより後（inventory チェックが先）。"""
+        """不正 JSON のエラーは事前チェック通過後に検出される。"""
         mock_ctx = MagicMock()
-        mock_ctx.state = {"_inventory_consulted": True}
+        mock_ctx.state = {
+            "_inventory_consulted": True,
+            "_word_count_verified": True,
+        }
 
         result = save_structured_report("not valid json", mock_ctx)
         result_data = json.loads(result)
@@ -643,3 +650,42 @@ class TestValidateEvidenceGroundingDirect:
         }
         warnings = _validate_evidence_grounding(report_data, mock_ctx)
         assert warnings == []
+
+
+class TestWordCountVerifiedCheck:
+    """語数検証フラグ強制チェックのテスト。"""
+
+    def test_error_when_word_count_not_verified(self):
+        """_word_count_verified 未設定で save_structured_report → エラー。"""
+        mock_ctx = MagicMock()
+        mock_ctx.state = {"_inventory_consulted": True}
+
+        report_data = {"title": "Test", "hypothesis": "Test"}
+        result = save_structured_report(json.dumps(report_data), mock_ctx)
+        result_data = json.loads(result)
+
+        assert result_data["status"] == "error"
+        assert "count_words" in result_data["error"]
+        assert "structured_report" not in mock_ctx.state
+
+    def test_error_when_word_count_verified_false(self):
+        """_word_count_verified = False（範囲外）でもエラー。"""
+        mock_ctx = MagicMock()
+        mock_ctx.state = {"_inventory_consulted": True, "_word_count_verified": False}
+
+        report_data = {"title": "Test"}
+        result = save_structured_report(json.dumps(report_data), mock_ctx)
+        result_data = json.loads(result)
+
+        assert result_data["status"] == "error"
+        assert "count_words" in result_data["error"]
+
+    def test_success_when_word_count_verified(self):
+        """_word_count_verified = True で正常保存。"""
+        mock_ctx = _make_ctx()
+
+        report_data = {"title": "Test"}
+        result = save_structured_report(json.dumps(report_data), mock_ctx)
+        result_data = json.loads(result)
+
+        assert result_data["status"] == "success"

--- a/tests/unit/test_word_count.py
+++ b/tests/unit/test_word_count.py
@@ -1,6 +1,7 @@
 """count_words ツールのユニットテスト。"""
 
 import json
+from unittest.mock import MagicMock
 
 from mystery_agents.tools.word_count import count_words
 
@@ -77,3 +78,33 @@ class TestCountWords:
         result = json.loads(count_words(text, min_words=2000, max_words=3500))
         assert result["within_range"] is True
         assert result["word_count"] == 2500
+
+
+class TestCountWordsToolContextFlag:
+    """count_words() の ToolContext フラグ設定検証。"""
+
+    def _make_tool_context(self) -> MagicMock:
+        ctx = MagicMock()
+        ctx.state = {}
+        return ctx
+
+    def test_within_range_sets_verified_flag(self):
+        """範囲内 → _word_count_verified = True がステートに設定される。"""
+        ctx = self._make_tool_context()
+        text = " ".join(["word"] * 5000)
+        count_words(text, tool_context=ctx, min_words=5000, max_words=10000)
+        assert ctx.state["_word_count_verified"] is True
+
+    def test_out_of_range_resets_verified_flag(self):
+        """範囲外 → _word_count_verified = False にリセットされる。"""
+        ctx = self._make_tool_context()
+        ctx.state["_word_count_verified"] = True  # 前回の成功を模擬
+        text = " ".join(["word"] * 500)
+        count_words(text, tool_context=ctx, min_words=5000, max_words=10000)
+        assert ctx.state["_word_count_verified"] is False
+
+    def test_no_range_does_not_set_flag(self):
+        """範囲未指定 → _word_count_verified は設定されない。"""
+        ctx = self._make_tool_context()
+        count_words("hello world", tool_context=ctx)
+        assert "_word_count_verified" not in ctx.state


### PR DESCRIPTION
## Summary

- `count_words` ツールに `tool_context` パラメータを追加し、`within_range=True` 時に `_word_count_verified` フラグをセッション状態に設定
- `save_structured_report` に `_word_count_verified` チェックを追加（`_inventory_consulted` パターンの再利用）
- LLM が `count_words` をスキップ or 範囲外のまま保存しようとした場合、エラーを返して再呼び出しを強制

## 変更内容

| ファイル | 変更 |
|----------|------|
| `mystery_agents/tools/word_count.py` | `tool_context` パラメータ追加、`_word_count_verified` フラグ設定 |
| `mystery_agents/tools/scholar_tools.py` | `_word_count_verified` チェック追加 |
| `tests/unit/test_word_count.py` | ToolContext フラグ設定テスト 3件追加 |
| `tests/unit/test_scholar_tools.py` | 語数検証チェックテスト 3件追加 + `_make_ctx` ヘルパー更新 |

## Test plan

- [x] `pytest tests/unit/test_word_count.py -v` — 14件全件パス
- [x] `pytest tests/unit/test_scholar_tools.py -v` — 33件全件パス
- [x] `pytest tests/unit/ -v` — 1136件全件パス（回帰なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)