### PR TITLE
fix: Polymath に max_output_tokens=65536 設定 + ツール呼び出しログ追加

### DIFF
--- a/mystery_agents/agents/armchair_polymath.py
+++ b/mystery_agents/agents/armchair_polymath.py
@@ -7,7 +7,10 @@ CrossReferenceScholar の後継。output_key は既存と同じ "mystery_report"
 下流エージェントとの互換性を維持。save_structured_report を必ず呼び出す。
 """
 
+import logging
+
 from google.adk.agents import LlmAgent
+from google.genai import types
 
 from shared.model_config import create_pro_model
 
@@ -16,6 +19,8 @@ from ..tools.openalex import search_academic_papers
 from ..tools.scholar_tools import save_structured_report
 from ..tools.search_metadata import get_search_metadata
 from ..tools.word_count import count_words
+
+logger = logging.getLogger(__name__)
 
 # === 日本語訳 ===
 # あなたは「Ghost in the Archive」プロジェクトの Armchair Polymath です。
@@ -537,6 +542,43 @@ POLYMATH_TOOLS = [
     count_words,
 ]
 
+# 5,000〜10,000語のレポートを1ターンで出力するための max_output_tokens
+POLYMATH_MAX_OUTPUT_TOKENS = 65536
+
+# ツール呼び出しカウンター用ステートキー
+_TOOL_CALL_COUNT_KEY = "polymath_tool_call_count"
+
+# ログに出力する args 値の最大文字数
+_TRUNCATE_THRESHOLD = 200
+
+
+def log_polymath_tool_call(tool, args, tool_context):
+    """Polymath のツール呼び出しをログに記録する。
+
+    カウンターをインクリメントし、ツール名と引数をログ出力する。
+    長文フィールド（200字超）はトランケートする。
+    常に None を返し、ツール実行をブロックしない。
+    """
+    count = tool_context.state.get(_TOOL_CALL_COUNT_KEY, 0) + 1
+    tool_context.state[_TOOL_CALL_COUNT_KEY] = count
+
+    # args の長文フィールドをトランケート
+    truncated_args = {}
+    for key, value in args.items():
+        if isinstance(value, str) and len(value) > _TRUNCATE_THRESHOLD:
+            truncated_args[key] = value[:_TRUNCATE_THRESHOLD] + "..."
+        else:
+            truncated_args[key] = value
+
+    logger.info(
+        "Polymath tool call #%d: %s (args: %s)",
+        count,
+        tool.name,
+        truncated_args,
+    )
+    return None
+
+
 # Polymath 説明文（DynamicPolymathBlock でも共有）
 POLYMATH_DESCRIPTION = (
     "The Armchair Polymath: a sardonic, encyclopaedically learned synthesizer "
@@ -556,6 +598,10 @@ def create_armchair_polymath() -> LlmAgent:
         instruction=ARMCHAIR_POLYMATH_INSTRUCTION,
         tools=POLYMATH_TOOLS,
         output_key="mystery_report",  # 既存と同じキー → 下流互換性維持
+        generate_content_config=types.GenerateContentConfig(
+            max_output_tokens=POLYMATH_MAX_OUTPUT_TOKENS,
+        ),
+        before_tool_callback=log_polymath_tool_call,
     )
 
 

--- a/mystery_agents/agents/dynamic_polymath_block.py
+++ b/mystery_agents/agents/dynamic_polymath_block.py
@@ -21,7 +21,9 @@ from .armchair_polymath import (
     INSTRUCTION_BODY,
     INSTRUCTION_PREAMBLE,
     POLYMATH_DESCRIPTION,
+    POLYMATH_MAX_OUTPUT_TOKENS,
     POLYMATH_TOOLS,
+    log_polymath_tool_call,
 )
 from .language_scholars import SCHOLAR_CONFIGS
 from .pipeline_gate import _is_meaningful, _log_and_record_failure
@@ -112,6 +114,10 @@ class DynamicPolymathBlock(BaseAgent):
             instruction=instruction,
             tools=POLYMATH_TOOLS,
             output_key="mystery_report",
+            generate_content_config=types.GenerateContentConfig(
+                max_output_tokens=POLYMATH_MAX_OUTPUT_TOKENS,
+            ),
+            before_tool_callback=log_polymath_tool_call,
         )
         async for event in polymath.run_async(ctx):
             yield event

--- a/tests/unit/test_polymath_callback.py
+++ b/tests/unit/test_polymath_callback.py
@@ -1,0 +1,75 @@
+"""Unit tests for Polymath before_tool_callback (tool call logging)."""
+
+from unittest.mock import MagicMock
+
+from mystery_agents.agents.armchair_polymath import (
+    POLYMATH_MAX_OUTPUT_TOKENS,
+    log_polymath_tool_call,
+)
+
+
+class TestLogPolymathToolCall:
+    """log_polymath_tool_call コールバックのテスト。"""
+
+    def _make_tool_context(self):
+        ctx = MagicMock()
+        ctx.state = {}
+        return ctx
+
+    def _make_tool(self, name: str):
+        tool = MagicMock()
+        tool.name = name
+        return tool
+
+    def test_returns_none(self):
+        """常に None を返す（ツール実行をブロックしない）。"""
+        ctx = self._make_tool_context()
+        tool = self._make_tool("get_search_metadata")
+        result = log_polymath_tool_call(tool, {}, ctx)
+        assert result is None
+
+    def test_increments_counter(self):
+        """呼び出しごとにカウンターがインクリメントされる。"""
+        ctx = self._make_tool_context()
+        tool = self._make_tool("get_search_metadata")
+
+        log_polymath_tool_call(tool, {}, ctx)
+        assert ctx.state["polymath_tool_call_count"] == 1
+
+        log_polymath_tool_call(tool, {}, ctx)
+        assert ctx.state["polymath_tool_call_count"] == 2
+
+    def test_counter_persists_across_tools(self):
+        """異なるツールでもカウンターが共有される。"""
+        ctx = self._make_tool_context()
+        tool_a = self._make_tool("get_search_metadata")
+        tool_b = self._make_tool("search_academic_papers")
+
+        log_polymath_tool_call(tool_a, {}, ctx)
+        log_polymath_tool_call(tool_b, {"query": "test"}, ctx)
+        assert ctx.state["polymath_tool_call_count"] == 2
+
+    def test_truncates_large_args(self, caplog):
+        """200字超の args 値がログ上でトランケートされる。"""
+        import logging
+
+        ctx = self._make_tool_context()
+        tool = self._make_tool("save_structured_report")
+        long_value = "x" * 300
+
+        with caplog.at_level(logging.INFO):
+            log_polymath_tool_call(tool, {"report_json": long_value}, ctx)
+
+        # ログにトランケートされた値が含まれる（原文300字ではなく切り詰め）
+        log_text = caplog.text
+        assert "save_structured_report" in log_text
+        assert long_value not in log_text  # 元の300字はそのまま出ない
+        assert "..." in log_text  # トランケートマーカーがある
+
+
+class TestPolymathMaxOutputTokens:
+    """POLYMATH_MAX_OUTPUT_TOKENS 定数のテスト。"""
+
+    def test_max_output_tokens_value(self):
+        """65536 であること。"""
+        assert POLYMATH_MAX_OUTPUT_TOKENS == 65536


### PR DESCRIPTION
## Summary

- Armchair Polymath の `max_output_tokens` をデフォルト 8,192 → **65,536** に引き上げ、5,000〜10,000語のレポートを1ターンで出力可能にした
- `before_tool_callback` で全ツール呼び出しをログ記録する `log_polymath_tool_call` を追加（呼び出し番号・ツール名・引数を出力、200字超はトランケート）
- `create_armchair_polymath()` と `DynamicPolymathBlock` の両方に同じ設定を適用

## 背景

Polymath が理論上の最小6ターンより3ターン以上多い9+ターンの LLM リクエストを行っていた。

- **原因1**: `max_output_tokens` 未設定（デフォルト8,192トークン）→ 長いレポートを1回で出力できず `count_words` → 修正 → 再カウントの追加ターンが発生
- **原因2**: ツール呼び出しログがなく、追加ターンの原因を特定できなかった

## Test plan

- [x] `test_polymath_callback.py` — 純関数テスト（returns None, カウンター, トランケート）
- [x] 既存テスト全パス（`test_armchair_polymath.py`, `test_dynamic_polymath_block.py`）
- [x] 全ユニットテストでリグレッション確認
- [ ] 本番パイプライン実行でターン数が6〜7に削減されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)