### PR TITLE
fix: DynamicBlock の _run_async_impl → run_async に修正

### DIFF
--- a/mystery_agents/agents/dynamic_polymath_block.py
+++ b/mystery_agents/agents/dynamic_polymath_block.py
@@ -113,7 +113,7 @@ class DynamicPolymathBlock(BaseAgent):
             tools=POLYMATH_TOOLS,
             output_key="mystery_report",
         )
-        async for event in polymath._run_async_impl(ctx):
+        async for event in polymath.run_async(ctx):
             yield event
 
 

--- a/mystery_agents/agents/dynamic_scholar_block.py
+++ b/mystery_agents/agents/dynamic_scholar_block.py
@@ -95,7 +95,7 @@ class DynamicScholarBlock(BaseAgent):
             name="dynamic_analysis",
             sub_agents=analysis_scholars,
         )
-        async for event in parallel_analysis._run_async_impl(ctx):
+        async for event in parallel_analysis.run_async(ctx):
             yield event
 
         # 有意な分析を出した言語を特定
@@ -162,7 +162,7 @@ class DynamicScholarBlock(BaseAgent):
                 name=f"dynamic_debate_{iteration}",
                 sub_agents=debate_scholars,
             )
-            async for event in parallel_debate._run_async_impl(ctx):
+            async for event in parallel_debate.run_async(ctx):
                 yield event
 
             # 収束判定（LLM を介さず直接チェック）


### PR DESCRIPTION
## Summary

- DynamicPolymathBlock / DynamicScholarBlock で動的生成したサブエージェントを `_run_async_impl()` で直接呼び出していたのを `run_async()` に修正
- `_run_async_impl` は `InvocationContext.agent` を更新しないため、ADK の LLM フロー（`base_llm_flow.py:526`）が `ctx.agent` を検査した際に BaseAgent を発見し TypeError を送出していた
- `run_async` は `_create_invocation_context()` で `ctx.agent` を正しく設定するため、この問題を回避する

## 変更内容（3行）

| ファイル | 行 | 変更 |
|---|---|---|
| `dynamic_polymath_block.py` | 116 | `polymath._run_async_impl(ctx)` → `polymath.run_async(ctx)` |
| `dynamic_scholar_block.py` | 98 | `parallel_analysis._run_async_impl(ctx)` → `parallel_analysis.run_async(ctx)` |
| `dynamic_scholar_block.py` | 165 | `parallel_debate._run_async_impl(ctx)` → `parallel_debate.run_async(ctx)` |

## Test plan

- [x] 既存ユニットテスト 32件パス（`test_dynamic_polymath_block.py` + `test_dynamic_scholar_block.py`）
- [ ] ローカルでパイプライン実行し TypeError が解消されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)