### PR TITLE
fix: TOC と本文の見出し ID ずれを修正（markdown 処理の一元化）

### DIFF
--- a/packages/shared/src/components/mystery/mystery-article.tsx
+++ b/packages/shared/src/components/mystery/mystery-article.tsx
@@ -13,6 +13,7 @@ import { DetailSidebar } from "./detail-sidebar"
 import { TableOfContents } from "../table-of-contents"
 import { SECTION_IDS, type TocSection } from "../../lib/toc-config"
 import { extractHeadings } from "../../lib/markdown-headings"
+import { normalizeImagePlacement } from "../../lib/normalize-image-placement"
 import { stripLeadingH1 } from "../../lib/utils"
 import type { FirestoreMystery } from "../../types/mystery"
 import type { LocalizedMystery } from "../../lib/localize"
@@ -87,8 +88,11 @@ export function MysteryArticle({
   const location = mystery.historical_context?.geographic_scope?.join(", ") || ""
   const timePeriod = mystery.historical_context?.time_period || ""
 
-  // 本文見出しから TOC セクションを動的構築（1回だけ計算）
-  const narrativeHeadings = extractHeadings(stripLeadingH1(narrativeContent || ""))
+  // markdown 処理を1回だけ行い、TOC と NarrativeSection の両方に同じ文字列を渡す
+  const processedNarrative = normalizeImagePlacement(
+    stripLeadingH1(narrativeContent || "").replace(/\*\*(.+?)\*\*/g, ' **$1** ')
+  )
+  const narrativeHeadings = extractHeadings(processedNarrative)
   const precomputedHeadingIds = narrativeHeadings.map(h => h.id)
 
   const tocSections: TocSection[] = [
@@ -129,7 +133,7 @@ export function MysteryArticle({
           {heroImage}
 
           <NarrativeSection
-            narrativeContent={narrativeContent}
+            narrativeContent={processedNarrative}
             summary={summary}
             lang={lang}
             precomputedHeadingIds={precomputedHeadingIds}

--- a/packages/shared/src/components/mystery/narrative-section.tsx
+++ b/packages/shared/src/components/mystery/narrative-section.tsx
@@ -1,9 +1,7 @@
 import Markdown, { type Components } from "react-markdown"
 import remarkGfm from "remark-gfm"
 import { rehypeUnwrapImages } from "../../lib/rehype-unwrap-images"
-import { normalizeImagePlacement } from "../../lib/normalize-image-placement"
 import { FileText } from "lucide-react"
-import { stripLeadingH1 } from "../../lib/utils"
 import { slugify } from "../../lib/markdown-headings"
 import type { ReactNode } from "react"
 import { ArchiveImage } from "./archive-image"
@@ -86,7 +84,7 @@ export function NarrativeSection({ narrativeContent, summary, lang = "en", preco
     return (
       <section id="section-narrative" className="scroll-mt-24 prose prose-lg prose-invert max-w-none prose-headings:font-serif prose-headings:text-parchment prose-headings:mt-12 prose-headings:mb-4 prose-p:text-foreground/90 prose-p:leading-loose prose-p:mb-6 prose-a:text-gold prose-strong:text-parchment prose-hr:border-border">
         <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeUnwrapImages]} components={markdownComponents}>
-          {normalizeImagePlacement(stripLeadingH1(narrativeContent).replace(/\*\*(.+?)\*\*/g, ' **$1** '))}
+          {narrativeContent}
         </Markdown>
       </section>
     )


### PR DESCRIPTION
## Summary

- TOC 生成（`extractHeadings`）と本文レンダリング（`react-markdown`）で異なる markdown 前処理パイプラインを使用していたため、検出される見出し数が一致せず、TOC リンクが誤った見出しを指していた
- `mystery-article.tsx` で markdown 処理（`stripLeadingH1` + `normalizeImagePlacement` + bold_regex）を1回だけ実行し、処理済み文字列を TOC と `NarrativeSection` の両方に渡すように修正
- `narrative-section.tsx` 内の重複 markdown 処理と不要な import を削除

## Test plan

- [ ] 管理画面プレビューで DevTools を開き、`<h2 id="...">` の id とテキストが一致していることを確認
- [ ] TOC クリック → 正しい見出しにスクロールすることを確認
- [ ] web-public のビルドが正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)