### PR TITLE
feat: Scholar 2層アーキテクチャ + 動的言語サポート（Named + Multilingual）

### DIFF
--- a/mystery_agents/agents/aggregator.py
+++ b/mystery_agents/agents/aggregator.py
@@ -1,11 +1,10 @@
 """AggregatorAgent — API Librarian の検索結果を言語別に集約する。
 
-LLM を介さず、セッション状態の raw_search_results から
-ドキュメントを言語別にグループ化し、collected_documents_{lang} に
-Scholar が読める形式でテキストを書き込む。
+LLM を介さず、セッション状態の raw_search_results* キーを動的スキャンし、
+ドキュメントを言語別にグループ化して collected_documents_{lang} に書き込む。
 
 また active_languages（ドキュメント数ランキング）をステートに書き込み、
-後段の DynamicScholarBlock（PR 3）が参照する。
+後段の DynamicScholarBlock が参照する。
 """
 
 import logging
@@ -17,27 +16,15 @@ from google.adk.agents.invocation_context import InvocationContext
 from google.adk.events.event import Event, EventActions
 from google.genai import types
 
+from shared.language_names import get_language_name
+
 logger = logging.getLogger(__name__)
-
-# 言語名マッピング（ログ・ヘッダー表示用）
-_LANGUAGE_NAMES: dict[str, str] = {
-    "en": "English",
-    "de": "German",
-    "es": "Spanish",
-    "fr": "French",
-    "ja": "Japanese",
-    "nl": "Dutch",
-    "pt": "Portuguese",
-}
-
-# 収集対象の raw_search_results キーサフィックス
-_KNOWN_LANGUAGES = ["en", "de", "es", "fr", "ja", "nl", "pt"]
 
 
 class AggregatorAgent(BaseAgent):
     """API Librarian 出力を言語別に集約する LLM 不使用エージェント。
 
-    raw_search_results* からドキュメントを抽出し、
+    raw_search_results* キーを動的スキャンし、
     各ドキュメントの language フィールドに基づいて言語別にグループ化する。
     """
 
@@ -46,14 +33,12 @@ class AggregatorAgent(BaseAgent):
     ) -> AsyncGenerator[Event, None]:
         state = ctx.session.state
 
-        # 全 raw_search_results を収集（既知キーパターンを安全にチェック）
+        # raw_search_results* キーを動的スキャン
         docs_by_lang: dict[str, list[dict]] = defaultdict(list)
 
-        keys_to_check = ["raw_search_results"] + [
-            f"raw_search_results_{lang}" for lang in _KNOWN_LANGUAGES
-        ]
-
-        for key in keys_to_check:
+        for key in list(state.keys()):
+            if not key.startswith("raw_search_results"):
+                continue
             value = state.get(key)
             if not value or not isinstance(value, list):
                 continue
@@ -131,11 +116,11 @@ def _format_documents(lang: str, docs: list[dict]) -> str:
         elif not url:
             unique_docs.append(doc)
 
+    lang_name = get_language_name(lang)
+
     if not unique_docs:
-        lang_name = _LANGUAGE_NAMES.get(lang, lang)
         return f"NO_DOCUMENTS_FOUND: No {lang_name}-language documents collected."
 
-    lang_name = _LANGUAGE_NAMES.get(lang, lang)
     lines = [
         f"# Collected Documents ({lang_name}) — {len(unique_docs)} documents\n"
     ]
@@ -172,6 +157,7 @@ def create_aggregator() -> AggregatorAgent:
         name="aggregator",
         description=(
             "Aggregates search results from all API Librarians by document language. "
+            "Dynamically scans raw_search_results* keys. "
             "Writes collected_documents_{lang} for each language found. "
             "Deterministic execution without LLM."
         ),

--- a/mystery_agents/agents/api_librarians.py
+++ b/mystery_agents/agents/api_librarians.py
@@ -166,13 +166,18 @@ API_CONFIGS: dict[str, dict] = {
         ),
         "search_strategy": (
             "1. Analyze the theme and determine which European languages are relevant\n"
-            "2. Generate 3-5 keywords in the most relevant European language\n"
-            '3. Call **search_archives** with:\n'
+            "   (up to 3 languages)\n"
+            "2. For EACH relevant language, generate 3-5 keywords in that language\n"
+            '3. Call **search_archives** once per language with:\n'
             '   - `sources="europeana"`\n'
-            "   - `language` set to the most relevant language code\n"
-            "   - Example: keywords=\"Geisterschiff, Nordsee, Schiffbruch\", language=\"de\"\n"
-            "4. If the theme spans multiple European cultures, prioritize the language\n"
-            "   most likely to yield results for this specific topic\n"
+            "   - `language` set to the relevant language code\n"
+            "   - Example for a German theme:\n"
+            '     Call 1: keywords="Geisterschiff, Nordsee, Schiffbruch", language="de"\n'
+            "   - Example for a Franco-German border theme:\n"
+            '     Call 1: keywords="Geisterschiff, Rhein, Grenze", language="de"\n'
+            '     Call 2: keywords="vaisseau fantôme, Rhin, frontière", language="fr"\n'
+            "4. Always search in the primary language of the theme's region.\n"
+            "   Add additional languages when the theme spans borders or cultures.\n"
             "5. Date filtering is OPTIONAL — use only when the time period is clear"
         ),
         "has_newspapers": False,

--- a/mystery_agents/agents/dynamic_polymath_block.py
+++ b/mystery_agents/agents/dynamic_polymath_block.py
@@ -4,6 +4,8 @@
 非アクティブ言語の空プレースホルダーを排除する。
 DynamicScholarBlock と同じ BaseAgent パターン。
 
+Named Scholar + Multilingual Scholar の両方の分析結果を動的に参照。
+
 ゲート機能を内包: 全 Scholar 分析が空なら INSUFFICIENT_DATA を返す。
 """
 
@@ -25,27 +27,40 @@ from .armchair_polymath import (
     POLYMATH_TOOLS,
     log_polymath_tool_call,
 )
-from .language_scholars import SCHOLAR_CONFIGS
+from .language_scholars import get_scholar_config
 from .pipeline_gate import _is_meaningful, _log_and_record_failure
 
 logger = logging.getLogger(__name__)
 
 
-def _build_analyses_section(meaningful_langs: list[str]) -> str:
-    """アクティブ言語のみの Scholar Analyses セクションを構築する。"""
+def _build_analyses_section(meaningful_langs: list[str], has_multilingual: bool = False) -> str:
+    """アクティブ言語のみの Scholar Analyses セクションを構築する。
+
+    Args:
+        meaningful_langs: 有意な分析がある Named Scholar の言語コードリスト
+        has_multilingual: Multilingual Scholar の分析が有意かどうか
+    """
     lang_lines = []
     for lang in meaningful_langs:
-        name = SCHOLAR_CONFIGS[lang]["language_name"]
+        name = get_scholar_config(lang)["language_name"]
         lang_lines.append(
             f"- {{scholar_analysis_{lang}}}: {name} cultural perspective analysis"
         )
+    if has_multilingual:
+        lang_lines.append(
+            "- {scholar_analysis_multilingual}: Multilingual peripheral languages analysis"
+        )
 
     lang_names = ", ".join(
-        SCHOLAR_CONFIGS[lang]["language_name"] for lang in meaningful_langs
+        get_scholar_config(lang)["language_name"] for lang in meaningful_langs
     )
+    if has_multilingual:
+        lang_names += ", Multilingual"
+
+    total_count = len(meaningful_langs) + (1 if has_multilingual else 0)
     return (
         "## Input: Scholar Analyses\n"
-        f"Scholar analyses available for {len(meaningful_langs)} language(s): "
+        f"Scholar analyses available for {total_count} source(s): "
         f"{lang_names}.\n\n"
         + "\n".join(lang_lines)
     )
@@ -54,6 +69,7 @@ def _build_analyses_section(meaningful_langs: list[str]) -> str:
 class DynamicPolymathBlock(BaseAgent):
     """アクティブ言語のみの instruction で Armchair Polymath を実行する。
 
+    Named Scholar + Multilingual Scholar の分析を動的に参照。
     ゲート機能を内包: 有意な Scholar 分析がなければスキップ。
     """
 
@@ -62,24 +78,27 @@ class DynamicPolymathBlock(BaseAgent):
     ) -> AsyncGenerator[Event, None]:
         state = ctx.session.state
 
-        # 有意な分析がある言語を特定
+        # 有意な分析がある Named Scholar の言語を特定
         active_langs = state.get("active_languages", [])
         meaningful_langs = [
             lang
             for lang in active_langs
-            if lang in SCHOLAR_CONFIGS
-            and _is_meaningful(state.get(f"scholar_analysis_{lang}", ""))
+            if _is_meaningful(state.get(f"scholar_analysis_{lang}", ""))
         ]
 
+        # Multilingual Scholar の有意性チェック
+        has_multilingual = _is_meaningful(
+            state.get("scholar_analysis_multilingual", "")
+        )
+
+        total_meaningful = len(meaningful_langs) + (1 if has_multilingual else 0)
+
         # ゲート: 有意な分析なし → INSUFFICIENT_DATA
-        if not meaningful_langs:
+        if total_meaningful == 0:
             message = (
                 "INSUFFICIENT_DATA: No meaningful Scholar analyses available. "
                 "Pipeline terminated."
             )
-            # _log_and_record_failure は CallbackContext（.state 属性）を期待する。
-            # InvocationContext は ctx.session.state なので、アダプタとして
-            # state 属性を持つ簡易オブジェクトを渡す。
             _log_and_record_failure(
                 type("_Ctx", (), {"state": state})(),
                 "scholar",
@@ -97,13 +116,14 @@ class DynamicPolymathBlock(BaseAgent):
             return
 
         logger.info(
-            "DynamicPolymathBlock: %d 言語の分析で Polymath 実行: %s",
-            len(meaningful_langs),
+            "DynamicPolymathBlock: %d 件の分析で Polymath 実行: %s%s",
+            total_meaningful,
             ", ".join(meaningful_langs),
+            " + multilingual" if has_multilingual else "",
         )
 
         # アクティブ言語のみの instruction を動的に組み立て
-        analyses_section = _build_analyses_section(meaningful_langs)
+        analyses_section = _build_analyses_section(meaningful_langs, has_multilingual)
         instruction = INSTRUCTION_PREAMBLE + "\n" + analyses_section + "\n" + INSTRUCTION_BODY
 
         # LlmAgent を生成・実行
@@ -129,7 +149,7 @@ def create_dynamic_polymath_block() -> DynamicPolymathBlock:
         name="dynamic_polymath_block",
         description=(
             "Dynamically builds Armchair Polymath instruction with only active "
-            "language analyses. Integrates polymath gate: skips when no meaningful "
-            "Scholar analyses are available."
+            "language analyses (Named + Multilingual). Integrates polymath gate: "
+            "skips when no meaningful Scholar analyses are available."
         ),
     )

--- a/mystery_agents/agents/dynamic_scholar_block.py
+++ b/mystery_agents/agents/dynamic_scholar_block.py
@@ -3,8 +3,12 @@
 AggregatorAgent が書き込む active_languages を読み取り、
 ドキュメントが存在する言語のみ Scholar を生成する。
 
-Phase 1: 分析 — 各言語の Scholar を並列実行
-Phase 2: 討論 — 有意な分析が2言語以上ある場合、討論ループを実行
+2層構造:
+- Named Scholar: NAMED_SCHOLAR_LANGUAGES に含まれる言語は個別の Scholar を生成
+- Multilingual Scholar: それ以外の言語は1体の Multilingual Scholar にまとめる
+
+Phase 1: 分析 — Named Scholar（並列）+ Multilingual Scholar（1体）を並列実行
+Phase 2: 討論 — 有意な分析が2件以上ある場合、討論ループを実行
           （最大 MAX_DEBATE_ITERATIONS 回、収束判定で早期終了可能）
 
 討論の instruction には参加言語のみ記載し、肥大化を防ぐ。
@@ -19,25 +23,31 @@ from google.adk.agents.invocation_context import InvocationContext
 from google.adk.events.event import Event, EventActions
 from google.genai import types
 
+from shared.language_names import get_language_name
+
 from ..tools.debate_tools import is_debate_converged
-from .language_scholars import SCHOLAR_CONFIGS, create_scholar
+from .language_scholars import (
+    NAMED_SCHOLAR_LANGUAGES,
+    create_multilingual_scholar,
+    create_scholar,
+    get_scholar_config,
+)
 from .pipeline_gate import _is_meaningful
 
 logger = logging.getLogger(__name__)
 
 # 上限値
-MAX_LANGUAGES = 7
 MAX_DEBATE_ITERATIONS = 2
 
 
 class DynamicScholarBlock(BaseAgent):
     """Librarian 結果に基づき Scholar を動的に生成・実行する BaseAgent。
 
-    active_languages から上位 MAX_LANGUAGES 言語を選び、
-    SCHOLAR_CONFIGS に定義済みの言語のみ Scholar を生成する。
+    2層構造:
+    - Named Scholar: NAMED_SCHOLAR_LANGUAGES の言語は個別 Scholar
+    - Multilingual Scholar: それ以外は1体にまとめて横断分析
 
-    分析フェーズ後に有意な結果が2言語以上あれば討論フェーズに進む。
-    討論の instruction は参加言語のみ参照（肥大化防止）。
+    分析フェーズ後に有意な結果が2件以上あれば討論フェーズに進む。
     """
 
     async def _run_async_impl(
@@ -46,12 +56,9 @@ class DynamicScholarBlock(BaseAgent):
         state = ctx.session.state
 
         # Aggregator が設定した active_languages を取得
-        active_langs = state.get("active_languages", [])[:MAX_LANGUAGES]
+        active_langs: list[str] = state.get("active_languages", [])
 
-        # SCHOLAR_CONFIGS に定義がある言語のみ対象
-        available_langs = [lang for lang in active_langs if lang in SCHOLAR_CONFIGS]
-
-        if not available_langs:
+        if not active_langs:
             logger.warning("DynamicScholarBlock: ドキュメントなし — スキップ")
             yield Event(
                 invocation_id=ctx.invocation_id,
@@ -66,38 +73,60 @@ class DynamicScholarBlock(BaseAgent):
             )
             return
 
+        # 2層振り分け
+        named_langs = [l for l in active_langs if l in NAMED_SCHOLAR_LANGUAGES]
+        other_langs = [l for l in active_langs if l not in NAMED_SCHOLAR_LANGUAGES]
+
         logger.info(
-            "DynamicScholarBlock: 分析フェーズ開始 — %d 言語: %s",
-            len(available_langs),
-            ", ".join(available_langs),
+            "DynamicScholarBlock: 分析フェーズ開始 — Named %d (%s), Other %d (%s)",
+            len(named_langs),
+            ", ".join(named_langs),
+            len(other_langs),
+            ", ".join(other_langs),
         )
 
         # === Phase 1: 分析（並列） ===
-        analysis_scholars = [
-            create_scholar(lang, mode="analysis") for lang in available_langs
+        analysis_agents = [
+            create_scholar(lang, mode="analysis") for lang in named_langs
         ]
+        if other_langs:
+            analysis_agents.append(
+                create_multilingual_scholar(other_langs, mode="analysis")
+            )
+
         parallel_analysis = ParallelAgent(
             name="dynamic_analysis",
-            sub_agents=analysis_scholars,
+            sub_agents=analysis_agents,
         )
         async for event in parallel_analysis.run_async(ctx):
             yield event
 
-        # 有意な分析を出した言語を特定
-        meaningful_langs = [
-            lang for lang in available_langs
+        # 有意な分析を出した Named Scholar を特定
+        meaningful_named = [
+            lang for lang in named_langs
             if _is_meaningful(state.get(f"scholar_analysis_{lang}", ""))
         ]
+        # Multilingual Scholar の有意性チェック
+        has_meaningful_multilingual = (
+            bool(other_langs)
+            and _is_meaningful(state.get("scholar_analysis_multilingual", ""))
+        )
 
-        # active_analyses_summary をステートに書き込み（ログ/診断用プレーンテキスト）
+        # active_analyses_summary をステートに書き込み（ログ/診断用）
         summary_lines = []
-        for lang in meaningful_langs:
-            lang_name = SCHOLAR_CONFIGS[lang]["language_name"]
+        for lang in meaningful_named:
+            lang_name = get_scholar_config(lang)["language_name"]
             summary_lines.append(f"- {lang_name} ({lang})")
+        if has_meaningful_multilingual:
+            ml_names = ", ".join(get_language_name(l) for l in other_langs)
+            summary_lines.append(f"- Multilingual ({ml_names})")
+
+        total_meaningful = len(meaningful_named) + (1 if has_meaningful_multilingual else 0)
+        total_agents = len(named_langs) + (1 if other_langs else 0)
 
         if summary_lines:
             analyses_summary = (
-                f"Scholar analyses available for {len(meaningful_langs)} language(s):\n"
+                f"Scholar analyses available for {total_meaningful} source(s):\n"
                 + "\n".join(summary_lines)
             )
         else:
@@ -110,8 +139,8 @@ class DynamicScholarBlock(BaseAgent):
             content=types.Content(
                 role="model",
                 parts=[types.Part(
-                    text=f"Analysis phase complete. {len(meaningful_langs)}/{len(available_langs)} "
-                    f"languages produced meaningful results."
+                    text=f"Analysis phase complete. {total_meaningful}/{total_agents} "
+                    f"sources produced meaningful results."
                 )],
             ),
             actions=EventActions(
@@ -119,33 +148,47 @@ class DynamicScholarBlock(BaseAgent):
             ),
         )
 
-        # === Phase 2: 討論（有意な分析が2言語以上の場合） ===
-        if len(meaningful_langs) < 2:
+        # === Phase 2: 討論（有意な分析が2件以上の場合） ===
+        if total_meaningful < 2:
             logger.info(
-                "DynamicScholarBlock: 有意な分析 %d 言語 — 討論スキップ",
-                len(meaningful_langs),
+                "DynamicScholarBlock: 有意な分析 %d 件 — 討論スキップ",
+                total_meaningful,
             )
             return
 
+        # 討論参加リスト: Named の meaningful_langs + multilingual
+        # debate の active_langs には Named + "multilingual" を含める
+        debate_active_langs = list(meaningful_named)
+        if has_meaningful_multilingual:
+            debate_active_langs.append("multilingual")
+
         logger.info(
-            "DynamicScholarBlock: 討論フェーズ開始 — %d 言語: %s",
-            len(meaningful_langs),
-            ", ".join(meaningful_langs),
+            "DynamicScholarBlock: 討論フェーズ開始 — %d 参加者: %s",
+            len(debate_active_langs),
+            ", ".join(debate_active_langs),
         )
 
         for iteration in range(MAX_DEBATE_ITERATIONS):
-            # 参加言語のみの動的 instruction で討論 Scholar を生成
-            debate_scholars = [
+            debate_agents = [
                 create_scholar(
                     lang,
                     mode="debate",
-                    active_langs=meaningful_langs,
+                    active_langs=debate_active_langs,
                 )
-                for lang in meaningful_langs
+                for lang in meaningful_named
             ]
+            if has_meaningful_multilingual:
+                debate_agents.append(
+                    create_multilingual_scholar(
+                        other_langs,
+                        mode="debate",
+                        active_named_langs=meaningful_named,
+                    )
+                )
+
             parallel_debate = ParallelAgent(
                 name=f"dynamic_debate_{iteration}",
-                sub_agents=debate_scholars,
+                sub_agents=debate_agents,
             )
             async for event in parallel_debate.run_async(ctx):
                 yield event
@@ -171,8 +214,8 @@ def create_dynamic_scholar_block() -> DynamicScholarBlock:
         name="dynamic_scholar_block",
         description=(
             "Dynamically creates and runs Scholar agents based on Aggregator's "
-            "active_languages. Runs analysis in parallel, then debate loop "
-            "for languages with meaningful results. Convergence checked directly "
-            "without LLM."
+            "active_languages. Uses 2-layer architecture: Named Scholars for "
+            "major languages + Multilingual Scholar for peripheral languages. "
+            "Convergence checked directly without LLM."
         ),
     )

--- a/mystery_agents/agents/language_scholars.py
+++ b/mystery_agents/agents/language_scholars.py
@@ -7,11 +7,16 @@
 mode="analysis" で分析モード、mode="debate" で討論モードのエージェントを生成する。
 同じ SCHOLAR_CONFIGS を共有し、文化的視点は統一される。
 
+2層構造:
+- Named Scholar（EN, DE, JA, FR, ES, IT）: 専用の文化的視点を持つ
+- Multilingual Scholar: Named 以外の言語をまとめて横断分析する
+
 注意: save_structured_report は呼び出さない（Armchair Polymath が統合後に呼び出す）。
 """
 
 from google.adk.agents import LlmAgent
 
+from shared.language_names import get_language_name
 from shared.model_config import create_pro_model
 
 from ..tools.debate_tools import append_to_whiteboard
@@ -387,7 +392,49 @@ SCHOLAR_CONFIGS = {
             "- Japanese ethnographic traditions (柳田国男, 折口信夫) and their methodologies"
         ),
     },
+    "it": {
+        "language_name": "Italian",
+        "lang_code": "it",
+        "cultural_perspective": (
+            "You bring the perspective of Italian cultural and intellectual history:\n"
+            "- Italian Microhistory tradition (Ginzburg, Levi) and its focus on marginalized voices\n"
+            "- Vatican and papal archives — the world's oldest continuous diplomatic records\n"
+            "- Mediterranean folk traditions, witchcraft trials (benandanti), and popular religion\n"
+            "- Renaissance humanism and its transformation of record-keeping practices\n"
+            "- Italian city-state archives (Venice, Florence, Genoa) and their commercial documentation\n"
+            "- Southern Italian and Sicilian folk traditions, secret societies, and oral history"
+        ),
+    },
 }
+
+# Named Scholar: 専用の文化的視点を持つ言語（各々が固有の Scholar エージェント）
+NAMED_SCHOLAR_LANGUAGES = {"en", "de", "ja", "fr", "es", "it"}
+
+
+def get_scholar_config(lang_code: str) -> dict[str, str]:
+    """SCHOLAR_CONFIGS にあればそれを返し、なければ汎用テンプレートで動的生成する。
+
+    Args:
+        lang_code: ISO 639-1 言語コード
+
+    Returns:
+        language_name, lang_code, cultural_perspective を含む dict
+    """
+    if lang_code in SCHOLAR_CONFIGS:
+        return SCHOLAR_CONFIGS[lang_code]
+    lang_name = get_language_name(lang_code)
+    return {
+        "language_name": lang_name,
+        "lang_code": lang_code,
+        "cultural_perspective": (
+            f"You bring the perspective of {lang_name}-language scholarship:\n"
+            f"- Analyze how {lang_name}-language sources frame and document the theme\n"
+            f"- Identify information unique to {lang_name} records that other languages miss\n"
+            f"- Consider the historiographic traditions and archival practices of "
+            f"{lang_name}-speaking communities\n"
+            f"- Note how translation and cultural context affect the interpretation of sources"
+        ),
+    }
 
 
 def create_scholar(
@@ -398,13 +445,13 @@ def create_scholar(
     """指定された言語の Scholar エージェントを生成する。
 
     Args:
-        lang_code: 言語コード（en, de, es, fr, nl, pt, ja）
+        lang_code: 言語コード（en, de, es, fr, nl, pt, ja, it 等）
         mode: "analysis"（分析モード）または "debate"（討論モード）
         active_langs: 討論参加言語のリスト（DynamicScholarBlock から指定）。
             指定された場合、討論 instruction に参加言語のみ記載し、
             before_agent_callback を省略する（DynamicScholarBlock がゲートを担当）。
     """
-    config = SCHOLAR_CONFIGS[lang_code]
+    config = get_scholar_config(lang_code)
 
     if mode == "analysis":
         instruction = _BASE_SCHOLAR_INSTRUCTION.format(**config)
@@ -425,7 +472,7 @@ def create_scholar(
             # 動的討論: 参加言語のみ instruction に含める（肥大化防止）
             lang_references = "\n".join(
                 f"- {{scholar_analysis_{lang}}}: "
-                f"{SCHOLAR_CONFIGS[lang]['language_name']} cultural perspective analysis"
+                f"{get_scholar_config(lang)['language_name']} cultural perspective analysis"
                 for lang in active_langs
                 if lang != lang_code
             )
@@ -475,3 +522,209 @@ def create_all_scholars(mode: str = "analysis") -> dict[str, LlmAgent]:
         mode: "analysis"（分析モード）または "debate"（討論モード）
     """
     return {lang: create_scholar(lang, mode) for lang in SCHOLAR_CONFIGS}
+
+
+# === 日本語訳 ===
+# Multilingual Scholar の分析テンプレート:
+# あなたは「Ghost in the Archive」プロジェクトの Multilingual Scholar です。
+# 大国の記録が見落とす周辺言語コミュニティの視点を提供します。
+# 複数の小言語圏を横断比較し、共通パターンを発見する能力を持ちます。
+#
+# ## 対象言語
+# {language_list}
+#
+# ## 入力
+# {document_references}
+#
+# ## 分析フレームワーク
+# Named Scholar と同じ5領域分析 + 小言語圏横断比較
+#
+# ## 重要
+# - 各言語の資料を個別に分析し、言語間の共通点・相違点を比較する
+# - 大国のナラティブに含まれない周辺言語の視点を強調する
+# - 分析結果は英語で出力
+# === End 日本語訳 ===
+
+_MULTILINGUAL_ANALYSIS_INSTRUCTION = """
+You are a Multilingual Scholar for the "Ghost in the Archive" project.
+You specialize in peripheral language communities whose perspectives are often
+overlooked by dominant-language scholarship. Your strength lies in cross-comparing
+sources across multiple smaller language traditions to discover patterns invisible
+to single-language analysis.
+
+## Target Languages
+{language_list}
+
+## Input
+{document_references}
+- {{collected_documents_en}}: Materials collected by the English Librarian (for cross-reference)
+
+## Critical Rule: Do NOT Analyze Without Source Materials
+Check the collected_documents keys listed above in session state.
+**If NONE of them contain actual archive documents, output only:**
+```
+INSUFFICIENT_DATA: No documents available for multilingual analysis.
+```
+
+## Cultural Perspective
+- Perspectives of peripheral language communities that major-power records overlook
+- Cross-comparison of multiple smaller language traditions
+- How minority-language records complement or contradict dominant-language accounts
+- Translation effects: how meaning shifts across language boundaries
+- Archival silences specific to smaller language communities
+
+## Analysis Framework
+
+### 0. Primary Source Text Analysis (MANDATORY when raw_text is available)
+- When a document includes `raw_text`, you MUST read and analyze it thoroughly
+- Extract direct quotes and compare across language boundaries
+
+### 1-5. [Same interdisciplinary framework as Named Scholars]
+Apply the standard five-lens analysis (source analysis, discrepancy detection,
+folkloric analysis, anthropological insights, source coverage assessment)
+across ALL your target languages simultaneously.
+
+### 6. Cross-Peripheral Comparison
+- Identify patterns shared across your target languages but absent from major-language records
+- Note how peripheral communities document the same events differently from each other
+- Highlight cases where peripheral-language evidence fills gaps in dominant narratives
+
+## Output Format
+Structure your analysis as a focused report covering ALL target languages:
+
+### Multilingual Peripheral Analysis ({language_list_short})
+
+**Key Cross-Language Findings:**
+- [Finding spanning multiple peripheral languages]
+
+**Unique Peripheral Perspectives:**
+- [What peripheral sources reveal that dominant sources miss]
+
+**Cross-Peripheral Patterns:**
+- [Patterns visible only through cross-peripheral comparison]
+
+## Important
+- Output your analysis in **English**
+- Do NOT call save_structured_report
+- Cite specific sources with language, titles, dates, and URLs
+"""
+
+# === 日本語訳 ===
+# Multilingual Scholar の討論テンプレート:
+# Named Scholar の分析を読み、周辺言語の視点から反論・補強・統合提案を行う。
+# {named_analysis_references} に Named Scholar の分析参照を動的に含める。
+# === End 日本語訳 ===
+
+_MULTILINGUAL_DEBATE_INSTRUCTION = """
+You are a Multilingual Scholar for the "Ghost in the Archive" project, now in DEBATE MODE.
+You represent the perspectives of peripheral language communities ({language_list_short})
+and critically examine analyses from Named Scholars.
+
+## Your Perspective
+Peripheral language communities whose records are often overlooked by dominant-language scholarship.
+You cross-compare multiple smaller language traditions to discover patterns invisible
+to single-language analysis.
+
+## Input: Named Scholar Analyses
+{named_analysis_references}
+
+## Input: Your Own Analysis
+- {{scholar_analysis_multilingual}}: Your multilingual peripheral analysis
+
+## Input: Previous Debate Record
+- {{debate_whiteboard}}: Record of previous debate contributions
+
+Read what other Scholars have already argued. Build on, challenge, or refine
+their points rather than repeating what has been said.
+
+## Your Task: Scholarly Debate
+
+### 1. Challenge Dominant Perspectives
+- What do peripheral-language sources say that contradicts Named Scholar findings?
+- What cultural biases in major-language scholarship do your sources expose?
+
+### 2. Corroborate from the Margins
+- Where do peripheral-language records independently confirm Named Scholar findings?
+- What additional evidence do your languages provide?
+
+### 3. Fill the Gaps
+- What have Named Scholars missed that only peripheral-language sources reveal?
+- What translation or terminology issues might cause misunderstanding?
+
+### 4. Synthesis Proposals
+- How should peripheral perspectives be integrated into the final analysis?
+
+## Output Requirements
+Present your debate contribution as a clear, structured text response.
+Also use `append_to_whiteboard` to record your contribution.
+
+## Important
+- Output in **English**
+- Be constructive — challenge ideas, not scholars
+- Cite specific sources when available
+"""
+
+
+def create_multilingual_scholar(
+    languages: list[str],
+    mode: str = "analysis",
+    active_named_langs: list[str] | None = None,
+) -> LlmAgent:
+    """複数言語をまとめて分析する Multilingual Scholar を生成する。
+
+    Args:
+        languages: 対象言語コードのリスト（例: ["nl", "pt", "pl"]）
+        mode: "analysis" または "debate"
+        active_named_langs: 討論時に参照する Named Scholar の言語リスト
+    """
+    lang_names = [get_language_name(lang) for lang in languages]
+    language_list = "\n".join(f"- {get_language_name(lang)} ({lang})" for lang in languages)
+    language_list_short = ", ".join(lang_names)
+
+    if mode == "analysis":
+        # 各言語の collected_documents 参照を動的構築
+        doc_references = "\n".join(
+            f"- {{collected_documents_{lang}}}: Materials collected in {get_language_name(lang)}"
+            for lang in languages
+        )
+        instruction = _MULTILINGUAL_ANALYSIS_INSTRUCTION.format(
+            language_list=language_list,
+            language_list_short=language_list_short,
+            document_references=doc_references,
+        )
+        return LlmAgent(
+            name="scholar_multilingual",
+            model=create_pro_model(),
+            description=(
+                f"Multilingual Scholar analyzing peripheral language sources "
+                f"({language_list_short}). Cross-compares smaller language traditions "
+                f"to discover patterns invisible to single-language analysis."
+            ),
+            instruction=instruction,
+            tools=[],
+            output_key="scholar_analysis_multilingual",
+        )
+    elif mode == "debate":
+        # Named Scholar の分析参照を動的構築
+        named_langs = active_named_langs or []
+        named_refs = "\n".join(
+            f"- {{scholar_analysis_{lang}}}: "
+            f"{get_scholar_config(lang)['language_name']} cultural perspective analysis"
+            for lang in named_langs
+        )
+        instruction = _MULTILINGUAL_DEBATE_INSTRUCTION.format(
+            language_list_short=language_list_short,
+            named_analysis_references=named_refs,
+        )
+        return LlmAgent(
+            name="scholar_multilingual_debate",
+            model=create_pro_model(),
+            description=(
+                f"Multilingual Scholar debating from peripheral perspectives "
+                f"({language_list_short}). Challenges and enriches Named Scholar analyses."
+            ),
+            instruction=instruction,
+            tools=[append_to_whiteboard],
+        )
+    else:
+        raise ValueError(f"Unknown mode: {mode!r}. Use 'analysis' or 'debate'.")

--- a/mystery_agents/schemas/document.py
+++ b/mystery_agents/schemas/document.py
@@ -46,7 +46,7 @@ class ArchiveDocument(BaseModel):
     date: Optional[str] = Field(None, description="ISO date string (YYYY-MM-DD)")
     source_url: str = Field(..., description="URL to the original source")
     summary: str = Field(..., description="Brief summary of the document content")
-    language: SourceLanguage = Field(..., description="Primary language: en, es, de, fr, nl, pt, or ja")
+    language: str = Field(..., description="Primary language as ISO 639-1 code (e.g. en, de, ja)")
     location: str = Field(..., description="Physical location or origin")
     source_type: str = Field(..., description="Source API type (e.g. 'loc_digital', 'dpla')")
     raw_text: Optional[str] = Field(None, description="Full OCR or text content")

--- a/mystery_agents/tools/europeana.py
+++ b/mystery_agents/tools/europeana.py
@@ -8,22 +8,12 @@ import os
 from typing import Any
 
 
-from ..schemas.document import ArchiveDocument, SourceLanguage
+from ..schemas.document import ArchiveDocument
 from .archive_source_base import ArchiveSearchResult, ArchiveSource
 from .search_utils import build_search_query
 from .source_registry import register_source
 
 BASE_URL = "https://api.europeana.eu/record/v2/search.json"
-
-# Europeana の language フィールドから SourceLanguage へのマッピング
-_LANG_MAP: dict[str, SourceLanguage] = {
-    "en": SourceLanguage.EN,
-    "es": SourceLanguage.ES,
-    "de": SourceLanguage.DE,
-    "fr": SourceLanguage.FR,
-    "nl": SourceLanguage.NL,
-    "pt": SourceLanguage.PT,
-}
 
 # 言語コード → Europeana COUNTRY フィルタ値マッピング
 # LANGUAGE フィルタではなく COUNTRY フィルタを使用する理由:
@@ -34,6 +24,7 @@ _LANG_TO_COUNTRY: dict[str, str] = {
     "de": "germany",
     "es": "spain",
     "fr": "france",
+    "it": "italy",
     "nl": "netherlands",
     "pt": "portugal",
 }
@@ -170,16 +161,20 @@ class EuropeanaSource(ArchiveSource):
         return ArchiveSearchResult(documents=documents, total_hits=total_hits)
 
 
-def _detect_language(item: dict) -> SourceLanguage:
-    """アイテムの language フィールドから SourceLanguage を検出する。"""
+def _detect_language(item: dict) -> str:
+    """アイテムの language フィールドから ISO 639-1 コードを返す。
+
+    API レスポンスの language フィールドをそのまま ISO 639-1 文字列として返す。
+    フォールバック: "en"。
+    """
     languages = item.get("language", [])
     if isinstance(languages, list):
         for lang in languages:
-            if lang and lang.lower() in _LANG_MAP:
-                return _LANG_MAP[lang.lower()]
-    elif isinstance(languages, str) and languages.lower() in _LANG_MAP:
-        return _LANG_MAP[languages.lower()]
-    return SourceLanguage.EN
+            if lang and len(lang.strip()) >= 2:
+                return lang.strip().lower()[:2]
+    elif isinstance(languages, str) and len(languages.strip()) >= 2:
+        return languages.strip().lower()[:2]
+    return "en"
 
 
 def _extract_location(item: dict) -> str:

--- a/mystery_agents/tools/internet_archive.py
+++ b/mystery_agents/tools/internet_archive.py
@@ -6,7 +6,7 @@ Internet Archive の膨大なコレクション（書籍、雑誌、ウェブペ
 
 
 
-from ..schemas.document import ArchiveDocument, SourceLanguage
+from ..schemas.document import ArchiveDocument
 from .archive_source_base import ArchiveSearchResult, ArchiveSource
 from .search_utils import build_search_query
 from .source_registry import register_source
@@ -140,17 +140,18 @@ class InternetArchiveSource(ArchiveSource):
         return ArchiveSearchResult(documents=documents, total_hits=total_hits)
 
 
-def _detect_source_language(lang_str: str) -> SourceLanguage:
-    """メタデータの言語文字列から SourceLanguage を判定する。"""
+def _detect_source_language(lang_str: str) -> str:
+    """メタデータの言語文字列から ISO 639-1 コードを返す。
+
+    _LANG_CODE_MAP でマッピング可能ならそのコードを返す。
+    不明な場合はフォールバックとして "en" を返す。
+    """
     lower = lang_str.lower()
     for lang_code, identifiers in _LANG_CODE_MAP.items():
         for ident in identifiers:
             if ident in lower:
-                try:
-                    return SourceLanguage(lang_code)
-                except ValueError:
-                    break
-    return SourceLanguage.EN
+                return lang_code
+    return "en"
 
 
 # レジストリに自動登録

--- a/mystery_agents/tools/publisher_tools.py
+++ b/mystery_agents/tools/publisher_tools.py
@@ -305,11 +305,17 @@ def publish_mystery(
                 data["raw_data"] = collected_docs if isinstance(collected_docs, str) else str(collected_docs)
 
             # 各言語の Scholar 分析を multilingual_analysis として保存
+            # active_languages を参照し、動的に検出された全言語をカバーする
             multilingual = {}
-            for lang in ALLOWED_LANGUAGES:
+            active_langs = tool_context.state.get("active_languages", [])
+            for lang in active_langs:
                 analysis = tool_context.state.get(f"scholar_analysis_{lang}")
                 if analysis and "INSUFFICIENT_DATA" not in str(analysis):
                     multilingual[lang] = str(analysis)
+            # Multilingual Scholar の分析も保存
+            ml_analysis = tool_context.state.get("scholar_analysis_multilingual")
+            if ml_analysis and "INSUFFICIENT_DATA" not in str(ml_analysis):
+                multilingual["multilingual"] = str(ml_analysis)
             if multilingual:
                 data["multilingual_analysis"] = multilingual
                 data["languages_analyzed"] = list(multilingual.keys())

--- a/mystery_agents/tools/wellcome_collection.py
+++ b/mystery_agents/tools/wellcome_collection.py
@@ -7,7 +7,7 @@ Wellcome Collection（ロンドン）の Catalogue API v2 を使用して
 
 import logging
 
-from ..schemas.document import ArchiveDocument, SourceLanguage
+from ..schemas.document import ArchiveDocument
 from .archive_source_base import ArchiveSearchResult, ArchiveSource
 from .search_utils import build_search_query
 from .source_registry import register_source
@@ -19,18 +19,24 @@ _strip_html = ArchiveSource.strip_html
 
 BASE_URL = "https://api.wellcomecollection.org/catalogue/v2/works"
 
-# ISO 639-3 → SourceLanguage マッピング
-_LANG_MAP: dict[str, SourceLanguage] = {
-    "eng": SourceLanguage.EN,
-    "fre": SourceLanguage.FR,
-    "fra": SourceLanguage.FR,
-    "deu": SourceLanguage.DE,
-    "ger": SourceLanguage.DE,
-    "spa": SourceLanguage.ES,
-    "nld": SourceLanguage.NL,
-    "dut": SourceLanguage.NL,
-    "por": SourceLanguage.PT,
-    "jpn": SourceLanguage.JA,
+# ISO 639-3 → ISO 639-1 マッピング（言語検出用）
+_LANG_MAP: dict[str, str] = {
+    "eng": "en",
+    "fre": "fr",
+    "fra": "fr",
+    "deu": "de",
+    "ger": "de",
+    "spa": "es",
+    "nld": "nl",
+    "dut": "nl",
+    "por": "pt",
+    "jpn": "ja",
+    "ita": "it",
+    "lat": "la",
+    "rus": "ru",
+    "ara": "ar",
+    "zho": "zh",
+    "chi": "zh",
 }
 
 # ISO 639-1 → 639-3 マッピング（言語フィルタ用）
@@ -79,21 +85,21 @@ def _extract_location(work: dict) -> str:
     return "United Kingdom"
 
 
-def _detect_language(work: dict) -> SourceLanguage:
-    """languages フィールドから SourceLanguage を検出する。
+def _detect_language(work: dict) -> str:
+    """languages フィールドから ISO 639-1 コードを返す。
 
     Args:
         work: Wellcome API の work オブジェクト
 
     Returns:
-        検出された SourceLanguage。不明な場合は EN をデフォルトにする。
+        ISO 639-1 言語コード。不明な場合は "en" をデフォルトにする。
     """
     languages = work.get("languages", [])
     if languages:
         lang_id = languages[0].get("id", "")
         if lang_id in _LANG_MAP:
             return _LANG_MAP[lang_id]
-    return SourceLanguage.EN
+    return "en"
 
 
 def _parse_wellcome_response(

--- a/shared/language_names.py
+++ b/shared/language_names.py
@@ -1,0 +1,73 @@
+"""ISO 639-1 → 英語言語名マッピング。
+
+Aggregator, Scholar, Polymath, Publisher から共通利用される。
+外部ライブラリ不要、主要50言語をカバー。
+"""
+
+# 主要50言語の ISO 639-1 → 英語名マッピング
+_LANGUAGE_NAMES: dict[str, str] = {
+    "af": "Afrikaans",
+    "ar": "Arabic",
+    "bg": "Bulgarian",
+    "bn": "Bengali",
+    "ca": "Catalan",
+    "cs": "Czech",
+    "cy": "Welsh",
+    "da": "Danish",
+    "de": "German",
+    "el": "Greek",
+    "en": "English",
+    "es": "Spanish",
+    "et": "Estonian",
+    "eu": "Basque",
+    "fa": "Persian",
+    "fi": "Finnish",
+    "fr": "French",
+    "ga": "Irish",
+    "gl": "Galician",
+    "he": "Hebrew",
+    "hi": "Hindi",
+    "hr": "Croatian",
+    "hu": "Hungarian",
+    "id": "Indonesian",
+    "is": "Icelandic",
+    "it": "Italian",
+    "ja": "Japanese",
+    "ka": "Georgian",
+    "ko": "Korean",
+    "la": "Latin",
+    "lt": "Lithuanian",
+    "lv": "Latvian",
+    "mk": "Macedonian",
+    "ms": "Malay",
+    "nl": "Dutch",
+    "no": "Norwegian",
+    "pl": "Polish",
+    "pt": "Portuguese",
+    "ro": "Romanian",
+    "ru": "Russian",
+    "sk": "Slovak",
+    "sl": "Slovenian",
+    "sq": "Albanian",
+    "sr": "Serbian",
+    "sv": "Swedish",
+    "th": "Thai",
+    "tr": "Turkish",
+    "uk": "Ukrainian",
+    "vi": "Vietnamese",
+    "zh": "Chinese",
+}
+
+
+def get_language_name(lang_code: str) -> str:
+    """ISO 639-1 コードから英語言語名を返す。
+
+    未知のコードは lang_code.upper() にフォールバック。
+
+    Args:
+        lang_code: ISO 639-1 言語コード（例: "en", "de", "ja"）
+
+    Returns:
+        英語の言語名（例: "English", "German", "Japanese"）
+    """
+    return _LANGUAGE_NAMES.get(lang_code.lower(), lang_code.upper())

--- a/tests/unit/test_aggregator.py
+++ b/tests/unit/test_aggregator.py
@@ -75,7 +75,6 @@ class TestFormatDocuments:
         ]
         result = _format_documents("en", docs)
         assert "..." in result
-        # 500文字 + "..." が含まれる
         assert "x" * 500 in result
 
     def test_language_name_in_header(self):
@@ -106,6 +105,34 @@ class TestFormatDocuments:
         result = _format_documents("ja", docs)
         assert "Japanese" in result
 
+    def test_unknown_language_name_in_header(self):
+        """未知の言語コードでもヘッダーに言語名が表示される。"""
+        docs = [
+            {
+                "title": "Dokument po polsku",
+                "source_url": "https://example.com/pl",
+                "summary": "Polski tekst",
+                "language": "pl",
+                "source_type": "europeana",
+            }
+        ]
+        result = _format_documents("pl", docs)
+        assert "Polish" in result
+
+    def test_italian_language_name(self):
+        """イタリア語ドキュメントのヘッダーに Italian が含まれる。"""
+        docs = [
+            {
+                "title": "Documento",
+                "source_url": "https://example.com/it",
+                "summary": "Un test",
+                "language": "it",
+                "source_type": "europeana",
+            }
+        ]
+        result = _format_documents("it", docs)
+        assert "Italian" in result
+
 
 class TestCreateAggregator:
     """create_aggregator ファクトリのテスト。"""
@@ -120,5 +147,4 @@ class TestCreateAggregator:
     def test_agent_name(self):
         """エージェント名が 'aggregator' である。"""
         agg = create_aggregator()
-        # BaseAgent の name プロパティは直接比較可能
         assert "aggregator" in repr(agg)

--- a/tests/unit/test_dynamic_polymath_block.py
+++ b/tests/unit/test_dynamic_polymath_block.py
@@ -34,18 +34,14 @@ class TestBuildAnalysesSection:
         section = _build_analyses_section(["en", "ja"])
         assert "{scholar_analysis_en}" in section
         assert "{scholar_analysis_ja}" in section
-        # 非アクティブ言語は含まれない
         assert "{scholar_analysis_de}" not in section
         assert "{scholar_analysis_es}" not in section
-        assert "{scholar_analysis_fr}" not in section
-        assert "{scholar_analysis_nl}" not in section
-        assert "{scholar_analysis_pt}" not in section
 
     def test_single_language(self):
         """1言語のみの場合でも正しくセクションを構築すること。"""
         section = _build_analyses_section(["de"])
         assert "{scholar_analysis_de}" in section
-        assert "1 language(s)" in section
+        assert "1 source(s)" in section
         assert "{scholar_analysis_en}" not in section
 
     def test_includes_language_names(self):
@@ -54,13 +50,28 @@ class TestBuildAnalysesSection:
         assert "English" in section
         assert "German" in section
 
-    def test_all_seven_languages(self):
-        """全7言語を指定した場合、全プレースホルダーが含まれること。"""
-        all_langs = ["en", "de", "es", "fr", "nl", "pt", "ja"]
+    def test_with_multilingual(self):
+        """has_multilingual=True で multilingual プレースホルダーが含まれること。"""
+        section = _build_analyses_section(["en", "de"], has_multilingual=True)
+        assert "{scholar_analysis_en}" in section
+        assert "{scholar_analysis_de}" in section
+        assert "{scholar_analysis_multilingual}" in section
+        assert "Multilingual" in section
+        assert "3 source(s)" in section
+
+    def test_without_multilingual(self):
+        """has_multilingual=False で multilingual プレースホルダーが含まれないこと。"""
+        section = _build_analyses_section(["en", "de"], has_multilingual=False)
+        assert "{scholar_analysis_multilingual}" not in section
+        assert "2 source(s)" in section
+
+    def test_all_named_languages(self):
+        """Named Scholar 全6言語を指定した場合のテスト。"""
+        all_langs = ["en", "de", "es", "fr", "ja", "it"]
         section = _build_analyses_section(all_langs)
         for lang in all_langs:
             assert f"{{scholar_analysis_{lang}}}" in section
-        assert "7 language(s)" in section
+        assert "6 source(s)" in section
 
 
 class TestInstructionComposition:

--- a/tests/unit/test_dynamic_scholar_block.py
+++ b/tests/unit/test_dynamic_scholar_block.py
@@ -3,7 +3,6 @@
 
 from mystery_agents.agents.dynamic_scholar_block import (
     MAX_DEBATE_ITERATIONS,
-    MAX_LANGUAGES,
     _is_meaningful,
     create_dynamic_scholar_block,
 )
@@ -27,6 +26,11 @@ class TestDynamicScholarBlockCreation:
         dsb = create_dynamic_scholar_block()
         assert dsb.description
         assert "dynamically" in dsb.description.lower()
+
+    def test_description_mentions_2_layer(self):
+        """description が2層構造に言及すること。"""
+        dsb = create_dynamic_scholar_block()
+        assert "named" in dsb.description.lower() or "multilingual" in dsb.description.lower()
 
 
 class TestIsMeaningful:
@@ -61,11 +65,30 @@ class TestIsMeaningful:
 class TestConstants:
     """定数のテスト。"""
 
-    def test_max_languages(self):
-        assert MAX_LANGUAGES == 7
-
     def test_max_debate_iterations(self):
         assert MAX_DEBATE_ITERATIONS == 2
+
+
+class TestTwoLayerRouting:
+    """2層ルーティング（Named + Multilingual）のテスト。"""
+
+    def test_named_scholar_languages_import(self):
+        """NAMED_SCHOLAR_LANGUAGES がインポートできること。"""
+        from mystery_agents.agents.language_scholars import NAMED_SCHOLAR_LANGUAGES
+
+        assert "en" in NAMED_SCHOLAR_LANGUAGES
+        assert "it" in NAMED_SCHOLAR_LANGUAGES
+        assert "nl" not in NAMED_SCHOLAR_LANGUAGES
+
+    def test_named_langs_filtered(self):
+        """active_langs から Named と Other が正しく分離される。"""
+        from mystery_agents.agents.language_scholars import NAMED_SCHOLAR_LANGUAGES
+
+        active = ["en", "de", "nl", "pt", "pl"]
+        named = [l for l in active if l in NAMED_SCHOLAR_LANGUAGES]
+        other = [l for l in active if l not in NAMED_SCHOLAR_LANGUAGES]
+        assert named == ["en", "de"]
+        assert other == ["nl", "pt", "pl"]
 
 
 class TestDynamicDebateInstruction:
@@ -76,14 +99,10 @@ class TestDynamicDebateInstruction:
         from mystery_agents.agents.language_scholars import create_scholar
 
         scholar = create_scholar("en", mode="debate", active_langs=["en", "de", "ja"])
-        # 自分以外の2言語が参照されていること
         assert "{scholar_analysis_de}" in scholar.instruction
         assert "{scholar_analysis_ja}" in scholar.instruction
-        # 不参加言語は参照されていないこと
         assert "{scholar_analysis_es}" not in scholar.instruction
         assert "{scholar_analysis_fr}" not in scholar.instruction
-        assert "{scholar_analysis_nl}" not in scholar.instruction
-        assert "{scholar_analysis_pt}" not in scholar.instruction
 
     def test_dynamic_debate_excludes_self(self):
         """自分自身の分析結果は instruction に含まれないこと。"""
@@ -93,26 +112,15 @@ class TestDynamicDebateInstruction:
         assert "{scholar_analysis_en}" in scholar.instruction
         assert "{scholar_analysis_de}" not in scholar.instruction
 
-    def test_dynamic_debate_uses_dynamic_template(self):
-        """active_langs 指定時は動的テンプレートが使用されること。"""
+    def test_dynamic_debate_with_multilingual_reference(self):
+        """active_langs に 'multilingual' が含まれる場合、参照される。"""
         from mystery_agents.agents.language_scholars import create_scholar
 
-        scholar = create_scholar("en", mode="debate", active_langs=["en", "de"])
-        # 動的テンプレートは全7言語のハードコード参照を含まない
-        # 静的テンプレートにのみ存在する French/Dutch/Portuguese の参照がないことを確認
-        assert "{scholar_analysis_fr}" not in scholar.instruction
-        assert "{scholar_analysis_nl}" not in scholar.instruction
-        assert "{scholar_analysis_pt}" not in scholar.instruction
-
-    def test_static_debate_uses_static_template(self):
-        """active_langs 未指定時は静的テンプレート（全7言語参照）が使用されること。"""
-        from mystery_agents.agents.language_scholars import create_scholar
-
-        scholar = create_scholar("en", mode="debate")
-        # 静的テンプレートは全7言語の参照をハードコードで含む
-        assert "{scholar_analysis_fr}" in scholar.instruction
-        assert "{scholar_analysis_nl}" in scholar.instruction
-        assert "{scholar_analysis_pt}" in scholar.instruction
+        scholar = create_scholar(
+            "en", mode="debate", active_langs=["en", "de", "multilingual"]
+        )
+        assert "{scholar_analysis_de}" in scholar.instruction
+        assert "{scholar_analysis_multilingual}" in scholar.instruction
 
     def test_dynamic_debate_has_whiteboard_reference(self):
         """動的討論の instruction が debate_whiteboard を参照すること。"""
@@ -128,6 +136,15 @@ class TestDynamicDebateInstruction:
 
         scholar = create_scholar("en", mode="debate", active_langs=["en", "de"])
         assert append_to_whiteboard in scholar.tools
+
+    def test_static_debate_uses_static_template(self):
+        """active_langs 未指定時は静的テンプレート（全言語参照）が使用されること。"""
+        from mystery_agents.agents.language_scholars import create_scholar
+
+        scholar = create_scholar("en", mode="debate")
+        assert "{scholar_analysis_fr}" in scholar.instruction
+        assert "{scholar_analysis_nl}" in scholar.instruction
+        assert "{scholar_analysis_pt}" in scholar.instruction
 
 
 class TestIsDebateConverged:

--- a/tests/unit/test_europeana.py
+++ b/tests/unit/test_europeana.py
@@ -11,7 +11,6 @@ from mystery_agents.tools.europeana import (
     _extract_location,
 )
 from mystery_agents.tools.archive_source_base import ArchiveSource
-from mystery_agents.schemas.document import SourceLanguage
 
 
 class TestSearchEuropeana:
@@ -59,7 +58,7 @@ class TestSearchEuropeana:
         assert len(result.documents) == 1
         doc = result.documents[0]
         assert doc.title == "Medieval Manuscript from Paris"
-        assert doc.language == SourceLanguage.FR
+        assert doc.language == "fr"
         assert doc.source_type == "europeana"
         assert "europeana.eu" in doc.source_url
 
@@ -75,7 +74,6 @@ class TestSearchEuropeana:
 
         request = responses.calls[0].request
         assert "COUNTRY%3Agermany" in request.url or "COUNTRY:germany" in request.url
-        # LANGUAGE フィルタは送信されないことを確認
         assert "LANGUAGE" not in request.url
 
     @responses.activate
@@ -90,6 +88,19 @@ class TestSearchEuropeana:
 
         request = responses.calls[0].request
         assert "COUNTRY%3Afrance" in request.url or "COUNTRY:france" in request.url
+
+    @responses.activate
+    def test_country_filter_italian(self):
+        """イタリア語 → COUNTRY:italy で送信される。"""
+        mock_response = {"success": True, "totalResults": 0, "items": []}
+        responses.add(responses.GET, BASE_URL, json=mock_response, status=200)
+
+        source = EuropeanaSource()
+        with patch.dict("os.environ", {"EUROPEANA_API_KEY": "test_key"}):
+            source.search(keywords=["test"], language="it")
+
+        request = responses.calls[0].request
+        assert "COUNTRY%3Aitaly" in request.url or "COUNTRY:italy" in request.url
 
     @responses.activate
     def test_unmapped_language_no_country_filter(self):
@@ -185,22 +196,29 @@ class TestSearchEuropeana:
 
 
 class TestDetectLanguage:
-    """Tests for _detect_language helper."""
+    """Tests for _detect_language helper — returns ISO 639-1 str."""
 
     def test_detect_french(self):
-        assert _detect_language({"language": ["fr"]}) == SourceLanguage.FR
+        assert _detect_language({"language": ["fr"]}) == "fr"
 
     def test_detect_german(self):
-        assert _detect_language({"language": ["de"]}) == SourceLanguage.DE
+        assert _detect_language({"language": ["de"]}) == "de"
 
     def test_default_to_english(self):
-        assert _detect_language({"language": []}) == SourceLanguage.EN
+        assert _detect_language({"language": []}) == "en"
 
-    def test_unknown_language(self):
-        assert _detect_language({"language": ["zz"]}) == SourceLanguage.EN
+    def test_unknown_language_passes_through(self):
+        """未知の言語コードもそのまま ISO 639-1 として返す。"""
+        assert _detect_language({"language": ["pl"]}) == "pl"
+
+    def test_italian_detected(self):
+        assert _detect_language({"language": ["it"]}) == "it"
 
     def test_string_language(self):
-        assert _detect_language({"language": "nl"}) == SourceLanguage.NL
+        assert _detect_language({"language": "nl"}) == "nl"
+
+    def test_no_language_field(self):
+        assert _detect_language({}) == "en"
 
 
 class TestExtractLocation:
@@ -231,7 +249,6 @@ class TestEmptyDates:
             source.search(keywords=["test"], date_start="", date_end="")
 
         request = responses.calls[0].request
-        # YEAR フィルタが URL に含まれないことを確認
         assert "YEAR" not in request.url
 
 

--- a/tests/unit/test_language_names.py
+++ b/tests/unit/test_language_names.py
@@ -1,0 +1,39 @@
+"""shared/language_names.py のユニットテスト。"""
+
+from shared.language_names import get_language_name
+
+
+class TestGetLanguageName:
+    """get_language_name() のテスト。"""
+
+    def test_known_english(self):
+        """英語コードが正しい名前を返す。"""
+        assert get_language_name("en") == "English"
+
+    def test_known_german(self):
+        assert get_language_name("de") == "German"
+
+    def test_known_japanese(self):
+        assert get_language_name("ja") == "Japanese"
+
+    def test_known_italian(self):
+        assert get_language_name("it") == "Italian"
+
+    def test_known_dutch(self):
+        assert get_language_name("nl") == "Dutch"
+
+    def test_known_polish(self):
+        assert get_language_name("pl") == "Polish"
+
+    def test_unknown_code_returns_uppercase(self):
+        """未知コードは大文字にフォールバック。"""
+        assert get_language_name("xx") == "XX"
+
+    def test_case_insensitive(self):
+        """大文字コードも正しく処理される。"""
+        assert get_language_name("EN") == "English"
+        assert get_language_name("De") == "German"
+
+    def test_empty_string(self):
+        """空文字列はフォールバック。"""
+        assert get_language_name("") == ""

--- a/tests/unit/test_multilingual_scholar.py
+++ b/tests/unit/test_multilingual_scholar.py
@@ -1,0 +1,133 @@
+"""Multilingual Scholar の生成・instruction 検証テスト。"""
+
+from mystery_agents.agents.language_scholars import (
+    NAMED_SCHOLAR_LANGUAGES,
+    create_multilingual_scholar,
+    get_scholar_config,
+)
+
+
+class TestGetScholarConfig:
+    """get_scholar_config() のテスト。"""
+
+    def test_known_language_returns_config(self):
+        """SCHOLAR_CONFIGS に定義済みの言語は既存設定を返す。"""
+        config = get_scholar_config("en")
+        assert config["language_name"] == "English"
+        assert config["lang_code"] == "en"
+        assert "cultural_perspective" in config
+
+    def test_italian_returns_config(self):
+        """IT は新規追加された Named Scholar。"""
+        config = get_scholar_config("it")
+        assert config["language_name"] == "Italian"
+        assert "Microhistory" in config["cultural_perspective"]
+
+    def test_unknown_language_generates_template(self):
+        """未知の言語コードは汎用テンプレートを動的生成する。"""
+        config = get_scholar_config("pl")
+        assert config["language_name"] == "Polish"
+        assert config["lang_code"] == "pl"
+        assert "Polish" in config["cultural_perspective"]
+
+    def test_unknown_language_has_required_keys(self):
+        """動的生成された設定が必須キーを持つ。"""
+        config = get_scholar_config("sv")
+        assert "language_name" in config
+        assert "lang_code" in config
+        assert "cultural_perspective" in config
+
+
+class TestNamedScholarLanguages:
+    """NAMED_SCHOLAR_LANGUAGES 定数のテスト。"""
+
+    def test_contains_six_languages(self):
+        assert len(NAMED_SCHOLAR_LANGUAGES) == 6
+
+    def test_contains_expected_languages(self):
+        expected = {"en", "de", "ja", "fr", "es", "it"}
+        assert NAMED_SCHOLAR_LANGUAGES == expected
+
+    def test_nl_and_pt_not_in_named(self):
+        """NL, PT は Named ではなく Multilingual に振り分けられる。"""
+        assert "nl" not in NAMED_SCHOLAR_LANGUAGES
+        assert "pt" not in NAMED_SCHOLAR_LANGUAGES
+
+
+class TestCreateMultilingualScholar:
+    """create_multilingual_scholar() のテスト。"""
+
+    def test_analysis_mode_output_key(self):
+        """分析モードの output_key が scholar_analysis_multilingual であること。"""
+        scholar = create_multilingual_scholar(["nl", "pt"], mode="analysis")
+        assert scholar.output_key == "scholar_analysis_multilingual"
+
+    def test_analysis_mode_name(self):
+        scholar = create_multilingual_scholar(["nl", "pt"], mode="analysis")
+        assert "scholar_multilingual" in repr(scholar)
+
+    def test_analysis_instruction_references_documents(self):
+        """分析 instruction が対象言語の collected_documents を参照する。"""
+        scholar = create_multilingual_scholar(["nl", "pt"], mode="analysis")
+        assert "{collected_documents_nl}" in scholar.instruction
+        assert "{collected_documents_pt}" in scholar.instruction
+
+    def test_analysis_instruction_references_english(self):
+        """分析 instruction が英語 collected_documents も参照する。"""
+        scholar = create_multilingual_scholar(["nl", "pt"], mode="analysis")
+        assert "{collected_documents_en}" in scholar.instruction
+
+    def test_analysis_instruction_contains_language_names(self):
+        """分析 instruction に言語名が含まれる。"""
+        scholar = create_multilingual_scholar(["nl", "pt"], mode="analysis")
+        assert "Dutch" in scholar.instruction
+        assert "Portuguese" in scholar.instruction
+
+    def test_debate_mode_has_whiteboard_tool(self):
+        """討論モードが append_to_whiteboard ツールを持つ。"""
+        from mystery_agents.tools.debate_tools import append_to_whiteboard
+
+        scholar = create_multilingual_scholar(
+            ["nl", "pt"],
+            mode="debate",
+            active_named_langs=["en", "de"],
+        )
+        assert append_to_whiteboard in scholar.tools
+
+    def test_debate_mode_references_named_analyses(self):
+        """討論 instruction が Named Scholar の分析を参照する。"""
+        scholar = create_multilingual_scholar(
+            ["nl", "pt"],
+            mode="debate",
+            active_named_langs=["en", "de"],
+        )
+        assert "{scholar_analysis_en}" in scholar.instruction
+        assert "{scholar_analysis_de}" in scholar.instruction
+
+    def test_debate_mode_references_own_analysis(self):
+        """討論 instruction が自身の分析 (multilingual) を参照する。"""
+        scholar = create_multilingual_scholar(
+            ["nl", "pt"],
+            mode="debate",
+            active_named_langs=["en"],
+        )
+        assert "{scholar_analysis_multilingual}" in scholar.instruction
+
+    def test_debate_mode_name(self):
+        scholar = create_multilingual_scholar(
+            ["nl"], mode="debate", active_named_langs=["en"]
+        )
+        assert "scholar_multilingual_debate" in repr(scholar)
+
+    def test_invalid_mode_raises(self):
+        """不正なモードは ValueError。"""
+        import pytest
+
+        with pytest.raises(ValueError, match="Unknown mode"):
+            create_multilingual_scholar(["nl"], mode="invalid")
+
+    def test_single_language(self):
+        """1言語でも正常に生成される。"""
+        scholar = create_multilingual_scholar(["pl"], mode="analysis")
+        assert "{collected_documents_pl}" in scholar.instruction
+        assert "Polish" in scholar.instruction

--- a/tests/unit/test_wellcome_collection.py
+++ b/tests/unit/test_wellcome_collection.py
@@ -305,9 +305,13 @@ class TestHelperFunctions:
         assert _detect_language({"languages": [{"id": "ger"}]}) == SourceLanguage.DE
         assert _detect_language({"languages": [{"id": "deu"}]}) == SourceLanguage.DE
 
+    def test_detect_language_chinese(self):
+        """中国語（zho）は zh にマッピングされる。"""
+        assert _detect_language({"languages": [{"id": "zho"}]}) == "zh"
+
     def test_detect_language_unknown_defaults_to_en(self):
         """不明な言語コードは EN をデフォルトにする。"""
-        assert _detect_language({"languages": [{"id": "zho"}]}) == SourceLanguage.EN
+        assert _detect_language({"languages": [{"id": "xyz"}]}) == "en"
 
     def test_detect_language_empty_languages(self):
         """languages が空の場合は EN。"""


### PR DESCRIPTION
## Summary

パイプラインの Scholar/討論フェーズを **Named Scholar（6体）+ Multilingual Scholar（1体）** の2層構造に再設計し、カバー言語を無制限に拡張。

### 背景
- 現行の `SCHOLAR_CONFIGS`（7言語固定）が言語を制約していた
- `SourceLanguage` enum が7言語以外を EN にフォールバックし、新言語が流れなかった
- Europeana Librarian が1言語しか検索せず、多言語資料を取りこぼしていた
- 5学術領域スコアリングの結果、NL/PT は独自性が低く Multilingual で十分と判断

### 主な変更

**2層アーキテクチャ:**
- **Named Scholar（専用文化的視点）**: EN, DE, JA, FR, ES, IT（IT 新設）
- **Multilingual Scholar（周辺言語横断）**: NL, PT + Europeana/IA/Wellcome が返す全言語

**言語検出の動的化:**
- `SourceLanguage` enum → `str` 緩和（後方互換維持）
- Europeana/Internet Archive/Wellcome: 固定 enum マッピング廃止 → ISO 639-1 文字列を直接返却
- Europeana Librarian: テーマに応じた最大3言語での多言語検索指示

**共通基盤:**
- `shared/language_names.py`: ISO 639-1 → 英語言語名マッピング（50言語）
- `aggregator.py`: `_KNOWN_LANGUAGES` 廃止 → 動的キースキャン
- `publisher_tools.py`: `ALLOWED_LANGUAGES` → `active_languages` + multilingual 分析参照

### 変更ファイル一覧（18ファイル）

| カテゴリ | ファイル | 変更内容 |
|---------|---------|---------|
| 新規 | `shared/language_names.py` | ISO 639-1 → 英語言語名マッピング |
| スキーマ | `mystery_agents/schemas/document.py` | `language: SourceLanguage` → `language: str` |
| ツール | `mystery_agents/tools/europeana.py` | `_detect_language` → str 返却, IT 国マッピング追加 |
| ツール | `mystery_agents/tools/internet_archive.py` | 言語検出 → str 返却 |
| ツール | `mystery_agents/tools/wellcome_collection.py` | 言語検出 → str 返却, `zho`/`ita`/`lat`等追加 |
| ツール | `mystery_agents/tools/publisher_tools.py` | `active_languages` + multilingual 参照 |
| エージェント | `mystery_agents/agents/language_scholars.py` | IT追加, `NAMED_SCHOLAR_LANGUAGES`, `get_scholar_config()`, `create_multilingual_scholar()` |
| エージェント | `mystery_agents/agents/dynamic_scholar_block.py` | 2層ルーティング（Named + Multilingual 振り分け） |
| エージェント | `mystery_agents/agents/dynamic_polymath_block.py` | `scholar_analysis_multilingual` 参照対応 |
| エージェント | `mystery_agents/agents/aggregator.py` | 動的キースキャン, `get_language_name()` |
| エージェント | `mystery_agents/agents/api_librarians.py` | Europeana 多言語検索指示 |
| テスト新規 | `tests/unit/test_language_names.py` | `get_language_name()` テスト |
| テスト新規 | `tests/unit/test_multilingual_scholar.py` | Multilingual Scholar 生成・instruction 検証 |
| テスト更新 | `tests/unit/test_dynamic_scholar_block.py` | 2層ロジック、multilingual 討論参照 |
| テスト更新 | `tests/unit/test_dynamic_polymath_block.py` | multilingual 対応テスト |
| テスト更新 | `tests/unit/test_aggregator.py` | 動的キースキャン、未知言語テスト |
| テスト更新 | `tests/unit/test_europeana.py` | str 言語検出、IT 国フィルタ |
| テスト更新 | `tests/unit/test_wellcome_collection.py` | zho→zh マッピング追加 |

## Test plan

- [x] `pytest tests/unit/ -v` — 全1190テストパス（0 failure）
- [x] `pytest tests/integration/test_agent_handover.py` — Scholar/Polymath/Aggregator 関連34テストパス（3 failure は Podcast 関連の pre-existing issue）
- [ ] ローカル Docker パイプライン実行で active_languages ログ確認
- [ ] Firestore の pipeline_runs で Named + Multilingual Scholar 実行確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)