### PR TITLE
refactor: 失敗マーカー判定を shared/constants.py に集約

### DIFF
--- a/mystery_agents/agents/dynamic_polymath_block.py
+++ b/mystery_agents/agents/dynamic_polymath_block.py
@@ -17,6 +17,7 @@ from google.adk.agents.invocation_context import InvocationContext
 from google.adk.events.event import Event
 from google.genai import types
 
+from shared.constants import is_meaningful
 from shared.model_config import create_pro_model
 
 from .armchair_polymath import (
@@ -28,7 +29,7 @@ from .armchair_polymath import (
     log_polymath_tool_call,
 )
 from .language_scholars import get_scholar_config
-from .pipeline_gate import _is_meaningful, _log_and_record_failure
+from .pipeline_gate import _log_and_record_failure
 
 logger = logging.getLogger(__name__)
 
@@ -83,11 +84,11 @@ class DynamicPolymathBlock(BaseAgent):
         meaningful_langs = [
             lang
             for lang in active_langs
-            if _is_meaningful(state.get(f"scholar_analysis_{lang}", ""))
+            if is_meaningful(state.get(f"scholar_analysis_{lang}", ""))
         ]
 
         # Multilingual Scholar の有意性チェック
-        has_multilingual = _is_meaningful(
+        has_multilingual = is_meaningful(
             state.get("scholar_analysis_multilingual", "")
         )
 

--- a/mystery_agents/agents/dynamic_scholar_block.py
+++ b/mystery_agents/agents/dynamic_scholar_block.py
@@ -23,6 +23,7 @@ from google.adk.agents.invocation_context import InvocationContext
 from google.adk.events.event import Event, EventActions
 from google.genai import types
 
+from shared.constants import is_meaningful
 from shared.language_names import get_language_name
 
 from ..tools.debate_tools import is_debate_converged
@@ -32,7 +33,6 @@ from .language_scholars import (
     create_scholar,
     get_scholar_config,
 )
-from .pipeline_gate import _is_meaningful
 
 logger = logging.getLogger(__name__)
 
@@ -104,12 +104,12 @@ class DynamicScholarBlock(BaseAgent):
         # 有意な分析を出した Named Scholar を特定
         meaningful_named = [
             lang for lang in named_langs
-            if _is_meaningful(state.get(f"scholar_analysis_{lang}", ""))
+            if is_meaningful(state.get(f"scholar_analysis_{lang}", ""))
         ]
         # Multilingual Scholar の有意性チェック
         has_meaningful_multilingual = (
             bool(other_langs)
-            and _is_meaningful(state.get("scholar_analysis_multilingual", ""))
+            and is_meaningful(state.get("scholar_analysis_multilingual", ""))
         )
 
         # active_analyses_summary をステートに書き込み（ログ/診断用）

--- a/mystery_agents/agents/language_gate.py
+++ b/mystery_agents/agents/language_gate.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Optional
 
 from google.genai import types
 
-from shared.constants import DEFAULT_SELECTED_LANGUAGES
+from shared.constants import DEFAULT_SELECTED_LANGUAGES, is_meaningful
 
 if TYPE_CHECKING:
     from google.adk.agents.callback_context import CallbackContext
@@ -34,7 +34,7 @@ def make_debate_gate(lang_code: str):
             )
         # Scholar が有意な分析を出していない場合もスキップ
         analysis = callback_context.state.get(f"scholar_analysis_{lang_code}", "")
-        if not analysis or "INSUFFICIENT_DATA" in str(analysis) or "Not available" in str(analysis):
+        if not is_meaningful(analysis):
             return types.Content(
                 parts=[types.Part(text="")], role="model"
             )
@@ -59,11 +59,7 @@ def make_debate_loop_gate():
         meaningful = 0
         for lang in selected:
             analysis = callback_context.state.get(f"scholar_analysis_{lang}", "")
-            if (
-                analysis
-                and "INSUFFICIENT_DATA" not in str(analysis)
-                and "Not available" not in str(analysis)
-            ):
+            if is_meaningful(analysis):
                 meaningful += 1
 
         if meaningful < 2:

--- a/mystery_agents/agents/pipeline_gate.py
+++ b/mystery_agents/agents/pipeline_gate.py
@@ -11,33 +11,15 @@ from typing import TYPE_CHECKING, Optional
 
 from google.genai import types
 
-from shared.constants import DEFAULT_SELECTED_LANGUAGES
+from shared.constants import DEFAULT_SELECTED_LANGUAGES, is_meaningful
 
 if TYPE_CHECKING:
     from google.adk.agents.callback_context import CallbackContext
 
 logger = logging.getLogger(__name__)
 
-# 失敗マーカー
-_FAILURE_MARKERS = frozenset({
-    "NO_DOCUMENTS_FOUND",
-    "INSUFFICIENT_DATA",
-    "NO_CONTENT",
-    "Not available",
-})
-
-
-def _is_meaningful(value: str) -> bool:
-    """セッション状態の値が有意なデータを含むか判定する。
-
-    テキストの先頭が失敗マーカーで始まる場合のみ「無意味」と判定する。
-    ドキュメント本文の途中や末尾に部分的な失敗マーカーが含まれていても、
-    先頭に有意なデータがあれば有意とみなす。
-    """
-    if not value:
-        return False
-    text = str(value).strip()
-    return not any(text.startswith(marker) for marker in _FAILURE_MARKERS)
+# 後方互換エイリアス（既存コードが _is_meaningful を参照）
+_is_meaningful = is_meaningful
 
 
 def _log_and_record_failure(callback_context: CallbackContext, stage: str, message: str) -> None:

--- a/shared/constants.py
+++ b/shared/constants.py
@@ -1,12 +1,14 @@
 """パイプライン全体で使用される定数の一元管理。
 
-Python ロジック（言語選択、翻訳収集、ステータス設定等）で使用する定数を
-集約し、typo やコピペ不一致を防止する。
+Python ロジック（言語選択、翻訳収集、ステータス設定、失敗判定等）で
+使用する定数を集約し、typo やコピペ不一致を防止する。
 
 注意: エージェント instruction（LLM プロンプト）内の失敗マーカーリテラル
 （例: "Output INSUFFICIENT_DATA if ..."）はここでは管理しない。
 プロンプト内のリテラルは LLM が直接読むものであり、Python 定数に置換できない。
 """
+
+from __future__ import annotations
 
 # ---------------------------------------------------------------------------
 # 言語設定
@@ -28,3 +30,28 @@ STATUS_PUBLISHED = "published"
 
 # Firestore ドキュメント構造のバージョン
 SCHEMA_VERSION = 2
+
+# ---------------------------------------------------------------------------
+# 失敗マーカー
+# ---------------------------------------------------------------------------
+# エージェントが出力する失敗マーカー文字列。
+# セッション状態の値がこれらで始まる場合、有意なデータなしと判定する。
+FAILURE_MARKERS: frozenset[str] = frozenset({
+    "NO_DOCUMENTS_FOUND",
+    "INSUFFICIENT_DATA",
+    "NO_CONTENT",
+    "Not available",
+})
+
+
+def is_meaningful(value: str | None) -> bool:
+    """セッション状態の値が有意なデータを含むか判定する。
+
+    テキストの先頭が失敗マーカーで始まる場合のみ「無意味」と判定する。
+    ドキュメント本文の途中や末尾に部分的な失敗マーカーが含まれていても、
+    先頭に有意なデータがあれば有意とみなす。
+    """
+    if not value:
+        return False
+    text = str(value).strip()
+    return not any(text.startswith(marker) for marker in FAILURE_MARKERS)

--- a/shared/orchestrator.py
+++ b/shared/orchestrator.py
@@ -21,8 +21,8 @@ from google.adk.runners import Runner
 from google.adk.sessions import InMemorySessionService
 from google.genai import types
 
-from mystery_agents.agents.pipeline_gate import _is_meaningful
 from mystery_agents.utils.pipeline_logger import PipelineLogger
+from shared.constants import is_meaningful
 from shared.logging_config import PipelineContext, set_pipeline_context
 from shared.search_metrics import extract_search_metrics, save_search_metrics
 from shared.pipeline_run import (
@@ -133,7 +133,7 @@ def _detect_gate_failure(session_state: dict) -> tuple[str, dict]:
         detail["storyteller_llm_metadata"] = llm_meta
 
     mystery_report = session_state.get("mystery_report", "")
-    if not _is_meaningful(mystery_report):
+    if not is_meaningful(mystery_report):
         return "十分な資料が見つからなかったため、記事を生成できませんでした", {
             "error_type": "gate_failure",
             "failed_stage": "scholar/polymath",
@@ -141,7 +141,7 @@ def _detect_gate_failure(session_state: dict) -> tuple[str, dict]:
         }
 
     creative_content = session_state.get("creative_content", "")
-    if not _is_meaningful(creative_content):
+    if not is_meaningful(creative_content):
         return "記事の生成に失敗しました", {
             "error_type": "gate_failure",
             "failed_stage": "storyteller",

--- a/tests/unit/test_constants.py
+++ b/tests/unit/test_constants.py
@@ -3,7 +3,9 @@
 from shared.constants import (
     ALLOWED_LANGUAGES,
     DEFAULT_SELECTED_LANGUAGES,
+    FAILURE_MARKERS,
     TRANSLATION_LANGUAGES,
+    is_meaningful,
 )
 
 
@@ -21,3 +23,35 @@ class TestLanguageConstants:
     def test_default_selected_languages_is_sorted(self):
         """DEFAULT_SELECTED_LANGUAGES はソート済み。"""
         assert DEFAULT_SELECTED_LANGUAGES == sorted(DEFAULT_SELECTED_LANGUAGES)
+
+
+class TestIsMeaningful:
+    """is_meaningful() の仕様テスト。"""
+
+    def test_empty_string_is_not_meaningful(self):
+        assert is_meaningful("") is False
+
+    def test_none_is_not_meaningful(self):
+        assert is_meaningful(None) is False
+
+    def test_failure_markers_at_start_are_not_meaningful(self):
+        """全失敗マーカーが先頭にある場合、無意味と判定する。"""
+        for marker in FAILURE_MARKERS:
+            assert is_meaningful(f"{marker}: details here") is False
+
+    def test_real_content_is_meaningful(self):
+        assert is_meaningful("The Bell Witch haunting of Adams, Tennessee...") is True
+
+    def test_trailing_failure_marker_is_still_meaningful(self):
+        """本文末尾に失敗マーカーがあっても、先頭が有意なら有意と判定する。"""
+        text = (
+            "**Document 1**\n"
+            "- **Title**: A history of Block Island\n"
+            "\n---\n\n"
+            "NO_DOCUMENTS_FOUND: No documents found."
+        )
+        assert is_meaningful(text) is True
+
+    def test_whitespace_before_failure_marker_is_not_meaningful(self):
+        """先頭に空白があっても失敗マーカーで始まれば無意味と判定する。"""
+        assert is_meaningful("  NO_DOCUMENTS_FOUND: nothing.") is False


### PR DESCRIPTION
## Summary
- `FAILURE_MARKERS` + `is_meaningful()` を `shared/constants.py` に集約
- `pipeline_gate._is_meaningful` / `language_gate` のインラインチェック / `orchestrator` のクロスパッケージ private import を統一
- `language_gate` の `in`（含む）ベースチェックを `startswith`（先頭一致）に統一（Scholar の失敗出力は常に先頭がマーカーのため安全）

## 変更ファイル（7ファイル）
- `shared/constants.py` — `FAILURE_MARKERS` + `is_meaningful()` 追加
- `mystery_agents/agents/pipeline_gate.py` — `_FAILURE_MARKERS` / `_is_meaningful` 削除、後方互換エイリアス残置
- `mystery_agents/agents/language_gate.py` — `is_meaningful()` に統一
- `mystery_agents/agents/dynamic_scholar_block.py` — import 先変更
- `mystery_agents/agents/dynamic_polymath_block.py` — import 先変更
- `shared/orchestrator.py` — クロスパッケージ private import 解消
- `tests/unit/test_constants.py` — `is_meaningful` テスト追加

## Test plan
- [x] `pytest tests/unit/test_pipeline_gate.py` — 19 tests passed
- [x] `pytest tests/unit/test_language_gate.py` — 21 tests passed
- [x] `pytest tests/unit/test_constants.py` — 9 tests passed (3 existing + 6 new)
- [x] `ruff check` — all passed
- [x] `from mystery_agents.agent import root_agent` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)