### PR TITLE
fix: Docker ビルド時の pip タイムアウトを解消

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Copy requirements and install Python dependencies
 COPY pyproject.toml ./
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir --default-timeout=300 -r requirements.txt
 
 # rembg U2-NET モデルをプリダウンロード（初回実行時の待ちを回避）
 RUN python -c "from rembg import new_session; new_session('u2netp')"


### PR DESCRIPTION
## Summary

- Dockerfile の `pip install` に `--default-timeout=300` を追加
- rembg 追加（PR #363）で依存パッケージが増え、litellm (14.6MB) 等がデフォルト15秒でタイムアウトしていた

## Test plan
- [x] ローカル `docker compose build` が成功することを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)