### PR TITLE
fix: パイプラインタイムアウト延長 + Polymath max_output_tokens 安全弁削減

### DIFF
--- a/mystery_agents/agents/armchair_polymath.py
+++ b/mystery_agents/agents/armchair_polymath.py
@@ -542,8 +542,8 @@ POLYMATH_TOOLS = [
     count_words,
 ]
 
-# 5,000〜10,000語のレポートを1ターンで出力するための max_output_tokens
-POLYMATH_MAX_OUTPUT_TOKENS = 65536
+# モデル暴走時の安全弁（通常は EOS で自然停止するため速度に影響なし）
+POLYMATH_MAX_OUTPUT_TOKENS = 32768
 
 # ツール呼び出しカウンター用ステートキー
 _TOOL_CALL_COUNT_KEY = "polymath_tool_call_count"

--- a/mystery_agents/cli.py
+++ b/mystery_agents/cli.py
@@ -20,7 +20,7 @@ from shared.orchestrator import run_pipeline
 # プロジェクト全体のログを有効化（Cloud Run: JSON / ローカル: プレーンテキスト）
 setup_logging()
 
-PIPELINE_TIMEOUT_SECONDS = 1800  # 30 minutes
+PIPELINE_TIMEOUT_SECONDS = 2400  # 40 minutes
 
 
 async def investigate(query: str, *, run_id: str | None = None) -> str | None:

--- a/shared/orchestrator.py
+++ b/shared/orchestrator.py
@@ -230,7 +230,7 @@ async def run_pipeline(
     *,
     run_id: str | None = None,
     run_type: str = "blog",
-    timeout_seconds: int = 1800,
+    timeout_seconds: int = 2400,
     max_llm_calls: int = 120,
     skip_authors: set[str] | None = None,
     sequential_agents: set[str] | None = None,

--- a/tests/unit/test_polymath_callback.py
+++ b/tests/unit/test_polymath_callback.py
@@ -71,5 +71,5 @@ class TestPolymathMaxOutputTokens:
     """POLYMATH_MAX_OUTPUT_TOKENS 定数のテスト。"""
 
     def test_max_output_tokens_value(self):
-        """65536 であること。"""
-        assert POLYMATH_MAX_OUTPUT_TOKENS == 65536
+        """32768 であること（モデル暴走時の安全弁）。"""
+        assert POLYMATH_MAX_OUTPUT_TOKENS == 32768


### PR DESCRIPTION
## Summary

ローカル実行でブログパイプラインが 1800s（30分）タイムアウトする問題を修正。

- **パイプラインタイムアウト延長**: 1800s → 2400s（40分）。全エージェント累計で最悪 45 分かかるケースに対応
- **Polymath max_output_tokens 削減**: 65536 → 32768。通常速度に影響なし（EOS で自然停止）。モデル暴走時の安全弁として被害を半減

## 変更内容

| ファイル | 変更 |
|----------|------|
| `mystery_agents/cli.py` | `PIPELINE_TIMEOUT_SECONDS` 1800 → 2400 |
| `shared/orchestrator.py` | デフォルト引数 `timeout_seconds` 1800 → 2400 |
| `mystery_agents/agents/armchair_polymath.py` | `POLYMATH_MAX_OUTPUT_TOKENS` 65536 → 32768 |
| `tests/unit/test_polymath_callback.py` | アサーション値を追従 |

## Test plan

- [x] `pytest tests/unit/test_polymath_callback.py` — 5 passed
- [x] `pytest tests/unit/test_orchestrator.py` — 42 passed
- [ ] ローカルパイプライン実行でタイムアウトせず完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)