### PR TITLE
refactor: 共有記事レンダラー MysteryArticle 抽出 + TOC スクロールスパイ修正

### DIFF
--- a/packages/shared/src/components/mystery/mystery-article.tsx
+++ b/packages/shared/src/components/mystery/mystery-article.tsx
@@ -1,0 +1,218 @@
+// 共有記事レンダラー
+// 管理画面プレビューと公開ページの両方から使用する。
+// "use client" なし — サーバーコンポーネント互換（子コンポーネントが個別に "use client" を持つ）
+import type { ReactNode } from "react"
+import { FileText } from "lucide-react"
+import { EvidenceBlock } from "../evidence-block"
+import { CaseFileHeader } from "./case-file-header"
+import { NarrativeSection } from "./narrative-section"
+import { DiscrepancySection } from "./discrepancy-section"
+import { HypothesisSection } from "./hypothesis-section"
+import { HistoricalContextSection } from "./historical-context-section"
+import { DetailSidebar } from "./detail-sidebar"
+import { TableOfContents } from "../table-of-contents"
+import { SECTION_IDS, type TocSection } from "../../lib/toc-config"
+import { extractHeadings } from "../../lib/markdown-headings"
+import { stripLeadingH1 } from "../../lib/utils"
+import type { FirestoreMystery } from "../../types/mystery"
+import type { LocalizedMystery } from "../../lib/localize"
+
+// --- ラベル型定義 ---
+
+export interface MysteryArticleLabels {
+  // CaseFileHeader
+  publishedLabel: string
+  storytellerBylineLabel: string
+  confidence: { confirmedGhost: string; suspectedGhost: string; archivalEcho: string }
+  classification: Record<string, string>
+  // TableOfContents
+  tableOfContents: string
+  // TOC セクションラベル
+  tocNarrative: string
+  tocDiscrepancy: string
+  tocEvidence: string
+  tocHypothesis: string
+  tocHistoricalContext: string
+  // 各セクション
+  archivalData: string
+  discoveredDiscrepancy: string
+  archivalEvidence: string
+  primarySource: string
+  contrastingSource: string
+  additionalEvidence: string
+  evidence: { source: string; view: string; originalText: string }
+  hypothesis: string
+  alternativeHypotheses: string
+  historicalContext: string
+  relatedEvents: string
+  keyFigures: string
+  storyAngles: string
+  classificationNotice: string
+  sourceCoverage: { heading: string }
+}
+
+// --- Props ---
+
+export interface MysteryArticleProps {
+  mystery: FirestoreMystery
+  localized: LocalizedMystery
+  lang: string
+  labels: MysteryArticleLabels
+  translatedExcerpts: { a?: string; b?: string; additional: (string | undefined)[] }
+  heroImage?: ReactNode
+  publishedAt?: Date
+  afterHeader?: ReactNode
+  mainColumnFooter?: ReactNode
+}
+
+// --- コンポーネント ---
+
+export function MysteryArticle({
+  mystery,
+  localized,
+  lang,
+  labels,
+  translatedExcerpts,
+  heroImage,
+  publishedAt,
+  afterHeader,
+  mainColumnFooter,
+}: MysteryArticleProps) {
+  const {
+    title, summary, narrativeContent, discrepancyDetected,
+    hypothesis, alternativeHypotheses, politicalClimate, storyHooks,
+    confidenceRationale,
+  } = localized
+
+  const location = mystery.historical_context?.geographic_scope?.join(", ") || ""
+  const timePeriod = mystery.historical_context?.time_period || ""
+
+  // 本文見出しから TOC セクションを動的構築（1回だけ計算）
+  const narrativeHeadings = extractHeadings(stripLeadingH1(narrativeContent || ""))
+  const precomputedHeadingIds = narrativeHeadings.map(h => h.id)
+
+  const tocSections: TocSection[] = [
+    ...(narrativeHeadings.length > 0
+      ? narrativeHeadings.map(h => ({ id: h.id, label: h.text }))
+      : [{ id: SECTION_IDS.narrative, label: labels.tocNarrative }]),
+    ...(discrepancyDetected ? [{ id: SECTION_IDS.discrepancy, label: labels.tocDiscrepancy }] : []),
+    { id: SECTION_IDS.evidence, label: labels.tocEvidence },
+    ...(hypothesis ? [{ id: SECTION_IDS.hypothesis, label: labels.tocHypothesis }] : []),
+    ...(mystery.historical_context ? [{ id: SECTION_IDS.historicalContext, label: labels.tocHistoricalContext }] : []),
+  ]
+
+  return (
+    <>
+      <CaseFileHeader
+        mysteryId={mystery.mystery_id}
+        title={title}
+        location={location}
+        timePeriod={timePeriod}
+        publishedAt={publishedAt}
+        publishedLabel={labels.publishedLabel}
+        confidenceLevel={mystery.confidence_level}
+        confidenceLabels={labels.confidence}
+        classificationLabels={labels.classification}
+        storyteller={mystery.storyteller}
+        storytellerBylineLabel={labels.storytellerBylineLabel}
+      />
+
+      {afterHeader}
+
+      {/* モバイル目次 */}
+      <TableOfContents sections={tocSections} heading={labels.tableOfContents} variant="mobile" />
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 lg:gap-12">
+        {/* メインコンテンツ */}
+        <div className="lg:col-span-2 space-y-12">
+          {/* ヒーロー画像（アプリ固有コンポーネントを slot で受け取る） */}
+          {heroImage}
+
+          <NarrativeSection
+            narrativeContent={narrativeContent}
+            summary={summary}
+            lang={lang}
+            precomputedHeadingIds={precomputedHeadingIds}
+          />
+
+          {/* 本文とアーカイブデータの区切り */}
+          <div className="flex items-center gap-4">
+            <div className="h-px flex-1 bg-border" />
+            <span className="text-xs font-mono uppercase tracking-wider text-muted-foreground">{labels.archivalData}</span>
+            <div className="h-px flex-1 bg-border" />
+          </div>
+
+          {discrepancyDetected && (
+            <DiscrepancySection discrepancyDetected={discrepancyDetected} label={labels.discoveredDiscrepancy} />
+          )}
+
+          {/* 証拠セクション */}
+          <section id="section-evidence" className="scroll-mt-24">
+            <div className="flex items-center gap-3 mb-6">
+              <FileText className="w-5 h-5 text-gold" />
+              <h2 className="font-serif text-xl text-parchment">{labels.archivalEvidence}</h2>
+            </div>
+            <div className="space-y-8">
+              <EvidenceBlock
+                evidence={mystery.evidence_a}
+                label={labels.primarySource}
+                translatedExcerpt={translatedExcerpts.a}
+                labels={labels.evidence}
+              />
+              <EvidenceBlock
+                evidence={mystery.evidence_b}
+                label={labels.contrastingSource}
+                translatedExcerpt={translatedExcerpts.b}
+                labels={labels.evidence}
+              />
+              {mystery.additional_evidence.map((ev, i) => (
+                <EvidenceBlock
+                  key={i}
+                  evidence={ev}
+                  label={`${labels.additionalEvidence} ${i + 1}`}
+                  translatedExcerpt={translatedExcerpts.additional[i]}
+                  labels={labels.evidence}
+                />
+              ))}
+            </div>
+          </section>
+
+          {hypothesis && (
+            <HypothesisSection
+              hypothesis={hypothesis}
+              alternativeHypotheses={alternativeHypotheses}
+              labels={{ hypothesis: labels.hypothesis, alternativeHypotheses: labels.alternativeHypotheses }}
+            />
+          )}
+
+          {mystery.historical_context && (
+            <HistoricalContextSection
+              historicalContext={mystery.historical_context}
+              politicalClimate={politicalClimate}
+              labels={{
+                historicalContext: labels.historicalContext,
+                relatedEvents: labels.relatedEvents,
+                keyFigures: labels.keyFigures,
+              }}
+            />
+          )}
+
+          {mainColumnFooter}
+        </div>
+
+        <DetailSidebar
+          storyHooks={storyHooks}
+          labels={{
+            storyAngles: labels.storyAngles,
+            classificationNotice: labels.classificationNotice,
+          }}
+          confidenceRationale={confidenceRationale}
+          sourceCoverageLabels={labels.sourceCoverage}
+        >
+          {/* デスクトップ目次（サイドバー内） */}
+          <TableOfContents sections={tocSections} heading={labels.tableOfContents} variant="desktop" />
+        </DetailSidebar>
+      </div>
+    </>
+  )
+}

--- a/packages/shared/src/components/mystery/narrative-section.tsx
+++ b/packages/shared/src/components/mystery/narrative-section.tsx
@@ -48,9 +48,12 @@ interface NarrativeSectionProps {
   narrativeContent?: string
   summary: string
   lang?: string
+  // extractHeadings で事前計算した ID 配列。渡された場合はこの ID を使い、
+  // TOC と DOM 見出しの ID 一致を保証する（スクロールスパイ修正の核心）
+  precomputedHeadingIds?: string[]
 }
 
-export function NarrativeSection({ narrativeContent, summary, lang = "en" }: NarrativeSectionProps) {
+export function NarrativeSection({ narrativeContent, summary, lang = "en", precomputedHeadingIds }: NarrativeSectionProps) {
   if (narrativeContent) {
     // 重複スラグを追跡するクロージャ（レンダーごとにリセット）
     const slugCounts = new Map<string, number>()
@@ -64,13 +67,18 @@ export function NarrativeSection({ narrativeContent, summary, lang = "en" }: Nar
         <ArchiveImage src={typeof src === "string" ? src : undefined} alt={alt} lang={lang} />
       ),
       h2: ({ children }) => {
+        const currentIndex = headingIndex
+        headingIndex++
+        // precomputedHeadingIds があればそれを使い、TOC と DOM の ID を一致させる
+        if (precomputedHeadingIds && currentIndex < precomputedHeadingIds.length) {
+          return <h2 id={precomputedHeadingIds[currentIndex]} className="scroll-mt-24">{children}</h2>
+        }
+        // フォールバック: 従来の getTextContent + slugify
         const text = getTextContent(children)
-        // 空スラグのフォールバック（Unicode 対応で解消済みだが安全策）
-        const baseSlug = slugify(text) || `heading-${headingIndex}`
+        const baseSlug = slugify(text) || `heading-${currentIndex}`
         const count = slugCounts.get(baseSlug) || 0
         const id = count > 0 ? `${baseSlug}-${count}` : baseSlug
         slugCounts.set(baseSlug, count + 1)
-        headingIndex++
         return <h2 id={id} className="scroll-mt-24">{children}</h2>
       },
     }

--- a/web-admin/src/app/(main)/preview/[id]/preview-content.tsx
+++ b/web-admin/src/app/(main)/preview/[id]/preview-content.tsx
@@ -2,38 +2,41 @@
 
 import Link from "next/link"
 import Image from "next/image"
-import { EvidenceBlock } from "@ghost/shared/src/components/evidence-block"
-import { CaseFileHeader } from "@ghost/shared/src/components/mystery/case-file-header"
-import { NarrativeSection } from "@ghost/shared/src/components/mystery/narrative-section"
-import { DiscrepancySection } from "@ghost/shared/src/components/mystery/discrepancy-section"
-import { HypothesisSection } from "@ghost/shared/src/components/mystery/hypothesis-section"
-import { HistoricalContextSection } from "@ghost/shared/src/components/mystery/historical-context-section"
-import { DetailSidebar } from "@ghost/shared/src/components/mystery/detail-sidebar"
-import { TableOfContents } from "@ghost/shared/src/components/table-of-contents"
-import { SECTION_IDS, type TocSection } from "@ghost/shared/src/lib/toc-config"
-import { extractHeadings } from "@ghost/shared/src/lib/markdown-headings"
-import { stripLeadingH1 } from "@ghost/shared/src/lib/utils"
+import { MysteryArticle } from "@ghost/shared/src/components/mystery/mystery-article"
+import type { MysteryArticleLabels } from "@ghost/shared/src/components/mystery/mystery-article"
 import { localizeMystery, getTranslatedExcerpt } from "@ghost/shared/src/lib/localize"
 import { LanguageSelector } from "@/components/language-selector"
 import { useLanguage } from "@/contexts/language-context"
 import type { FirestoreMystery } from "@ghost/shared/src/types/mystery"
-import { ArrowLeft, FileText, Eye } from "lucide-react"
+import { ArrowLeft, Eye } from "lucide-react"
 
 // 管理画面は日本語固定のため、公開サイト ja 辞書に準拠したハードコード定数を使用
-const PREVIEW_LABELS = {
+const ADMIN_LABELS: MysteryArticleLabels = {
+  publishedLabel: "公開日：",
+  storytellerBylineLabel: "語り部:",
   confidence: { confirmedGhost: "確認済みゴースト", suspectedGhost: "疑わしいゴースト", archivalEcho: "アーカイブの残響" },
-  classification: { HIS: "歴史", FLK: "民俗", ANT: "人類学", OCC: "怪奇", URB: "都市伝説", CRM: "未解決事件", REL: "信仰・禁忌", LOC: "地霊・場所" } as Record<string, string>,
+  classification: { HIS: "歴史", FLK: "民俗", ANT: "人類学", OCC: "怪奇", URB: "都市伝説", CRM: "未解決事件", REL: "信仰・禁忌", LOC: "地霊・場所" },
+  tableOfContents: "目次",
+  tocNarrative: "本文",
+  tocDiscrepancy: "発見された矛盾",
+  tocEvidence: "アーカイブ証拠",
+  tocHypothesis: "仮説",
+  tocHistoricalContext: "歴史的背景",
+  archivalData: "アーカイブデータ",
+  discoveredDiscrepancy: "発見された矛盾",
+  archivalEvidence: "アーカイブ証拠",
+  primarySource: "主要資料",
+  contrastingSource: "対比資料",
+  additionalEvidence: "追加証拠",
+  evidence: { source: "出典", view: "閲覧", originalText: "原文" },
+  hypothesis: "仮説",
+  alternativeHypotheses: "代替仮説：",
+  historicalContext: "歴史的背景",
+  relatedEvents: "関連する出来事：",
+  keyFigures: "主要人物：",
+  storyAngles: "物語の視点",
+  classificationNotice: "このケースファイルはAIによるアーカイブ記録の分析です。すべてのソースを独自に検証してください。",
   sourceCoverage: { heading: "Ghost 評価" },
-}
-
-/**
- * Date は Server→Client シリアライズで string になるため、
- * toLocaleDateString を安全に呼ぶヘルパー
- */
-function formatDate(d: Date | string | undefined): string {
-  if (!d) return ""
-  const date = typeof d === "string" ? new Date(d) : d
-  return date.toLocaleDateString()
 }
 
 interface PreviewContentProps {
@@ -48,30 +51,14 @@ export function PreviewContent({ mystery }: PreviewContentProps) {
   // *_ja レガシーフィールドの有無
   const hasLegacyJa = !!(mystery.title_ja || mystery.narrative_content_ja)
 
-  const {
-    title, summary, narrativeContent, discrepancyDetected,
-    hypothesis, alternativeHypotheses, politicalClimate, storyHooks,
-    confidenceRationale,
-  } = localizeMystery(mystery, lang)
+  const localized = localizeMystery(mystery, lang)
 
   // 証拠の翻訳済み抜粋テキスト
-  const evidenceAExcerpt = getTranslatedExcerpt(mystery, "a", lang)
-  const evidenceBExcerpt = getTranslatedExcerpt(mystery, "b", lang)
-
-  const location = mystery.historical_context?.geographic_scope?.join(", ") || ""
-  const timePeriod = mystery.historical_context?.time_period || ""
-
-  // 本文見出しから TOC セクションを動的構築
-  const narrativeHeadings = extractHeadings(stripLeadingH1(narrativeContent || ""))
-  const tocSections: TocSection[] = [
-    ...(narrativeHeadings.length > 0
-      ? narrativeHeadings.map(h => ({ id: h.id, label: h.text }))
-      : [{ id: SECTION_IDS.narrative, label: "本文" }]),
-    ...(discrepancyDetected ? [{ id: SECTION_IDS.discrepancy, label: "発見された矛盾" }] : []),
-    { id: SECTION_IDS.evidence, label: "アーカイブ証拠" },
-    ...(hypothesis ? [{ id: SECTION_IDS.hypothesis, label: "仮説" }] : []),
-    ...(mystery.historical_context ? [{ id: SECTION_IDS.historicalContext, label: "歴史的背景" }] : []),
-  ]
+  const translatedExcerpts = {
+    a: getTranslatedExcerpt(mystery, "a", lang),
+    b: getTranslatedExcerpt(mystery, "b", lang),
+    additional: mystery.additional_evidence.map((_, i) => getTranslatedExcerpt(mystery, i, lang)),
+  }
 
   // publishedAt を安全に Date に変換
   const publishedAt = mystery.publishedAt
@@ -79,6 +66,28 @@ export function PreviewContent({ mystery }: PreviewContentProps) {
     : mystery.createdAt
       ? (typeof mystery.createdAt === "string" ? new Date(mystery.createdAt) : mystery.createdAt)
       : undefined
+
+  // 管理画面固有: 未公開記事は「作成日」ラベルを使用
+  const labelsWithDate = mystery.publishedAt
+    ? ADMIN_LABELS
+    : { ...ADMIN_LABELS, publishedLabel: "作成日：" }
+
+  // ヒーロー画像（admin 固有: next/image + unoptimized for localhost）
+  const heroImage = mystery.images?.hero ? (
+    <figure className="mx-auto max-w-2xl">
+      <div className="aged-card letterpress-border rounded-sm overflow-hidden">
+        <Image
+          src={mystery.images.hero}
+          alt={localized.title}
+          width={1200}
+          height={675}
+          className="w-full h-auto"
+          priority
+          unoptimized={mystery.images.hero.includes('localhost')}
+        />
+      </div>
+    </figure>
+  ) : undefined
 
   return (
     <>
@@ -115,117 +124,15 @@ export function PreviewContent({ mystery }: PreviewContentProps) {
             Return to Dashboard
           </Link>
 
-          <CaseFileHeader
-            mysteryId={mystery.mystery_id}
-            title={title}
-            location={location}
-            timePeriod={timePeriod}
+          <MysteryArticle
+            mystery={mystery}
+            localized={localized}
+            lang={lang}
+            labels={labelsWithDate}
+            translatedExcerpts={translatedExcerpts}
+            heroImage={heroImage}
             publishedAt={publishedAt}
-            publishedLabel={mystery.publishedAt ? "公開日：" : "作成日："}
-            confidenceLevel={mystery.confidence_level}
-            confidenceLabels={PREVIEW_LABELS.confidence}
-            classificationLabels={PREVIEW_LABELS.classification}
-            storyteller={mystery.storyteller}
-            storytellerBylineLabel="語り部:"
           />
-
-          {/* モバイル目次 */}
-          <TableOfContents sections={tocSections} heading="目次" variant="mobile" />
-
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 lg:gap-12">
-            {/* Main content */}
-            <div className="lg:col-span-2 space-y-12">
-              {/* Hero image */}
-              {mystery.images?.hero && (
-                <figure className="mx-auto max-w-2xl">
-                  <div className="aged-card letterpress-border rounded-sm overflow-hidden">
-                    <Image
-                      src={mystery.images.hero}
-                      alt={title}
-                      width={1200}
-                      height={675}
-                      className="w-full h-auto"
-                      priority
-                      unoptimized={mystery.images.hero.includes('localhost')}
-                    />
-                  </div>
-                </figure>
-              )}
-
-              <NarrativeSection narrativeContent={narrativeContent} summary={summary} lang={lang} />
-
-              {/* Divider between narrative and archival data */}
-              <div className="flex items-center gap-4">
-                <div className="h-px flex-1 bg-border" />
-                <span className="text-xs font-mono uppercase tracking-wider text-muted-foreground">アーカイブデータ</span>
-                <div className="h-px flex-1 bg-border" />
-              </div>
-
-              {discrepancyDetected && (
-                <DiscrepancySection discrepancyDetected={discrepancyDetected} label="発見された矛盾" />
-              )}
-
-              {/* Evidence */}
-              <section id="section-evidence" className="scroll-mt-24">
-                <div className="flex items-center gap-3 mb-6">
-                  <FileText className="w-5 h-5 text-gold" />
-                  <h2 className="font-serif text-xl text-parchment">アーカイブ証拠</h2>
-                </div>
-                <div className="space-y-8">
-                  <EvidenceBlock
-                    evidence={mystery.evidence_a}
-                    label="主要資料"
-                    translatedExcerpt={evidenceAExcerpt}
-                    labels={{ source: "出典", view: "閲覧", originalText: "原文" }}
-                  />
-                  <EvidenceBlock
-                    evidence={mystery.evidence_b}
-                    label="対比資料"
-                    translatedExcerpt={evidenceBExcerpt}
-                    labels={{ source: "出典", view: "閲覧", originalText: "原文" }}
-                  />
-                  {mystery.additional_evidence.map((ev, i) => (
-                    <EvidenceBlock
-                      key={i}
-                      evidence={ev}
-                      label={`追加証拠 ${i + 1}`}
-                      translatedExcerpt={getTranslatedExcerpt(mystery, i, lang)}
-                      labels={{ source: "出典", view: "閲覧", originalText: "原文" }}
-                    />
-                  ))}
-                </div>
-              </section>
-
-              {hypothesis && (
-                <HypothesisSection
-                  hypothesis={hypothesis}
-                  alternativeHypotheses={alternativeHypotheses}
-                  labels={{ hypothesis: "仮説", alternativeHypotheses: "代替仮説：" }}
-                />
-              )}
-
-              {mystery.historical_context && (
-                <HistoricalContextSection
-                  historicalContext={mystery.historical_context}
-                  politicalClimate={politicalClimate}
-                  labels={{ historicalContext: "歴史的背景", relatedEvents: "関連する出来事：", keyFigures: "主要人物：" }}
-                />
-              )}
-            </div>
-
-            <DetailSidebar
-              storyHooks={storyHooks}
-              confidenceRationale={confidenceRationale}
-              sourceCoverageLabels={PREVIEW_LABELS.sourceCoverage}
-              labels={{
-                storyAngles: "物語の視点",
-                classificationNotice: "このケースファイルはAIによるアーカイブ記録の分析です。すべてのソースを独自に検証してください。",
-              }}
-            >
-              {/* デスクトップ目次 */}
-              <TableOfContents sections={tocSections} heading="目次" variant="desktop" />
-            </DetailSidebar>
-          </div>
         </div>
       </div>
     </>

--- a/web-public/src/app/[lang]/mystery/[id]/page.tsx
+++ b/web-public/src/app/[lang]/mystery/[id]/page.tsx
@@ -2,21 +2,14 @@ import { notFound } from "next/navigation"
 import { ResponsiveHeroImage } from "@/components/responsive-hero-image"
 import { Header } from "@/components/header"
 import { PublicFooter } from "@/components/public-footer"
-import { EvidenceBlock } from "@ghost/shared/src/components/evidence-block"
-import { CaseFileHeader } from "@/components/mystery/case-file-header"
-import { NarrativeSection } from "@/components/mystery/narrative-section"
-import { DiscrepancySection } from "@/components/mystery/discrepancy-section"
-import { HypothesisSection } from "@/components/mystery/hypothesis-section"
-import { HistoricalContextSection } from "@/components/mystery/historical-context-section"
-import { DetailSidebar } from "@/components/mystery/detail-sidebar"
+import { MysteryArticle } from "@/components/mystery/mystery-article"
+import type { MysteryArticleLabels } from "@ghost/shared/src/components/mystery/mystery-article"
 import { Breadcrumb } from "@/components/breadcrumb"
-import { TableOfContents } from "@/components/table-of-contents"
-import { SECTION_IDS } from "@/lib/toc-config"
 import { RelatedArticles } from "@/components/related-articles"
 import { ShareButtons } from "@/components/share-buttons"
 import { ArticleJsonLd } from "@/components/article-json-ld"
 import { getMysteryById, getPublishedMysteryIds, getAllPublishedMysteriesMap } from "@ghost/shared/src/lib/firestore/queries"
-import { FileText, Share2 } from "lucide-react"
+import { Share2 } from "lucide-react"
 import { localizeMystery, getTranslatedExcerpt } from "@ghost/shared/src/lib/localize"
 import { SUPPORTED_LANGS, isValidLang } from "@/lib/i18n/config"
 import type { SupportedLang } from "@/lib/i18n/config"
@@ -24,9 +17,6 @@ import { getDictionary } from "@/lib/i18n/dictionaries"
 import { findRelatedArticles } from "@/lib/related-articles"
 import { getSiteUrl } from "@/lib/site-url"
 import { buildOgpMetadata, buildAlternates } from "@/lib/seo"
-import { extractHeadings } from "@/lib/markdown-headings"
-import { stripLeadingH1 } from "@ghost/shared/src/lib/utils"
-import type { TocSection } from "@/lib/toc-config"
 
 export async function generateStaticParams() {
   let ids: string[]
@@ -83,6 +73,39 @@ export async function generateMetadata({
   }
 }
 
+/**
+ * i18n 辞書から MysteryArticleLabels を構築するヘルパー
+ */
+function buildLabels(dict: Awaited<ReturnType<typeof getDictionary>>): MysteryArticleLabels {
+  return {
+    publishedLabel: dict.detail.published,
+    storytellerBylineLabel: dict.detail.storytoldBy,
+    confidence: dict.confidence,
+    classification: dict.classification,
+    tableOfContents: dict.detail.tableOfContents,
+    tocNarrative: dict.detail.tocNarrative,
+    tocDiscrepancy: dict.detail.tocDiscrepancy,
+    tocEvidence: dict.detail.tocEvidence,
+    tocHypothesis: dict.detail.tocHypothesis,
+    tocHistoricalContext: dict.detail.tocHistoricalContext,
+    archivalData: dict.detail.archivalData,
+    discoveredDiscrepancy: dict.detail.discoveredDiscrepancy,
+    archivalEvidence: dict.detail.archivalEvidence,
+    primarySource: dict.detail.primarySource,
+    contrastingSource: dict.detail.contrastingSource,
+    additionalEvidence: dict.detail.additionalEvidence,
+    evidence: dict.evidence,
+    hypothesis: dict.detail.hypothesis,
+    alternativeHypotheses: dict.detail.alternativeHypotheses,
+    historicalContext: dict.detail.historicalContext,
+    relatedEvents: dict.detail.relatedEvents,
+    keyFigures: dict.detail.keyFigures,
+    storyAngles: dict.detail.storyAngles,
+    classificationNotice: dict.detail.classificationNotice,
+    sourceCoverage: dict.sourceCoverage,
+  }
+}
+
 export default async function MysteryDetailPage({
   params,
 }: {
@@ -100,33 +123,14 @@ export default async function MysteryDetailPage({
   }
 
   const dict = await getDictionary(lang)
-
-  const {
-    title, summary, narrativeContent, discrepancyDetected,
-    hypothesis, alternativeHypotheses, politicalClimate, storyHooks,
-    confidenceRationale,
-  } = localizeMystery(mystery, lang)
-
-  const location = mystery.historical_context?.geographic_scope?.join(", ") || ""
-  const timePeriod = mystery.historical_context?.time_period || ""
+  const localized = localizeMystery(mystery, lang)
 
   // 証拠の翻訳済み抜粋テキスト
-  const evidenceAExcerpt = getTranslatedExcerpt(mystery, "a", lang)
-  const evidenceBExcerpt = getTranslatedExcerpt(mystery, "b", lang)
-
-  // 本文見出しから TOC セクションを動的構築
-  const narrativeHeadings = extractHeadings(stripLeadingH1(narrativeContent || ""))
-  const tocSections: TocSection[] = [
-    // 見出しが抽出できた場合は記事固有の見出しを使用、なければ固定ラベル
-    ...(narrativeHeadings.length > 0
-      ? narrativeHeadings.map(h => ({ id: h.id, label: h.text }))
-      : [{ id: SECTION_IDS.narrative, label: dict.detail.tocNarrative }]),
-    // 固定セクション（条件付き）
-    ...(discrepancyDetected ? [{ id: SECTION_IDS.discrepancy, label: dict.detail.tocDiscrepancy }] : []),
-    { id: SECTION_IDS.evidence, label: dict.detail.tocEvidence },
-    ...(hypothesis ? [{ id: SECTION_IDS.hypothesis, label: dict.detail.tocHypothesis }] : []),
-    ...(mystery.historical_context ? [{ id: SECTION_IDS.historicalContext, label: dict.detail.tocHistoricalContext }] : []),
-  ]
+  const translatedExcerpts = {
+    a: getTranslatedExcerpt(mystery, "a", lang),
+    b: getTranslatedExcerpt(mystery, "b", lang),
+    additional: mystery.additional_evidence.map((_, i) => getTranslatedExcerpt(mystery, i, lang)),
+  }
 
   // シェアボタン用の URL
   const shareUrl = `${getSiteUrl()}/${lang}/mystery/${id}/`
@@ -135,6 +139,41 @@ export default async function MysteryDetailPage({
   const relatedArticles = findRelatedArticles(
     mystery,
     Array.from(mysteriesMap.values())
+  )
+
+  // ヒーロー画像（公開ページ固有: ResponsiveHeroImage）
+  const heroImage = mystery.images?.hero ? (
+    <figure className="mx-auto max-w-2xl">
+      <div className="aged-card letterpress-border rounded-sm overflow-hidden">
+        <ResponsiveHeroImage
+          hero={mystery.images.hero}
+          variants={mystery.images.variants}
+          alt={localized.title}
+          priority
+          className="w-full h-auto"
+        />
+      </div>
+    </figure>
+  ) : undefined
+
+  // compact シェアボタン（CaseFileHeader 直後）
+  const afterHeader = (
+    <div className="flex items-center gap-4 mb-8">
+      <div className="h-px flex-1 bg-border" />
+      <ShareButtons url={shareUrl} title={localized.title} variant="compact" labels={dict.share} />
+      <div className="h-px flex-1 bg-border" />
+    </div>
+  )
+
+  // full シェアボタン（メインカラム末尾）
+  const mainColumnFooter = (
+    <section className="pt-4">
+      <div className="flex items-center gap-3 mb-6">
+        <Share2 className="w-5 h-5 text-gold" />
+        <h2 className="font-serif text-xl text-parchment">{dict.share.shareThisArticle}</h2>
+      </div>
+      <ShareButtons url={shareUrl} title={localized.title} variant="full" labels={dict.share} />
+    </section>
   )
 
   return (
@@ -146,7 +185,7 @@ export default async function MysteryDetailPage({
           {/* パンくずリスト */}
           <Breadcrumb
             lang={lang}
-            title={title}
+            title={localized.title}
             labels={{
               home: dict.detail.breadcrumbHome,
               archive: dict.nav.archive,
@@ -155,8 +194,8 @@ export default async function MysteryDetailPage({
 
           {/* Article 構造化データ */}
           <ArticleJsonLd
-            title={title}
-            description={summary}
+            title={localized.title}
+            description={localized.summary}
             url={shareUrl}
             datePublished={mystery.publishedAt?.toISOString()}
             dateModified={mystery.updatedAt?.toISOString()}
@@ -164,141 +203,17 @@ export default async function MysteryDetailPage({
             lang={lang}
           />
 
-          <CaseFileHeader
-            mysteryId={mystery.mystery_id}
-            title={title}
-            location={location}
-            timePeriod={timePeriod}
+          <MysteryArticle
+            mystery={mystery}
+            localized={localized}
+            lang={lang}
+            labels={buildLabels(dict)}
+            translatedExcerpts={translatedExcerpts}
+            heroImage={heroImage}
             publishedAt={mystery.publishedAt}
-            publishedLabel={dict.detail.published}
-            confidenceLevel={mystery.confidence_level}
-            confidenceLabels={dict.confidence}
-            classificationLabels={dict.classification}
-            storyteller={mystery.storyteller}
-            storytellerBylineLabel={dict.detail.storytoldBy}
+            afterHeader={afterHeader}
+            mainColumnFooter={mainColumnFooter}
           />
-
-          {/* シェアボタン（compact） */}
-          <div className="flex items-center gap-4 mb-8">
-            <div className="h-px flex-1 bg-border" />
-            <ShareButtons url={shareUrl} title={title} variant="compact" labels={dict.share} />
-            <div className="h-px flex-1 bg-border" />
-          </div>
-
-          {/* モバイル目次（Grid の前） */}
-          <TableOfContents sections={tocSections} heading={dict.detail.tableOfContents} variant="mobile" />
-
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 lg:gap-12">
-            {/* Main content */}
-            <div className="lg:col-span-2 space-y-12">
-              {/* Hero image — 学術書の図版のようなフレーミング */}
-              {mystery.images?.hero && (
-                <figure className="mx-auto max-w-2xl">
-                  <div className="aged-card letterpress-border rounded-sm overflow-hidden">
-                    <ResponsiveHeroImage
-                      hero={mystery.images.hero}
-                      variants={mystery.images.variants}
-                      alt={title}
-                      priority
-                      className="w-full h-auto"
-                    />
-                  </div>
-                </figure>
-              )}
-
-              <NarrativeSection narrativeContent={narrativeContent} summary={summary} lang={lang} />
-
-              {/* Divider between narrative and archival data */}
-              <div className="flex items-center gap-4">
-                <div className="h-px flex-1 bg-border" />
-                <span className="text-xs font-mono uppercase tracking-wider text-muted-foreground">{dict.detail.archivalData}</span>
-                <div className="h-px flex-1 bg-border" />
-              </div>
-
-              {discrepancyDetected && (
-                <DiscrepancySection
-                  discrepancyDetected={discrepancyDetected}
-                  label={dict.detail.discoveredDiscrepancy}
-                />
-              )}
-
-              {/* Evidence */}
-              <section id="section-evidence" className="scroll-mt-24">
-                <div className="flex items-center gap-3 mb-6">
-                  <FileText className="w-5 h-5 text-gold" />
-                  <h2 className="font-serif text-xl text-parchment">{dict.detail.archivalEvidence}</h2>
-                </div>
-                <div className="space-y-8">
-                  <EvidenceBlock
-                    evidence={mystery.evidence_a}
-                    label={dict.detail.primarySource}
-                    translatedExcerpt={evidenceAExcerpt}
-                    labels={dict.evidence}
-                  />
-                  <EvidenceBlock
-                    evidence={mystery.evidence_b}
-                    label={dict.detail.contrastingSource}
-                    translatedExcerpt={evidenceBExcerpt}
-                    labels={dict.evidence}
-                  />
-                  {mystery.additional_evidence.map((ev, i) => (
-                    <EvidenceBlock
-                      key={i}
-                      evidence={ev}
-                      label={`${dict.detail.additionalEvidence} ${i + 1}`}
-                      translatedExcerpt={getTranslatedExcerpt(mystery, i, lang)}
-                      labels={dict.evidence}
-                    />
-                  ))}
-                </div>
-              </section>
-
-              {hypothesis && (
-                <HypothesisSection
-                  hypothesis={hypothesis}
-                  alternativeHypotheses={alternativeHypotheses}
-                  labels={{
-                    hypothesis: dict.detail.hypothesis,
-                    alternativeHypotheses: dict.detail.alternativeHypotheses,
-                  }}
-                />
-              )}
-
-              {mystery.historical_context && (
-                <HistoricalContextSection
-                  historicalContext={mystery.historical_context}
-                  politicalClimate={politicalClimate}
-                  labels={{
-                    historicalContext: dict.detail.historicalContext,
-                    relatedEvents: dict.detail.relatedEvents,
-                    keyFigures: dict.detail.keyFigures,
-                  }}
-                />
-              )}
-
-              {/* シェアボタン（full） */}
-              <section className="pt-4">
-                <div className="flex items-center gap-3 mb-6">
-                  <Share2 className="w-5 h-5 text-gold" />
-                  <h2 className="font-serif text-xl text-parchment">{dict.share.shareThisArticle}</h2>
-                </div>
-                <ShareButtons url={shareUrl} title={title} variant="full" labels={dict.share} />
-              </section>
-            </div>
-
-            <DetailSidebar
-              storyHooks={storyHooks}
-              labels={{
-                storyAngles: dict.detail.storyAngles,
-                classificationNotice: dict.detail.classificationNotice,
-              }}
-              confidenceRationale={confidenceRationale}
-              sourceCoverageLabels={dict.sourceCoverage}
-            >
-              {/* デスクトップ目次（サイドバー内） */}
-              <TableOfContents sections={tocSections} heading={dict.detail.tableOfContents} variant="desktop" />
-            </DetailSidebar>
-          </div>
 
           {/* 関連記事 */}
           <RelatedArticles

--- a/web-public/src/components/mystery/mystery-article.tsx
+++ b/web-public/src/components/mystery/mystery-article.tsx
@@ -1,0 +1,1 @@
+export { MysteryArticle } from "@ghost/shared/src/components/mystery/mystery-article"


### PR DESCRIPTION
## Summary

- 管理画面プレビューと公開ページが独立に組み立てていた記事レイアウトを `@ghost/shared` の `MysteryArticle` コンポーネントに抽出
- `NarrativeSection` に `precomputedHeadingIds` prop を追加し、`extractHeadings` で1回だけ計算した見出し ID を DOM に渡すことで TOC スクロールスパイの ID 一致を保証
- `heroImage` / `afterHeader` / `mainColumnFooter` を ReactNode slot で受け取り、アプリ固有のコンポーネントを注入可能に

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `packages/shared/.../narrative-section.tsx` | `precomputedHeadingIds` optional prop 追加 |
| `packages/shared/.../mystery-article.tsx` | **新規** — 共有記事レンダラー |
| `web-admin/.../preview-content.tsx` | `MysteryArticle` 使用に置換 |
| `web-public/.../[id]/page.tsx` | `MysteryArticle` 使用に置換 |
| `web-public/.../mystery-article.tsx` | **新規** — 再エクスポートラッパー |

## Test plan

- [x] `tsc --noEmit` — shared / web-admin / web-public 全て型チェック通過
- [x] `pytest tests/unit/ -v` — 既存テスト 1149 件全通過
- [ ] 管理画面プレビューで本文見出しのスクロールスパイが正常に動作することを手動確認
- [ ] 公開ページのスクロールスパイ・レイアウトが引き続き正常であることを手動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)