### PR TITLE
refactor: _strip_html() を archive_source_base.py に集約

### DIFF
--- a/mystery_agents/tools/archive_source_base.py
+++ b/mystery_agents/tools/archive_source_base.py
@@ -139,6 +139,27 @@ class ArchiveSource(ABC):
         ...
 
     @staticmethod
+    def strip_html(text: str | list | None) -> str:
+        """HTML タグを除去する。
+
+        複数のソースモジュールに重複していた _strip_html を統一。
+
+        Args:
+            text: HTML を含む可能性のあるテキスト。
+                  list[str] の場合はスペース結合してからタグ除去する。
+
+        Returns:
+            タグ除去済みのプレーンテキスト。None の場合は空文字列。
+        """
+        if not text:
+            return ""
+        if isinstance(text, list):
+            text = " ".join(str(item) for item in text if item)
+        if not isinstance(text, str):
+            return str(text)
+        return re.sub(r"<[^>]+>", "", text).strip()
+
+    @staticmethod
     def parse_year(date_str: str, min_century: int = 13) -> str | None:
         """日付文字列から年を抽出し ISO 形式に変換する。
 

--- a/mystery_agents/tools/ndl_search.py
+++ b/mystery_agents/tools/ndl_search.py
@@ -19,6 +19,9 @@ from .source_registry import register_source
 
 logger = logging.getLogger(__name__)
 
+# archive_source_base.py に統一された strip_html を使用
+_strip_html = ArchiveSource.strip_html
+
 BASE_URL = "https://ndlsearch.ndl.go.jp/api/opensearch"
 _NDL_LAB_URL = "https://lab.ndl.go.jp/dl/api/book/layouttext/{pid}"
 
@@ -35,11 +38,6 @@ _NS = {
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
 }
-
-
-def _strip_html(text: str) -> str:
-    """HTML タグを除去する。"""
-    return re.sub(r"<[^>]+>", "", text)
 
 
 def _extract_pid(url: str) -> str | None:

--- a/mystery_agents/tools/wellcome_collection.py
+++ b/mystery_agents/tools/wellcome_collection.py
@@ -6,7 +6,6 @@ Wellcome Collection（ロンドン）の Catalogue API v2 を使用して
 """
 
 import logging
-import re
 
 from ..schemas.document import ArchiveDocument, SourceLanguage
 from .archive_source_base import ArchiveSearchResult, ArchiveSource
@@ -14,6 +13,9 @@ from .search_utils import build_search_query
 from .source_registry import register_source
 
 logger = logging.getLogger(__name__)
+
+# archive_source_base.py に統一された strip_html を使用
+_strip_html = ArchiveSource.strip_html
 
 BASE_URL = "https://api.wellcomecollection.org/catalogue/v2/works"
 
@@ -41,25 +43,6 @@ _LANG_1_TO_3: dict[str, str] = {
     "pt": "por",
     "ja": "jpn",
 }
-
-
-def _strip_html(text: str | list | None) -> str:
-    """HTML タグを除去する。
-
-    Args:
-        text: HTML を含む可能性のあるテキスト。
-              Wellcome API の notes[].contents は list[str] の場合がある。
-
-    Returns:
-        タグ除去済みのプレーンテキスト。None の場合は空文字列。
-    """
-    if not text:
-        return ""
-    if isinstance(text, list):
-        text = " ".join(str(item) for item in text if item)
-    if not isinstance(text, str):
-        return str(text)
-    return re.sub(r"<[^>]+>", "", text).strip()
 
 
 def _extract_date_label(work: dict) -> str:

--- a/tests/unit/test_archive_source_base.py
+++ b/tests/unit/test_archive_source_base.py
@@ -113,6 +113,38 @@ class TestArchiveSourceSearch:
         assert result.error is None
 
 
+class TestStripHtml:
+    """ArchiveSource.strip_html() のテスト。"""
+
+    def test_removes_html_tags(self):
+        """HTML タグが除去される。"""
+        assert ArchiveSource.strip_html("<p>Hello <b>world</b></p>") == "Hello world"
+
+    def test_none_returns_empty(self):
+        """None の場合は空文字列を返す。"""
+        assert ArchiveSource.strip_html(None) == ""
+
+    def test_empty_string_returns_empty(self):
+        """空文字列の場合はそのまま返す。"""
+        assert ArchiveSource.strip_html("") == ""
+
+    def test_plain_text_unchanged(self):
+        """タグなしテキストはそのまま返す。"""
+        assert ArchiveSource.strip_html("plain text") == "plain text"
+
+    def test_list_input_joined(self):
+        """list 型入力はスペース結合してからタグ除去する。"""
+        assert ArchiveSource.strip_html(["<p>a</p>", "<b>b</b>"]) == "a b"
+
+    def test_list_with_none_items(self):
+        """list 内の falsy 項目をスキップする。"""
+        assert ArchiveSource.strip_html(["<p>text</p>", None, ""]) == "text"
+
+    def test_empty_list_returns_empty(self):
+        """空リストの場合は空文字列を返す。"""
+        assert ArchiveSource.strip_html([]) == ""
+
+
 class TestParseYear:
     """ArchiveSource.parse_year() のテスト。"""
 


### PR DESCRIPTION
## Summary
- `ArchiveSource.strip_html()` スタティックメソッドを追加（Wellcome 版の `str | list | None` 対応をスーパーセットとして採用）
- `ndl_search.py` と `wellcome_collection.py` の重複 `_strip_html()` を削除し、基底クラスのメソッドに置き換え
- `test_archive_source_base.py` に `strip_html` テスト 7 件を追加

## Test plan
- [x] `test_archive_source_base.py` 新規テスト 7 件含む全テスト通過
- [x] `test_ndl_search.py` 全テスト通過
- [x] `test_wellcome_collection.py` 全テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)