### PR TITLE
refactor: curator_agents DRY 違反解消（ADK ランナー一元化 + ビジネスロジック集約）

### DIFF
--- a/curator_agents/cli.py
+++ b/curator_agents/cli.py
@@ -1,8 +1,7 @@
 """Curator - CLI Entry Point
 
 Suggests investigation themes for the Ghost in the Archive blog pipeline.
-Fetches existing mystery titles from Firestore to avoid duplicates,
-then runs the Curator agent to generate new theme ideas.
+Delegates to core.suggest_themes() for the actual logic.
 
 Outputs JSON to stdout (last line) for consumption by the web API.
 
@@ -19,83 +18,27 @@ from dotenv import load_dotenv
 
 load_dotenv(Path(__file__).parent.parent / ".env")
 
-from google.adk.runners import Runner
-from google.adk.sessions import InMemorySessionService
-from google.genai import types
-
-from .agents.curator import curator_agent
-from .queries import get_existing_titles, get_category_distribution, format_category_distribution
-from .schemas import strip_markdown_codeblock, validate_suggestions
-from shared.pipeline_failure import get_recent_failures
+from .core import suggest_themes
 
 
-async def suggest_themes() -> None:
+async def _run() -> None:
     """Run the Curator agent and output JSON to stdout."""
-    # 3つの Firestore クエリを並列実行
-    existing_titles, recent_failures, distribution = await asyncio.gather(
-        asyncio.to_thread(get_existing_titles),
-        asyncio.to_thread(get_recent_failures, 20),
-        asyncio.to_thread(get_category_distribution),
-    )
-
-    titles_text = "\n".join(f"- {t}" for t in existing_titles) if existing_titles else "(なし - まだ調査済みのテーマはありません)"
-
-    failed_themes = list({f["theme"] for f in recent_failures if f.get("theme")})
-    failed_themes_text = (
-        "\n".join(f"- {t}" for t in failed_themes)
-        if failed_themes
-        else "(None)"
-    )
-
-    category_distribution_text = format_category_distribution(distribution)
-
-    session_service = InMemorySessionService()
-    runner = Runner(
-        agent=curator_agent,
-        app_name="ghost_in_the_archive_curator",
-        session_service=session_service,
-    )
-
-    user_id = "curator"
-    session_id = "theme_suggestion"
-
-    await session_service.create_session(
-        app_name="ghost_in_the_archive_curator",
-        user_id=user_id,
-        session_id=session_id,
-        state={
-            "existing_titles": titles_text,
-            "failed_themes": failed_themes_text,
-            "category_distribution": category_distribution_text,
-        },
-    )
-
-    result_text = ""
-    async for event in runner.run_async(
-        user_id=user_id,
-        session_id=session_id,
-        new_message=types.Content(
-            role="user",
-            parts=[types.Part(text="調査テーマを5件提案してください。")],
-        ),
-    ):
-        if event.content and event.content.parts:
-            for part in event.content.parts:
-                if hasattr(part, "text") and part.text:
-                    result_text += part.text
-
-    # マークダウンコードブロック除去 + JSON パース + スキーマ検証
-    cleaned = strip_markdown_codeblock(result_text)
-
     try:
-        raw_suggestions = json.loads(cleaned)
+        suggestions = await suggest_themes(
+            user_message="調査テーマを5件提案してください。",
+            empty_titles_text="(なし - まだ調査済みのテーマはありません)",
+        )
     except json.JSONDecodeError:
-        print(json.dumps({"error": "Failed to parse suggestions", "raw": result_text[:500]}, ensure_ascii=False))
+        print(json.dumps(
+            {"error": "Failed to parse suggestions"},
+            ensure_ascii=False,
+        ))
         sys.exit(1)
-
-    suggestions = validate_suggestions(raw_suggestions)
-    if not suggestions:
-        print(json.dumps({"error": "All suggestions failed schema validation", "raw": result_text[:500]}, ensure_ascii=False))
+    except ValueError as e:
+        print(json.dumps(
+            {"error": str(e)},
+            ensure_ascii=False,
+        ))
         sys.exit(1)
 
     print(json.dumps(suggestions, ensure_ascii=False))
@@ -103,7 +46,7 @@ async def suggest_themes() -> None:
 
 def main():
     """Main entry point."""
-    asyncio.run(suggest_themes())
+    asyncio.run(_run())
 
 
 if __name__ == "__main__":

--- a/curator_agents/core.py
+++ b/curator_agents/core.py
@@ -1,0 +1,99 @@
+"""Curator ビジネスロジック — テーマ提案の共通処理を一元管理。
+
+CLI (`cli.py`) と HTTP サービス (`services/curator.py`) の両方から呼ばれる。
+Firestore クエリ → セッション状態構築 → エージェント実行 → JSON パース・検証
+の一連の処理を `suggest_themes()` に集約する。
+"""
+
+import asyncio
+import json
+import logging
+
+from .agents.curator import curator_agent
+from .queries import (
+    get_existing_titles,
+    get_category_distribution,
+    format_category_distribution,
+)
+from .runner import run_single_agent
+from .schemas import strip_markdown_codeblock, validate_suggestions
+from shared.constants import is_meaningful
+from shared.pipeline_failure import get_recent_failures
+
+logger = logging.getLogger(__name__)
+
+
+async def suggest_themes(
+    *,
+    user_message: str = "Suggest 5 research themes.",
+    empty_titles_text: str = "(None - no themes have been investigated yet)",
+) -> list[dict]:
+    """テーマ提案の共通ロジック。
+
+    1. Firestore 3クエリ並列実行（既存タイトル, 最近の失敗, カテゴリ分布）
+    2. テキスト整形 + セッション状態構築
+    3. Curator エージェント実行
+    4. マークダウンコードブロック除去 + JSON パース + バリデーション
+
+    Args:
+        user_message: エージェントに送信するメッセージ（CLI: 日本語、サービス: 英語）
+        empty_titles_text: 既存タイトルが0件の場合の表示テキスト
+
+    Returns:
+        検証済みテーマ提案の dict リスト
+
+    Raises:
+        json.JSONDecodeError: エージェント出力の JSON パースに失敗した場合
+        ValueError: 全件バリデーション失敗の場合
+    """
+    # Firestore 3クエリを並列実行
+    existing_titles, recent_failures, distribution = await asyncio.gather(
+        asyncio.to_thread(get_existing_titles),
+        asyncio.to_thread(get_recent_failures, 20),
+        asyncio.to_thread(get_category_distribution),
+    )
+
+    titles_text = (
+        "\n".join(f"- {t}" for t in existing_titles)
+        if existing_titles
+        else empty_titles_text
+    )
+
+    failed_themes = list({f["theme"] for f in recent_failures if f.get("theme")})
+    failed_themes_text = (
+        "\n".join(f"- {t}" for t in failed_themes) if failed_themes else "(None)"
+    )
+
+    category_distribution_text = format_category_distribution(distribution)
+
+    result_text = await run_single_agent(
+        curator_agent,
+        app_name="ghost_in_the_archive_curator",
+        user_id="curator",
+        session_id="theme_suggestion",
+        state={
+            "existing_titles": titles_text,
+            "failed_themes": failed_themes_text,
+            "category_distribution": category_distribution_text,
+        },
+        user_message=user_message,
+    )
+
+    # 失敗マーカー早期検出（JSONDecodeError より先に判定）
+    if not is_meaningful(result_text):
+        raise ValueError(
+            f"Agent returned failure marker. Raw: {result_text[:500]}"
+        )
+
+    # マークダウンコードブロック除去 + JSON パース
+    cleaned = strip_markdown_codeblock(result_text)
+    raw_suggestions = json.loads(cleaned)
+
+    # スキーマ検証
+    suggestions = validate_suggestions(raw_suggestions)
+    if not suggestions:
+        raise ValueError(
+            f"All suggestions failed schema validation. Raw: {result_text[:500]}"
+        )
+
+    return suggestions

--- a/curator_agents/runner.py
+++ b/curator_agents/runner.py
@@ -1,0 +1,66 @@
+"""ADK 軽量実行ヘルパー — 単一エージェント1回実行のボイラープレートを一元化。
+
+shared/orchestrator.py は blog/podcast パイプライン向けの重量級ランナー
+（PipelineLogger, pipeline_run 等を含む）。Curator の「単一エージェント1回実行」
+ユースケースとは目的が異なるため、curator_agents 内に軽量ヘルパーとして配置する。
+"""
+
+from google.adk.runners import Runner
+from google.adk.sessions import InMemorySessionService
+from google.genai import types
+
+
+async def run_single_agent(
+    agent,
+    *,
+    app_name: str,
+    user_id: str,
+    session_id: str,
+    state: dict,
+    user_message: str,
+) -> str:
+    """単一 ADK エージェントを1回実行し、テキスト出力を返す。
+
+    InMemorySessionService でセッションを作成し、Runner.run_async で
+    イベントを収集して結合テキストを返す。
+
+    Args:
+        agent: 実行する ADK エージェント（LlmAgent 等）
+        app_name: ADK アプリケーション名
+        user_id: セッションのユーザー ID
+        session_id: セッション ID
+        state: セッション初期状態の dict
+        user_message: エージェントに送信するユーザーメッセージ
+
+    Returns:
+        エージェントの全テキスト出力を結合した文字列
+    """
+    session_service = InMemorySessionService()
+    runner = Runner(
+        agent=agent,
+        app_name=app_name,
+        session_service=session_service,
+    )
+
+    await session_service.create_session(
+        app_name=app_name,
+        user_id=user_id,
+        session_id=session_id,
+        state=state,
+    )
+
+    result_text = ""
+    async for event in runner.run_async(
+        user_id=user_id,
+        session_id=session_id,
+        new_message=types.Content(
+            role="user",
+            parts=[types.Part(text=user_message)],
+        ),
+    ):
+        if event.content and event.content.parts:
+            for part in event.content.parts:
+                if hasattr(part, "text") and part.text:
+                    result_text += part.text
+
+    return result_text

--- a/curator_agents/schemas.py
+++ b/curator_agents/schemas.py
@@ -47,7 +47,7 @@ def validate_suggestions(raw: list) -> list[dict]:
         try:
             suggestion = ThemeSuggestion.model_validate(item)
             valid.append(suggestion.model_dump())
-        except (ValidationError, Exception) as e:
+        except ValidationError as e:
             logger.warning("テーマ提案 #%d を除外: %s (データ: %s)", i, e, item)
     return valid
 

--- a/services/curator.py
+++ b/services/curator.py
@@ -9,7 +9,6 @@ Endpoints:
     GET  /health         - Health check
 """
 
-import asyncio
 import json
 import logging
 import os
@@ -18,43 +17,34 @@ from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 import uvicorn
 
-from google.adk.runners import Runner
-from google.adk.sessions import InMemorySessionService
-from google.genai import types
-
-from curator_agents.agents.curator import curator_agent
-from curator_agents.queries import (
-    get_existing_titles,
-    get_category_distribution,
-    format_category_distribution,
-)
-from curator_agents.schemas import strip_markdown_codeblock, validate_suggestions
+from curator_agents.core import suggest_themes as run_curator
+from curator_agents.runner import run_single_agent
+from curator_agents.schemas import strip_markdown_codeblock
 from mystery_agents.agents.translator import translator_agent
-from shared.logging_config import PipelineContext, set_pipeline_context, setup_logging
-from shared.pipeline_failure import get_recent_failures
+from shared.logging_config import (
+    PipelineContext,
+    set_pipeline_context,
+    setup_logging,
+    suppress_health_check_logs,
+)
 
 # プロジェクト全体のログを有効化（Cloud Run: JSON / ローカル: プレーンテキスト）
 setup_logging()
+suppress_health_check_logs()
 
 logger = logging.getLogger(__name__)
 
-
-class _HealthCheckFilter(logging.Filter):
-    """ヘルスチェック（/health）の INFO ログを抑制する。"""
-
-    def filter(self, record: logging.LogRecord) -> bool:
-        if record.levelno >= logging.WARNING:
-            return True
-        msg = record.getMessage()
-        if "/health" in msg:
-            return False
-        return True
-
-
-logging.getLogger("uvicorn.access").addFilter(_HealthCheckFilter())
-
 # 認証エラーを示すキーワード
 _AUTH_ERROR_KEYWORDS = ("reauthentication", "default credentials", "invalid_grant")
+
+# Translator のインストラクションが {creative_content}, {mystery_report},
+# {structured_report} を参照するため、空文字で初期化する必須ワークアラウンド。
+# Curator 経由の場合はユーザーメッセージの JSON が翻訳ソースとなる。
+_TRANSLATOR_EMPTY_STATE = {
+    "creative_content": "",
+    "mystery_report": "",
+    "structured_report": "",
+}
 
 app = FastAPI()
 
@@ -63,71 +53,6 @@ def _is_auth_error(error: Exception) -> bool:
     """例外が Google Cloud 認証エラーかどうかを判定する。"""
     msg = str(error).lower()
     return any(kw in msg for kw in _AUTH_ERROR_KEYWORDS)
-
-
-async def run_curator() -> list[dict]:
-    """Run the Curator agent and return parsed English suggestions."""
-    # 3つの Firestore クエリを並列実行
-    existing_titles, recent_failures, distribution = await asyncio.gather(
-        asyncio.to_thread(get_existing_titles),
-        asyncio.to_thread(get_recent_failures, 20),
-        asyncio.to_thread(get_category_distribution),
-    )
-
-    titles_text = (
-        "\n".join(f"- {t}" for t in existing_titles)
-        if existing_titles
-        else "(None - no themes have been investigated yet)"
-    )
-
-    failed_themes = list({f["theme"] for f in recent_failures if f.get("theme")})
-    failed_themes_text = (
-        "\n".join(f"- {t}" for t in failed_themes)
-        if failed_themes
-        else "(None)"
-    )
-
-    category_distribution_text = format_category_distribution(distribution)
-
-    session_service = InMemorySessionService()
-    runner = Runner(
-        agent=curator_agent,
-        app_name="ghost_in_the_archive_curator",
-        session_service=session_service,
-    )
-
-    user_id = "curator"
-    session_id = "theme_suggestion"
-
-    await session_service.create_session(
-        app_name="ghost_in_the_archive_curator",
-        user_id=user_id,
-        session_id=session_id,
-        state={
-            "existing_titles": titles_text,
-            "failed_themes": failed_themes_text,
-            "category_distribution": category_distribution_text,
-        },
-    )
-
-    result_text = ""
-    async for event in runner.run_async(
-        user_id=user_id,
-        session_id=session_id,
-        new_message=types.Content(
-            role="user",
-            parts=[types.Part(text="Suggest 5 research themes.")],
-        ),
-    ):
-        if event.content and event.content.parts:
-            for part in event.content.parts:
-                if hasattr(part, "text") and part.text:
-                    result_text += part.text
-
-    # マークダウンコードブロック除去 + JSON パース + スキーマ検証
-    cleaned = strip_markdown_codeblock(result_text)
-    raw_suggestions = json.loads(cleaned)
-    return validate_suggestions(raw_suggestions)
 
 
 async def translate_suggestions(suggestions: list[dict]) -> list[dict]:
@@ -147,46 +72,17 @@ async def translate_suggestions(suggestions: list[dict]) -> list[dict]:
         ],
     }
 
-    session_service = InMemorySessionService()
-    runner = Runner(
-        agent=translator_agent,
+    result_text = await run_single_agent(
+        translator_agent,
         app_name="ghost_in_the_archive_curator_translator",
-        session_service=session_service,
-    )
-
-    user_id = "curator_translator"
-    session_id = "theme_translation"
-
-    await session_service.create_session(
-        app_name="ghost_in_the_archive_curator_translator",
-        user_id=user_id,
-        session_id=session_id,
-        # Translator のインストラクションが {creative_content}, {mystery_report},
-        # {structured_report} を参照するため、空文字で初期化する。
-        # Curator 経由の場合はユーザーメッセージの JSON が翻訳ソースとなる。
-        state={
-            "creative_content": "",
-            "mystery_report": "",
-            "structured_report": "",
-        },
-    )
-
-    result_text = ""
-    async for event in runner.run_async(
-        user_id=user_id,
-        session_id=session_id,
-        new_message=types.Content(
-            role="user",
-            parts=[types.Part(text=(
-                f"Translate the following theme suggestions to Japanese:\n\n"
-                f"{json.dumps(translation_input, ensure_ascii=False, indent=2)}"
-            ))],
+        user_id="curator_translator",
+        session_id="theme_translation",
+        state=_TRANSLATOR_EMPTY_STATE,
+        user_message=(
+            f"Translate the following theme suggestions to Japanese:\n\n"
+            f"{json.dumps(translation_input, ensure_ascii=False, indent=2)}"
         ),
-    ):
-        if event.content and event.content.parts:
-            for part in event.content.parts:
-                if hasattr(part, "text") and part.text:
-                    result_text += part.text
+    )
 
     # マークダウンコードブロック除去
     cleaned = strip_markdown_codeblock(result_text)

--- a/services/pipeline_server.py
+++ b/services/pipeline_server.py
@@ -31,34 +31,14 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 import uvicorn
 
-from shared.logging_config import setup_logging
+from shared.logging_config import setup_logging, suppress_health_check_logs
 from shared.pipeline_run import create_pipeline_run, error_pipeline_run
 
 # プロジェクト全体のログを有効化（Cloud Run: JSON / ローカル: プレーンテキスト）
 setup_logging()
+suppress_health_check_logs()
 
 logger = logging.getLogger(__name__)
-
-
-class _HealthCheckFilter(logging.Filter):
-    """ヘルスチェック（/health）の INFO ログを抑制する。
-
-    Cloud Run のヘルスチェックは数秒ごとに発火し、ログが大量に生成されるため
-    INFO 以下を除外する。WARNING 以上は通す。
-    """
-
-    def filter(self, record: logging.LogRecord) -> bool:
-        if record.levelno >= logging.WARNING:
-            return True
-        msg = record.getMessage()
-        # uvicorn のアクセスログ: "GET /health HTTP/1.1"
-        if "/health" in msg:
-            return False
-        return True
-
-
-# uvicorn のアクセスログにフィルタ適用
-logging.getLogger("uvicorn.access").addFilter(_HealthCheckFilter())
 
 app = FastAPI()
 

--- a/shared/logging_config.py
+++ b/shared/logging_config.py
@@ -141,6 +141,27 @@ def _is_cloud_run() -> bool:
     return bool(os.environ.get("K_SERVICE"))
 
 
+class HealthCheckFilter(logging.Filter):
+    """ヘルスチェック（/health）の INFO ログを抑制する。
+
+    Cloud Run のヘルスチェックは数秒ごとに発火し、ログが大量に生成されるため
+    INFO 以下を除外する。WARNING 以上は通す。
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.levelno >= logging.WARNING:
+            return True
+        msg = record.getMessage()
+        if "/health" in msg:
+            return False
+        return True
+
+
+def suppress_health_check_logs() -> None:
+    """uvicorn のアクセスログにヘルスチェックフィルタを適用する。"""
+    logging.getLogger("uvicorn.access").addFilter(HealthCheckFilter())
+
+
 def setup_logging(*, force: bool = False) -> None:
     """root logger を初期化する。
 

--- a/tests/unit/test_curator_core.py
+++ b/tests/unit/test_curator_core.py
@@ -1,0 +1,143 @@
+"""Unit tests for curator_agents/core.py — テーマ提案共通ロジック。"""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_firestore_queries():
+    """Firestore クエリ3つをモック。"""
+    with patch("curator_agents.core.get_existing_titles", return_value=["Theme A"]), \
+         patch("curator_agents.core.get_recent_failures", return_value=[]), \
+         patch("curator_agents.core.get_category_distribution", return_value={"HIS": 2}), \
+         patch("curator_agents.core.format_category_distribution", return_value="HIS: 2"):
+        yield
+
+
+@pytest.fixture
+def valid_agent_output():
+    """Curator エージェントの正常な JSON 出力。"""
+    return json.dumps([
+        {"theme": "Theme X", "description": "Desc X", "category": "OCC"},
+        {"theme": "Theme Y", "description": "Desc Y", "category": "FLK"},
+    ])
+
+
+class TestSuggestThemes:
+    """suggest_themes() のテスト。"""
+
+    @pytest.mark.asyncio
+    async def test_returns_validated_suggestions(
+        self, mock_firestore_queries, valid_agent_output
+    ):
+        """Should return validated suggestion dicts on success."""
+        with patch(
+            "curator_agents.core.run_single_agent",
+            new_callable=AsyncMock,
+            return_value=valid_agent_output,
+        ):
+            from curator_agents.core import suggest_themes
+
+            result = await suggest_themes()
+
+        assert len(result) == 2
+        assert result[0]["theme"] == "Theme X"
+        assert result[0]["category"] == "OCC"
+        assert result[1]["theme"] == "Theme Y"
+
+    @pytest.mark.asyncio
+    async def test_raises_json_decode_error_on_invalid_json(
+        self, mock_firestore_queries
+    ):
+        """Should raise JSONDecodeError when agent output is not valid JSON."""
+        with patch(
+            "curator_agents.core.run_single_agent",
+            new_callable=AsyncMock,
+            return_value="not valid json at all",
+        ):
+            from curator_agents.core import suggest_themes
+
+            with pytest.raises(json.JSONDecodeError):
+                await suggest_themes()
+
+    @pytest.mark.asyncio
+    async def test_raises_value_error_when_all_fail_validation(
+        self, mock_firestore_queries
+    ):
+        """Should raise ValueError when all suggestions fail schema validation."""
+        # category が不正 → 全件バリデーション失敗
+        invalid_output = json.dumps([
+            {"theme": "T", "description": "D", "category": "INVALID"},
+        ])
+        with patch(
+            "curator_agents.core.run_single_agent",
+            new_callable=AsyncMock,
+            return_value=invalid_output,
+        ):
+            from curator_agents.core import suggest_themes
+
+            with pytest.raises(ValueError, match="All suggestions failed"):
+                await suggest_themes()
+
+    @pytest.mark.asyncio
+    async def test_passes_custom_user_message(self, mock_firestore_queries, valid_agent_output):
+        """Should pass user_message and empty_titles_text to agent."""
+        with patch(
+            "curator_agents.core.run_single_agent",
+            new_callable=AsyncMock,
+            return_value=valid_agent_output,
+        ) as mock_runner:
+            from curator_agents.core import suggest_themes
+
+            await suggest_themes(
+                user_message="テーマを提案",
+                empty_titles_text="(なし)",
+            )
+
+        # run_single_agent の呼び出し引数を検証
+        call_kwargs = mock_runner.call_args.kwargs
+        assert call_kwargs["user_message"] == "テーマを提案"
+
+    @pytest.mark.asyncio
+    async def test_strips_markdown_codeblock(self, mock_firestore_queries):
+        """Should handle agent output wrapped in markdown code blocks."""
+        wrapped = '```json\n[{"theme": "T", "description": "D", "category": "HIS"}]\n```'
+        with patch(
+            "curator_agents.core.run_single_agent",
+            new_callable=AsyncMock,
+            return_value=wrapped,
+        ):
+            from curator_agents.core import suggest_themes
+
+            result = await suggest_themes()
+
+        assert len(result) == 1
+        assert result[0]["theme"] == "T"
+
+    @pytest.mark.asyncio
+    async def test_raises_value_error_on_failure_marker(self, mock_firestore_queries):
+        """Should raise ValueError when agent returns a failure marker."""
+        with patch(
+            "curator_agents.core.run_single_agent",
+            new_callable=AsyncMock,
+            return_value="INSUFFICIENT_DATA: No suitable themes could be generated",
+        ):
+            from curator_agents.core import suggest_themes
+
+            with pytest.raises(ValueError, match="failure marker"):
+                await suggest_themes()
+
+    @pytest.mark.asyncio
+    async def test_raises_value_error_on_empty_output(self, mock_firestore_queries):
+        """Should raise ValueError when agent returns empty output."""
+        with patch(
+            "curator_agents.core.run_single_agent",
+            new_callable=AsyncMock,
+            return_value="",
+        ):
+            from curator_agents.core import suggest_themes
+
+            with pytest.raises(ValueError, match="failure marker"):
+                await suggest_themes()

--- a/tests/unit/test_curator_runner.py
+++ b/tests/unit/test_curator_runner.py
@@ -1,0 +1,125 @@
+"""Unit tests for curator_agents/runner.py — ADK 軽量実行ヘルパー。"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class TestRunSingleAgent:
+    """run_single_agent() のテスト。"""
+
+    @pytest.mark.asyncio
+    async def test_collects_text_from_events(self):
+        """Should concatenate text from all event parts."""
+        # 2つのイベントを返すモック
+        event1 = MagicMock()
+        part1 = MagicMock()
+        part1.text = "Hello "
+        event1.content.parts = [part1]
+
+        event2 = MagicMock()
+        part2 = MagicMock()
+        part2.text = "World"
+        event2.content.parts = [part2]
+
+        async def mock_run_async(**kwargs):
+            yield event1
+            yield event2
+
+        with patch("curator_agents.runner.Runner") as MockRunner, \
+             patch("curator_agents.runner.InMemorySessionService") as MockSession:
+            mock_runner = MagicMock()
+            mock_runner.run_async = mock_run_async
+            MockRunner.return_value = mock_runner
+            mock_session = AsyncMock()
+            MockSession.return_value = mock_session
+
+            from curator_agents.runner import run_single_agent
+
+            result = await run_single_agent(
+                MagicMock(),
+                app_name="test_app",
+                user_id="user1",
+                session_id="sess1",
+                state={"key": "value"},
+                user_message="test message",
+            )
+
+        assert result == "Hello World"
+        # セッション作成時に state が渡されることを検証
+        mock_session.create_session.assert_called_once()
+        call_kwargs = mock_session.create_session.call_args.kwargs
+        assert call_kwargs["state"] == {"key": "value"}
+        assert call_kwargs["user_id"] == "user1"
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_string_when_no_events(self):
+        """Should return empty string when agent produces no output."""
+
+        async def mock_run_async(**kwargs):
+            return
+            yield  # noqa: RET504 — async generator requires yield
+
+        with patch("curator_agents.runner.Runner") as MockRunner, \
+             patch("curator_agents.runner.InMemorySessionService") as MockSession:
+            mock_runner = MagicMock()
+            mock_runner.run_async = mock_run_async
+            MockRunner.return_value = mock_runner
+            mock_session = AsyncMock()
+            MockSession.return_value = mock_session
+
+            from curator_agents.runner import run_single_agent
+
+            result = await run_single_agent(
+                MagicMock(),
+                app_name="test_app",
+                user_id="user1",
+                session_id="sess1",
+                state={},
+                user_message="test",
+            )
+
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_skips_events_without_content(self):
+        """Should skip events with no content or no parts."""
+        # content が None のイベント
+        event_no_content = MagicMock()
+        event_no_content.content = None
+
+        # content.parts が None のイベント
+        event_no_parts = MagicMock()
+        event_no_parts.content.parts = None
+
+        # 正常なイベント
+        event_ok = MagicMock()
+        part = MagicMock()
+        part.text = "result"
+        event_ok.content.parts = [part]
+
+        async def mock_run_async(**kwargs):
+            yield event_no_content
+            yield event_no_parts
+            yield event_ok
+
+        with patch("curator_agents.runner.Runner") as MockRunner, \
+             patch("curator_agents.runner.InMemorySessionService") as MockSession:
+            mock_runner = MagicMock()
+            mock_runner.run_async = mock_run_async
+            MockRunner.return_value = mock_runner
+            mock_session = AsyncMock()
+            MockSession.return_value = mock_session
+
+            from curator_agents.runner import run_single_agent
+
+            result = await run_single_agent(
+                MagicMock(),
+                app_name="test_app",
+                user_id="u",
+                session_id="s",
+                state={},
+                user_message="msg",
+            )
+
+        assert result == "result"

--- a/tests/unit/test_curator_server.py
+++ b/tests/unit/test_curator_server.py
@@ -302,39 +302,21 @@ class TestTranslateSuggestionsMerge:
             ]
         })
 
-        # Runner.run_async をモックし、Translator の出力をシミュレート
-        mock_event = MagicMock()
-        mock_part = MagicMock()
-        mock_part.text = translator_output
-        mock_event.content.parts = [mock_part]
+        # run_single_agent をモックし、user_message をキャプチャ
+        captured_messages = []
 
-        async def mock_run_async(**kwargs):
-            yield mock_event
+        async def mock_run(agent, **kwargs):
+            captured_messages.append(kwargs.get("user_message", ""))
+            return translator_output
 
-        # json.dumps をスパイして translation_input をキャプチャ
-        captured_inputs = []
-        _original_dumps = json.dumps
-
-        def _spy_dumps(obj, *args, **kwargs):
-            if isinstance(obj, dict) and "suggestions" in obj:
-                captured_inputs.append(obj)
-            return _original_dumps(obj, *args, **kwargs)
-
-        with patch("services.curator.Runner") as MockRunner, \
-             patch("services.curator.InMemorySessionService") as MockSessionService, \
-             patch.object(json, "dumps", side_effect=_spy_dumps):
-            mock_runner_instance = MagicMock()
-            mock_runner_instance.run_async = mock_run_async
-            MockRunner.return_value = mock_runner_instance
-            mock_session = AsyncMock()
-            MockSessionService.return_value = mock_session
-
+        with patch("services.curator.run_single_agent", side_effect=mock_run):
             from services.curator import translate_suggestions
             result = await translate_suggestions(en_suggestions)
 
         # Translator への入力に category が含まれないことを検証
-        assert len(captured_inputs) == 1
-        for s in captured_inputs[0]["suggestions"]:
+        assert len(captured_messages) == 1
+        input_json = json.loads(captured_messages[0].split("\n\n", 1)[1])
+        for s in input_json["suggestions"]:
             assert "category" not in s, "Translator 入力に category が混入している"
 
         assert len(result) == 2
@@ -351,22 +333,10 @@ class TestTranslateSuggestionsMerge:
             {"theme": "Ghost Ships", "description": "Maritime mysteries"},
         ]
 
-        mock_event = MagicMock()
-        mock_part = MagicMock()
-        mock_part.text = "not valid json"
-        mock_event.content.parts = [mock_part]
+        async def mock_run(agent, **kwargs):
+            return "not valid json"
 
-        async def mock_run_async(**kwargs):
-            yield mock_event
-
-        with patch("services.curator.Runner") as MockRunner, \
-             patch("services.curator.InMemorySessionService") as MockSessionService:
-            mock_runner_instance = MagicMock()
-            mock_runner_instance.run_async = mock_run_async
-            MockRunner.return_value = mock_runner_instance
-            mock_session = AsyncMock()
-            MockSessionService.return_value = mock_session
-
+        with patch("services.curator.run_single_agent", side_effect=mock_run):
             from services.curator import translate_suggestions
             with caplog.at_level(logging.WARNING, logger="services.curator"):
                 result = await translate_suggestions(en_suggestions)

--- a/tests/unit/test_health_check_filter.py
+++ b/tests/unit/test_health_check_filter.py
@@ -1,0 +1,39 @@
+"""Unit tests for shared/logging_config.py — HealthCheckFilter。"""
+
+import logging
+
+from shared.logging_config import HealthCheckFilter
+
+
+class TestHealthCheckFilter:
+    """HealthCheckFilter のテスト。"""
+
+    def _make_record(self, msg: str, level: int = logging.INFO) -> logging.LogRecord:
+        """テスト用 LogRecord を生成する。"""
+        return logging.LogRecord(
+            name="uvicorn.access",
+            level=level,
+            pathname="",
+            lineno=0,
+            msg=msg,
+            args=(),
+            exc_info=None,
+        )
+
+    def test_suppresses_health_check_info_log(self):
+        """Should suppress INFO log containing /health."""
+        f = HealthCheckFilter()
+        record = self._make_record('GET /health HTTP/1.1 200')
+        assert f.filter(record) is False
+
+    def test_passes_non_health_info_log(self):
+        """Should pass INFO log not related to /health."""
+        f = HealthCheckFilter()
+        record = self._make_record('POST /suggest-theme HTTP/1.1 200')
+        assert f.filter(record) is True
+
+    def test_passes_health_check_warning_log(self):
+        """Should pass WARNING+ logs even if they contain /health."""
+        f = HealthCheckFilter()
+        record = self._make_record('/health endpoint error', logging.WARNING)
+        assert f.filter(record) is True


### PR DESCRIPTION
## Summary
- `curator_agents/runner.py` 新規: ADK 軽量実行ヘルパー `run_single_agent()` — `InMemorySessionService` + `Runner` + イベント収集のボイラープレートを一元化
- `curator_agents/core.py` 新規: テーマ提案の共通ビジネスロジック `suggest_themes()` — CLI とサービスの重複ロジック（Firestore 3クエリ並列実行 → エージェント実行 → JSON パース → バリデーション）を集約
  - `shared/constants.is_meaningful()` で失敗マーカーを早期検出（#371 活用）
- `curator_agents/cli.py`: `core.suggest_themes()` を呼ぶ薄いラッパーに縮小（111→47行）
- `services/curator.py`: `run_curator` を `core.suggest_themes` に置換、`translate_suggestions` で `run_single_agent` を使用（263→136行）
- `shared/logging_config.py`: `HealthCheckFilter` + `suppress_health_check_logs()` 追加 — 2サービスで同一定義されていた重複を解消
- `services/pipeline_server.py`: ローカル `_HealthCheckFilter` を `shared` に統合
- `curator_agents/schemas.py`: 冗長な `except (ValidationError, Exception)` を `except ValidationError` に修正

## 変更の効果
| ファイル | Before | After | 削減 |
|---|---|---|---|
| `curator_agents/cli.py` | 111行 | 47行 | -58% |
| `services/curator.py` | 263行 | 136行 | -48% |
| ADK ボイラープレート | 3箇所（各15行） | 1箇所 | -67% |
| `HealthCheckFilter` | 2箇所（同一定義） | 1箇所（shared） | -50% |

## Test plan
- [x] `pytest tests/unit/test_curator_runner.py` — 3 tests passed（新規）
- [x] `pytest tests/unit/test_curator_core.py` — 7 tests passed（新規）
- [x] `pytest tests/unit/test_health_check_filter.py` — 3 tests passed（新規）
- [x] `pytest tests/unit/test_curator_server.py` — 18 tests passed（モックターゲット更新）
- [x] `pytest tests/unit/` — 1185 tests passed（全テスト通過）

🤖 Generated with [Claude Code](https://claude.com/claude-code)