### PR TITLE
fix: mysteries.ts の静的 import チェーン完全排除（Docker ビルドエラー修正）

### DIFF
--- a/web-admin/src/lib/firestore/mysteries.ts
+++ b/web-admin/src/lib/firestore/mysteries.ts
@@ -1,21 +1,35 @@
 /**
  * Mysteries Firestore 操作（管理者用）
  * 書き込み操作と管理者固有の読み取りクエリのみ
- * 共通の読み取りクエリは @ghost/shared から import
+ * 共通の読み取りクエリは @ghost/shared から動的ラッパー経由で提供
  *
- * NOTE: firebase/firestore と @ghost/shared/src/lib/firebase/config は
- * 動的 import を使用する。静的 import にすると Docker ビルド時（環境変数なし）に
- * Firebase 初期化が失敗してプリレンダリングエラーになる。
+ * NOTE: @ghost/shared/src/lib/firestore/queries は firebase/firestore と
+ * firebase/config を静的 import しているため、re-export すると Docker ビルド時
+ * （環境変数なし）に Firebase 初期化が失敗してプリレンダリングエラーになる。
+ * すべて動的 import で取得すること。
  */
 
 import type {
   FirestoreMystery,
   MysteryStatus,
 } from "@ghost/shared/src/types/mystery";
-import { docToMystery } from "@ghost/shared/src/lib/firestore/queries";
 
-// 共通の読み取りクエリを re-export
-export { getPublishedMysteries, getMysteryById, getPublishedMysteryIds, toCardData } from "@ghost/shared/src/lib/firestore/queries";
+// ============================================
+// 共通クエリの動的ラッパー
+// （queries.ts の静的 Firebase import を回避するため）
+// ============================================
+
+/**
+ * 単一ミステリーをIDで取得（@ghost/shared の動的ラッパー）
+ */
+export async function getMysteryById(
+  mysteryId: string
+): Promise<FirestoreMystery | null> {
+  const { getMysteryById: fn } = await import(
+    "@ghost/shared/src/lib/firestore/queries"
+  );
+  return fn(mysteryId);
+}
 
 // ============================================
 // 管理者固有のクエリ
@@ -30,6 +44,7 @@ export async function getPendingMysteries(
 ): Promise<FirestoreMystery[]> {
   const { collection, getDocs, query, where, orderBy, limit } = await import("firebase/firestore");
   const { getFirestoreDb, COLLECTIONS } = await import("@ghost/shared/src/lib/firebase/config");
+  const { docToMystery } = await import("@ghost/shared/src/lib/firestore/queries");
 
   const db = getFirestoreDb();
   const mysteriesRef = collection(db, COLLECTIONS.MYSTERIES);
@@ -53,6 +68,7 @@ export async function getAllMysteries(
 ): Promise<FirestoreMystery[]> {
   const { collection, getDocs, query, orderBy, limit } = await import("firebase/firestore");
   const { getFirestoreDb, COLLECTIONS } = await import("@ghost/shared/src/lib/firebase/config");
+  const { docToMystery } = await import("@ghost/shared/src/lib/firestore/queries");
 
   const db = getFirestoreDb();
   const mysteriesRef = collection(db, COLLECTIONS.MYSTERIES);


### PR DESCRIPTION
## Summary

- `mysteries.ts` が `queries.ts` を静的 import/re-export → `config.ts` → Firebase 初期化 → 環境変数なしで throw、という静的チェーンが Docker ビルド時のプリレンダリングエラーの根本原因
- `docToMystery` の静的 import → 各関数内の動的 import に変更
- 未使用の re-export（`getPublishedMysteries`, `getPublishedMysteryIds`, `toCardData`）を削除
- `getMysteryById` を動的 import ラッパー関数に変更

## 根本原因

```
designs/page.tsx
  → import { getAllMysteries } from mysteries.ts
    → import { docToMystery } from queries.ts   ← 静的 import（値）
    → export { ... } from queries.ts             ← 静的 re-export
      → queries.ts: import { getFirestoreDb } from config.ts   ← 静的 import
        → config.ts: throw when NEXT_PUBLIC_FIREBASE_PROJECT_ID is unset
```

PR #365 で関数内の import を動的化済みだったが、`docToMystery` のインポートと re-export 行が残っており、ビルド時にモジュール評価チェーンが発動していた。

## Test plan

- [ ] CI docker-build ジョブが `/designs` プリレンダリングエラーなしで通ること
- [ ] `web-admin` のローカル開発で記事一覧・プレビュー・Podcast ページが正常動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)