### PR TITLE
refactor: セッション状態キー定数化（shared/state_keys.py）

### DIFF
--- a/mystery_agents/agent.py
+++ b/mystery_agents/agent.py
@@ -42,6 +42,7 @@ from .agents.publisher import create_publisher
 from .agents.storyteller import create_storyteller
 from .agents.translator import create_all_translators
 from shared.model_config import DEFAULT_STORYTELLER
+from shared.state_keys import DEBATE_WHITEBOARD, SELECTED_LANGUAGES, STRUCTURED_REPORT
 
 if TYPE_CHECKING:
     from google.adk.agents.callback_context import CallbackContext
@@ -97,9 +98,9 @@ def _initialize_pipeline_state(
     selected_languages は AggregatorAgent が検索結果から動的に設定するため、
     ここでは空リストで初期化する。
     """
-    callback_context.state["selected_languages"] = []
-    callback_context.state["debate_whiteboard"] = ""
-    callback_context.state["structured_report"] = {}
+    callback_context.state[SELECTED_LANGUAGES] = []
+    callback_context.state[DEBATE_WHITEBOARD] = ""
+    callback_context.state[STRUCTURED_REPORT] = {}
     # scholar_analysis_* は DynamicPolymathBlock が動的に参照するため初期化不要
     # active_analyses_summary は DynamicScholarBlock が設定するため初期化不要
     return None  # 実行続行

--- a/mystery_agents/agents/aggregator.py
+++ b/mystery_agents/agents/aggregator.py
@@ -17,6 +17,12 @@ from google.adk.events.event import Event, EventActions
 from google.genai import types
 
 from shared.language_names import get_language_name
+from shared.state_keys import (
+    ACTIVE_LANGUAGES,
+    RAW_SEARCH_RESULTS,
+    SELECTED_LANGUAGES,
+    collected_documents_key,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +43,7 @@ class AggregatorAgent(BaseAgent):
         docs_by_lang: dict[str, list[dict]] = defaultdict(list)
 
         for key in list(state.keys()):
-            if not key.startswith("raw_search_results"):
+            if not key.startswith(RAW_SEARCH_RESULTS):
                 continue
             value = state.get(key)
             if not value or not isinstance(value, list):
@@ -62,13 +68,13 @@ class AggregatorAgent(BaseAgent):
         for lang in active_languages:
             docs = docs_by_lang[lang]
             text = _format_documents(lang, docs)
-            state_delta[f"collected_documents_{lang}"] = text
+            state_delta[collected_documents_key(lang)] = text
 
-        state_delta["active_languages"] = active_languages
+        state_delta[ACTIVE_LANGUAGES] = active_languages
 
         # selected_languages を active_languages で更新（Scholar/debate layer 互換）
         if active_languages:
-            state_delta["selected_languages"] = active_languages
+            state_delta[SELECTED_LANGUAGES] = active_languages
 
         total_docs = sum(len(d) for d in docs_by_lang.values())
         summary = (

--- a/mystery_agents/agents/dynamic_polymath_block.py
+++ b/mystery_agents/agents/dynamic_polymath_block.py
@@ -19,6 +19,7 @@ from google.genai import types
 
 from shared.constants import is_meaningful
 from shared.model_config import create_pro_model
+from shared.state_keys import ACTIVE_LANGUAGES, scholar_analysis_key
 
 from .armchair_polymath import (
     INSTRUCTION_BODY,
@@ -80,16 +81,16 @@ class DynamicPolymathBlock(BaseAgent):
         state = ctx.session.state
 
         # 有意な分析がある Named Scholar の言語を特定
-        active_langs = state.get("active_languages", [])
+        active_langs = state.get(ACTIVE_LANGUAGES, [])
         meaningful_langs = [
             lang
             for lang in active_langs
-            if is_meaningful(state.get(f"scholar_analysis_{lang}", ""))
+            if is_meaningful(state.get(scholar_analysis_key(lang), ""))
         ]
 
         # Multilingual Scholar の有意性チェック
         has_multilingual = is_meaningful(
-            state.get("scholar_analysis_multilingual", "")
+            state.get(scholar_analysis_key("multilingual"), "")
         )
 
         total_meaningful = len(meaningful_langs) + (1 if has_multilingual else 0)

--- a/mystery_agents/agents/dynamic_scholar_block.py
+++ b/mystery_agents/agents/dynamic_scholar_block.py
@@ -25,6 +25,7 @@ from google.genai import types
 
 from shared.constants import is_meaningful
 from shared.language_names import get_language_name
+from shared.state_keys import ACTIVE_LANGUAGES, DEBATE_WHITEBOARD, scholar_analysis_key
 
 from ..tools.debate_tools import is_debate_converged
 from .language_scholars import (
@@ -56,7 +57,7 @@ class DynamicScholarBlock(BaseAgent):
         state = ctx.session.state
 
         # Aggregator が設定した active_languages を取得
-        active_langs: list[str] = state.get("active_languages", [])
+        active_langs: list[str] = state.get(ACTIVE_LANGUAGES, [])
 
         if not active_langs:
             logger.warning("DynamicScholarBlock: ドキュメントなし — スキップ")
@@ -104,12 +105,12 @@ class DynamicScholarBlock(BaseAgent):
         # 有意な分析を出した Named Scholar を特定
         meaningful_named = [
             lang for lang in named_langs
-            if is_meaningful(state.get(f"scholar_analysis_{lang}", ""))
+            if is_meaningful(state.get(scholar_analysis_key(lang), ""))
         ]
         # Multilingual Scholar の有意性チェック
         has_meaningful_multilingual = (
             bool(other_langs)
-            and is_meaningful(state.get("scholar_analysis_multilingual", ""))
+            and is_meaningful(state.get(scholar_analysis_key("multilingual"), ""))
         )
 
         # active_analyses_summary をステートに書き込み（ログ/診断用）
@@ -194,7 +195,7 @@ class DynamicScholarBlock(BaseAgent):
                 yield event
 
             # 収束判定（LLM を介さず直接チェック）
-            whiteboard = state.get("debate_whiteboard", "")
+            whiteboard = state.get(DEBATE_WHITEBOARD, "")
             if is_debate_converged(whiteboard):
                 logger.info(
                     "DynamicScholarBlock: 討論収束 — ラウンド %d で終了",

--- a/mystery_agents/agents/language_gate.py
+++ b/mystery_agents/agents/language_gate.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Optional
 from google.genai import types
 
 from shared.constants import DEFAULT_SELECTED_LANGUAGES, is_meaningful
+from shared.state_keys import SELECTED_LANGUAGES, scholar_analysis_key
 
 if TYPE_CHECKING:
     from google.adk.agents.callback_context import CallbackContext
@@ -25,7 +26,7 @@ def make_debate_gate(lang_code: str):
     """
 
     def gate(callback_context: CallbackContext) -> Optional[types.Content]:
-        selected = callback_context.state.get("selected_languages", DEFAULT_SELECTED_LANGUAGES)
+        selected = callback_context.state.get(SELECTED_LANGUAGES, DEFAULT_SELECTED_LANGUAGES)
         if not isinstance(selected, list):
             selected = list(DEFAULT_SELECTED_LANGUAGES)
         if lang_code not in selected or len(selected) < 2:
@@ -33,7 +34,7 @@ def make_debate_gate(lang_code: str):
                 parts=[types.Part(text="")], role="model"
             )
         # Scholar が有意な分析を出していない場合もスキップ
-        analysis = callback_context.state.get(f"scholar_analysis_{lang_code}", "")
+        analysis = callback_context.state.get(scholar_analysis_key(lang_code), "")
         if not is_meaningful(analysis):
             return types.Content(
                 parts=[types.Part(text="")], role="model"
@@ -51,14 +52,14 @@ def make_debate_loop_gate():
     """
 
     def gate(callback_context: CallbackContext) -> Optional[types.Content]:
-        selected = callback_context.state.get("selected_languages", DEFAULT_SELECTED_LANGUAGES)
+        selected = callback_context.state.get(SELECTED_LANGUAGES, DEFAULT_SELECTED_LANGUAGES)
         if not isinstance(selected, list):
             selected = list(DEFAULT_SELECTED_LANGUAGES)
 
         # 有意な分析を出した Scholar の数をカウント
         meaningful = 0
         for lang in selected:
-            analysis = callback_context.state.get(f"scholar_analysis_{lang}", "")
+            analysis = callback_context.state.get(scholar_analysis_key(lang), "")
             if is_meaningful(analysis):
                 meaningful += 1
 

--- a/mystery_agents/agents/pipeline_gate.py
+++ b/mystery_agents/agents/pipeline_gate.py
@@ -12,6 +12,14 @@ from typing import TYPE_CHECKING, Optional
 from google.genai import types
 
 from shared.constants import DEFAULT_SELECTED_LANGUAGES, is_meaningful
+from shared.state_keys import (
+    CREATIVE_CONTENT,
+    INVESTIGATION_QUERY,
+    MYSTERY_REPORT,
+    PIPELINE_RUN_ID,
+    SELECTED_LANGUAGES,
+    collected_documents_key,
+)
 
 if TYPE_CHECKING:
     from google.adk.agents.callback_context import CallbackContext
@@ -31,8 +39,8 @@ def _log_and_record_failure(callback_context: CallbackContext, stage: str, messa
     try:
         from shared.pipeline_failure import log_pipeline_failure
 
-        theme = callback_context.state.get("investigation_query", "unknown")
-        run_id = callback_context.state.get("pipeline_run_id")
+        theme = callback_context.state.get(INVESTIGATION_QUERY, "unknown")
+        run_id = callback_context.state.get(PIPELINE_RUN_ID)
         log_pipeline_failure(
             theme=str(theme),
             stage=stage,
@@ -48,12 +56,12 @@ def make_scholar_gate():
     """全 Librarian が失敗した場合に ParallelScholars をスキップ。"""
 
     def gate(callback_context: CallbackContext) -> Optional[types.Content]:
-        selected = callback_context.state.get("selected_languages", DEFAULT_SELECTED_LANGUAGES)
+        selected = callback_context.state.get(SELECTED_LANGUAGES, DEFAULT_SELECTED_LANGUAGES)
         if not isinstance(selected, list):
             selected = list(DEFAULT_SELECTED_LANGUAGES)
 
         for lang in selected:
-            docs = callback_context.state.get(f"collected_documents_{lang}", "")
+            docs = callback_context.state.get(collected_documents_key(lang), "")
             if _is_meaningful(docs):
                 logger.info(
                     "Pipeline gate [scholar]: 通過（%s に有意なデータあり）", lang,
@@ -78,7 +86,7 @@ def make_storyteller_gate():
     """mystery_report が空なら Storyteller をスキップ。"""
 
     def gate(callback_context: CallbackContext) -> Optional[types.Content]:
-        report = callback_context.state.get("mystery_report", "")
+        report = callback_context.state.get(MYSTERY_REPORT, "")
         if _is_meaningful(report):
             logger.info(
                 "Pipeline gate [storyteller]: 通過",
@@ -100,7 +108,7 @@ def make_post_story_gate():
     """creative_content が空なら Illustrator/Translator/Publisher をスキップ。"""
 
     def gate(callback_context: CallbackContext) -> Optional[types.Content]:
-        content = callback_context.state.get("creative_content", "")
+        content = callback_context.state.get(CREATIVE_CONTENT, "")
         if _is_meaningful(content):
             logger.info(
                 "Pipeline gate [post_story]: 通過",

--- a/mystery_agents/agents/publisher.py
+++ b/mystery_agents/agents/publisher.py
@@ -19,6 +19,8 @@ from google.adk.agents.invocation_context import InvocationContext
 from google.adk.events.event import Event, EventActions
 from google.genai import types
 
+from shared.state_keys import PUBLISHED_EPISODE, PUBLISHED_MYSTERY_ID, STRUCTURED_REPORT
+
 from ..tools.publisher_tools import _PublishContext, publish_mystery
 
 load_dotenv(Path(__file__).parent.parent / ".env")  # mystery_agents/.env
@@ -35,7 +37,7 @@ class PublisherAgent(BaseAgent):
         state = ctx.session.state
 
         # structured_report から ID 生成用データを取得
-        sr = state.get("structured_report", {})
+        sr = state.get(STRUCTURED_REPORT, {})
         if not isinstance(sr, dict):
             sr = {}
         minimal_json = json.dumps(
@@ -52,10 +54,10 @@ class PublisherAgent(BaseAgent):
         result_json = publish_mystery(minimal_json, "", publish_ctx)
 
         # state_delta: published_mystery_id + published_episode をセッションに反映
-        state_delta: dict[str, object] = {"published_episode": result_json}
-        mystery_id = state_copy.get("published_mystery_id")
+        state_delta: dict[str, object] = {PUBLISHED_EPISODE: result_json}
+        mystery_id = state_copy.get(PUBLISHED_MYSTERY_ID)
         if mystery_id:
-            state_delta["published_mystery_id"] = mystery_id
+            state_delta[PUBLISHED_MYSTERY_ID] = mystery_id
 
         yield Event(
             invocation_id=ctx.invocation_id,

--- a/mystery_agents/tools/debate_tools.py
+++ b/mystery_agents/tools/debate_tools.py
@@ -11,6 +11,8 @@ import re
 
 from google.adk.tools.tool_context import ToolContext
 
+from shared.state_keys import DEBATE_WHITEBOARD
+
 logger = logging.getLogger(__name__)
 
 
@@ -35,10 +37,10 @@ def append_to_whiteboard(
     Returns:
         Confirmation message.
     """
-    current = tool_context.state.get("debate_whiteboard", "")
+    current = tool_context.state.get(DEBATE_WHITEBOARD, "")
 
     entry = f"### [Round {round_number}] {speaker} Perspective\n\n{contribution}\n\n"
-    tool_context.state["debate_whiteboard"] = current + entry
+    tool_context.state[DEBATE_WHITEBOARD] = current + entry
 
     return f"Contribution from {speaker} (Round {round_number}) appended to whiteboard."
 
@@ -129,7 +131,7 @@ def check_debate_convergence(tool_context: ToolContext) -> str:
     Returns:
         収束判定結果のメッセージ。
     """
-    whiteboard = tool_context.state.get("debate_whiteboard", "")
+    whiteboard = tool_context.state.get(DEBATE_WHITEBOARD, "")
     if not whiteboard:
         return "No whiteboard content found. Debate should continue."
 

--- a/mystery_agents/tools/document_inventory.py
+++ b/mystery_agents/tools/document_inventory.py
@@ -17,6 +17,8 @@ from typing import Any, Optional
 
 from google.adk.tools.tool_context import ToolContext
 
+from shared.state_keys import RAW_SEARCH_RESULTS
+
 logger = logging.getLogger(__name__)
 
 # アーカイブ名マッピング（source_type → 表示名）
@@ -83,7 +85,7 @@ def get_document_inventory(tool_context: Optional[ToolContext] = None) -> str:
     all_results: list[dict[str, Any]] = []
 
     # ベースキー
-    base_results = state.get("raw_search_results")
+    base_results = state.get(RAW_SEARCH_RESULTS)
     if base_results and isinstance(base_results, list):
         for r in base_results:
             if isinstance(r, dict):
@@ -92,7 +94,7 @@ def get_document_inventory(tool_context: Optional[ToolContext] = None) -> str:
     # 言語別キー
     state_dict = state.to_dict() if hasattr(state, "to_dict") else state
     for key in list(state_dict.keys()):
-        if key.startswith("raw_search_results_") and key != "raw_search_results":
+        if key.startswith(RAW_SEARCH_RESULTS + "_") and key != RAW_SEARCH_RESULTS:
             lang_results = state.get(key)
             if lang_results and isinstance(lang_results, list):
                 for r in lang_results:

--- a/mystery_agents/tools/librarian_tools.py
+++ b/mystery_agents/tools/librarian_tools.py
@@ -14,6 +14,12 @@ from typing import Optional
 
 from google.adk.tools.tool_context import ToolContext
 from shared.keyword_translator import translate_keywords
+from shared.state_keys import (
+    ARCHIVE_IMAGES,
+    RAW_SEARCH_RESULTS,
+    SELECTED_LANGUAGES,
+    raw_search_results_key,
+)
 
 from ..schemas.document import ArchiveDocument
 from .bilingual_search import KEYWORD_PAIRS, expand_keywords_bilingual
@@ -47,9 +53,9 @@ def _accumulate_archive_images(
         if d.get("thumbnail_url") or d.get("image_url")
     ]
     if images_with_urls:
-        existing_images = tool_context.state.get("archive_images", [])
+        existing_images = tool_context.state.get(ARCHIVE_IMAGES, [])
         existing_images.extend(images_with_urls)
-        tool_context.state["archive_images"] = existing_images
+        tool_context.state[ARCHIVE_IMAGES] = existing_images
 
 
 def search_newspapers(
@@ -108,9 +114,9 @@ def search_newspapers(
             },
         }
         if tool_context is not None:
-            existing = tool_context.state.get("raw_search_results", [])
+            existing = tool_context.state.get(RAW_SEARCH_RESULTS, [])
             existing.append(empty_result)
-            tool_context.state["raw_search_results"] = existing
+            tool_context.state[RAW_SEARCH_RESULTS] = existing
         return json.dumps(empty_result, ensure_ascii=False, indent=2)
 
     # --- Chronicling America フォールバックロジック ---
@@ -235,9 +241,9 @@ def search_newspapers(
 
     # セッション状態に保存
     if tool_context is not None:
-        existing = tool_context.state.get("raw_search_results", [])
+        existing = tool_context.state.get(RAW_SEARCH_RESULTS, [])
         existing.append(result)
-        tool_context.state["raw_search_results"] = existing
+        tool_context.state[RAW_SEARCH_RESULTS] = existing
         _accumulate_archive_images(tool_context, docs)
 
     return json.dumps(result, ensure_ascii=False, indent=2)
@@ -437,7 +443,7 @@ def _get_expansion_languages(tool_context: Optional[ToolContext], current_lang: 
     """
     if tool_context is None:
         return []
-    selected = tool_context.state.get("selected_languages", [])
+    selected = tool_context.state.get(SELECTED_LANGUAGES, [])
     if not isinstance(selected, list) or len(selected) <= 1:
         return []
     return [lang for lang in selected if lang != current_lang]
@@ -694,7 +700,7 @@ def search_archives(
 
     # セッション状態に保存
     if tool_context is not None:
-        state_key = f"raw_search_results_{language}" if language else "raw_search_results"
+        state_key = raw_search_results_key(language) if language else RAW_SEARCH_RESULTS
         existing = tool_context.state.get(state_key, [])
         existing.append(result)
         tool_context.state[state_key] = existing

--- a/mystery_agents/tools/publisher_tools.py
+++ b/mystery_agents/tools/publisher_tools.py
@@ -26,6 +26,17 @@ from shared.constants import (
 )
 from shared.firestore import get_firestore_client, get_storage_bucket
 from shared.language_validator import validate_translation_language
+from shared.state_keys import (
+    ACTIVE_LANGUAGES,
+    CREATIVE_CONTENT,
+    IMAGE_METADATA,
+    MYSTERY_REPORT,
+    PUBLISHED_MYSTERY_ID,
+    STRUCTURED_REPORT,
+    collected_documents_key,
+    scholar_analysis_key,
+    translation_result_key,
+)
 
 from mystery_agents.tools.search_metadata import get_search_metadata as _get_search_metadata
 
@@ -269,7 +280,7 @@ def publish_mystery(
 
         # Overlay structured report from session state (more accurate than LLM text)
         if tool_context is not None:
-            structured_report = tool_context.state.get("structured_report")
+            structured_report = tool_context.state.get(STRUCTURED_REPORT)
             if structured_report and isinstance(structured_report, dict):
                 # Use structured data for critical fields, preferring state over LLM text
                 for key in (
@@ -285,7 +296,7 @@ def publish_mystery(
                         data[key] = structured_report[key]
 
             # narrative_content: creative_content セッション状態から直接読み取り
-            creative_content = tool_context.state.get("creative_content")
+            creative_content = tool_context.state.get(CREATIVE_CONTENT)
             if creative_content and isinstance(creative_content, str):
                 if not any(marker in creative_content for marker in ("NO_CONTENT", "NO_DOCUMENTS_FOUND")):
                     data["narrative_content"] = creative_content
@@ -299,20 +310,20 @@ def publish_mystery(
                     data["images"] = images_dict
 
             # raw_data: collected_documents_en セッション状態から直接読み取り
-            collected_docs = tool_context.state.get("collected_documents_en")
+            collected_docs = tool_context.state.get(collected_documents_key("en"))
             if collected_docs:
                 data["raw_data"] = collected_docs if isinstance(collected_docs, str) else str(collected_docs)
 
             # 各言語の Scholar 分析を multilingual_analysis として保存
             # active_languages を参照し、動的に検出された全言語をカバーする
             multilingual = {}
-            active_langs = tool_context.state.get("active_languages", [])
+            active_langs = tool_context.state.get(ACTIVE_LANGUAGES, [])
             for lang in active_langs:
-                analysis = tool_context.state.get(f"scholar_analysis_{lang}")
+                analysis = tool_context.state.get(scholar_analysis_key(lang))
                 if analysis and "INSUFFICIENT_DATA" not in str(analysis):
                     multilingual[lang] = str(analysis)
             # Multilingual Scholar の分析も保存
-            ml_analysis = tool_context.state.get("scholar_analysis_multilingual")
+            ml_analysis = tool_context.state.get(scholar_analysis_key("multilingual"))
             if ml_analysis and "INSUFFICIENT_DATA" not in str(ml_analysis):
                 multilingual["multilingual"] = str(ml_analysis)
             if multilingual:
@@ -320,7 +331,7 @@ def publish_mystery(
                 data["languages_analyzed"] = list(multilingual.keys())
 
             # mystery_report: Armchair Polymath の統合分析レポート全文を保存
-            mystery_report = tool_context.state.get("mystery_report")
+            mystery_report = tool_context.state.get(MYSTERY_REPORT)
             if mystery_report and isinstance(mystery_report, str):
                 if "INSUFFICIENT_DATA" not in mystery_report:
                     data["mystery_report"] = mystery_report
@@ -350,7 +361,7 @@ def publish_mystery(
             translations: dict[str, dict] = {}
             rejected_languages: list[str] = []
             for lang in TRANSLATION_LANGUAGES:
-                translation_result = tool_context.state.get(f"translation_result_{lang}")
+                translation_result = tool_context.state.get(translation_result_key(lang))
                 if not translation_result:
                     continue
                 # output_key の値は LLM テキスト出力（JSON 文字列の場合がある）
@@ -422,7 +433,7 @@ def publish_mystery(
         # Upload images: prefer image_metadata from session state, fall back to LLM text
         image_source = None
         if tool_context is not None:
-            image_source = tool_context.state.get("image_metadata")
+            image_source = tool_context.state.get(IMAGE_METADATA)
 
         if image_source and isinstance(image_source, dict):
             # Use accurate image metadata from session state
@@ -528,7 +539,7 @@ def publish_mystery(
 
         # mystery_id をセッション状態に直接保存（LLM テキスト解析に依存しない確実な受け渡し）
         if tool_context is not None:
-            tool_context.state["published_mystery_id"] = mystery_id
+            tool_context.state[PUBLISHED_MYSTERY_ID] = mystery_id
 
         return json.dumps({
             "status": "success",

--- a/mystery_agents/tools/scholar_tools.py
+++ b/mystery_agents/tools/scholar_tools.py
@@ -14,6 +14,8 @@ from typing import Any, Optional
 
 from google.adk.tools.tool_context import ToolContext
 
+from shared.state_keys import RAW_SEARCH_RESULTS, STRUCTURED_REPORT
+
 
 def load_search_results(filepath: str) -> str:
     """Load search results from the data directory.
@@ -491,7 +493,7 @@ def _build_url_index(tool_context: ToolContext) -> dict[str, dict[str, Any]]:
     state = tool_context.state
 
     # ベースキー
-    base = state.get("raw_search_results")
+    base = state.get(RAW_SEARCH_RESULTS)
     if base and isinstance(base, list):
         for result in base:
             if isinstance(result, dict):
@@ -503,7 +505,7 @@ def _build_url_index(tool_context: ToolContext) -> dict[str, dict[str, Any]]:
     # 言語別キー
     state_dict = state.to_dict() if hasattr(state, "to_dict") else state
     for key in list(state_dict.keys()):
-        if key.startswith("raw_search_results_") and key != "raw_search_results":
+        if key.startswith(RAW_SEARCH_RESULTS + "_") and key != RAW_SEARCH_RESULTS:
             lang_results = state.get(key)
             if lang_results and isinstance(lang_results, list):
                 for result in lang_results:
@@ -684,7 +686,7 @@ def save_structured_report(
     warnings.extend(grounding_warnings)
 
     # Store structured report in session state
-    tool_context.state["structured_report"] = report_data
+    tool_context.state[STRUCTURED_REPORT] = report_data
 
     return json.dumps(
         {

--- a/mystery_agents/tools/search_metadata.py
+++ b/mystery_agents/tools/search_metadata.py
@@ -13,6 +13,8 @@ from typing import Any, Optional
 
 from google.adk.tools.tool_context import ToolContext
 
+from shared.state_keys import RAW_SEARCH_RESULTS
+
 logger = logging.getLogger(__name__)
 
 # 検索結果がない場合のレスポンス
@@ -98,7 +100,7 @@ def get_search_metadata(tool_context: Optional[ToolContext] = None) -> str:
     all_results: list[tuple[str, list]] = []
 
     # ベースキー
-    base_results = state.get("raw_search_results")
+    base_results = state.get(RAW_SEARCH_RESULTS)
     if base_results and isinstance(base_results, list):
         all_results.append(("base", base_results))
 
@@ -107,7 +109,7 @@ def get_search_metadata(tool_context: Optional[ToolContext] = None) -> str:
     # ADK State は .keys() を持たないため to_dict() 経由、テスト用 dict はそのまま
     state_dict = state.to_dict() if hasattr(state, "to_dict") else state
     for key in list(state_dict.keys()):
-        if key.startswith("raw_search_results_") and key != "raw_search_results":
+        if key.startswith(RAW_SEARCH_RESULTS + "_") and key != RAW_SEARCH_RESULTS:
             lang = key.replace("raw_search_results_", "")
             lang_results = state.get(key)
             if lang_results and isinstance(lang_results, list):

--- a/shared/orchestrator.py
+++ b/shared/orchestrator.py
@@ -24,6 +24,15 @@ from google.genai import types
 from mystery_agents.utils.pipeline_logger import PipelineLogger
 from shared.constants import is_meaningful
 from shared.logging_config import PipelineContext, set_pipeline_context
+from shared.state_keys import (
+    CREATIVE_CONTENT,
+    IMAGE_METADATA,
+    MYSTERY_REPORT,
+    PIPELINE_RUN_ID,
+    PUBLISHED_EPISODE,
+    PUBLISHED_MYSTERY_ID,
+    STRUCTURED_REPORT,
+)
 from shared.search_metrics import extract_search_metrics, save_search_metrics
 from shared.pipeline_run import (
     create_pipeline_run,
@@ -101,8 +110,8 @@ OnText = Callable[[str], None]
 def _build_state_summary(session_state: dict) -> dict:
     """デバッグ用にセッション状態キーの存在と長さをサマリ化する。"""
     keys = [
-        "mystery_report", "creative_content", "structured_report",
-        "image_metadata", "published_mystery_id", "published_episode",
+        MYSTERY_REPORT, CREATIVE_CONTENT, STRUCTURED_REPORT,
+        IMAGE_METADATA, PUBLISHED_MYSTERY_ID, PUBLISHED_EPISODE,
     ]
     summary = {}
     for k in keys:
@@ -132,7 +141,7 @@ def _detect_gate_failure(session_state: dict) -> tuple[str, dict]:
     if llm_meta:
         detail["storyteller_llm_metadata"] = llm_meta
 
-    mystery_report = session_state.get("mystery_report", "")
+    mystery_report = session_state.get(MYSTERY_REPORT, "")
     if not is_meaningful(mystery_report):
         return "十分な資料が見つからなかったため、記事を生成できませんでした", {
             "error_type": "gate_failure",
@@ -140,7 +149,7 @@ def _detect_gate_failure(session_state: dict) -> tuple[str, dict]:
             **detail,
         }
 
-    creative_content = session_state.get("creative_content", "")
+    creative_content = session_state.get(CREATIVE_CONTENT, "")
     if not is_meaningful(creative_content):
         return "記事の生成に失敗しました", {
             "error_type": "gate_failure",
@@ -316,7 +325,7 @@ async def run_pipeline(
 
         state = {
             "pipeline_log": [],
-            "pipeline_run_id": run_id,
+            PIPELINE_RUN_ID: run_id,
             **initial_state,
         }
 
@@ -426,11 +435,11 @@ async def run_pipeline(
             mystery_id = None
             if run_type == "blog" and session_state:
                 # 優先: ツールがセッション状態に直接書き込んだ mystery_id
-                mystery_id = session_state.get("published_mystery_id")
+                mystery_id = session_state.get(PUBLISHED_MYSTERY_ID)
 
                 # フォールバック: published_episode テキストから抽出
                 if not mystery_id:
-                    published = session_state.get("published_episode", "")
+                    published = session_state.get(PUBLISHED_EPISODE, "")
                     if isinstance(published, str):
                         text = published.strip()
                         if text.startswith("{"):

--- a/shared/state_keys.py
+++ b/shared/state_keys.py
@@ -1,0 +1,55 @@
+"""セッション状態キーのランタイム定数。
+
+state.get("mystery_report") 等のマジックストリングを定数化し、
+typo によるサイレントバグを防止する。
+
+注意:
+- output_key="mystery_report" 等の ADK パラメータはここの定数に置換しない
+  （ADK 内部で文字列として扱われるため）
+- instruction 内の {mystery_report} プレースホルダーも置換しない
+  （LLM が読むテンプレート変数であり、Python 定数参照ではない）
+- ドキュメント/依存関係図は shared/state_registry.py を参照
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# 固定キー
+# ---------------------------------------------------------------------------
+MYSTERY_REPORT = "mystery_report"
+CREATIVE_CONTENT = "creative_content"
+STRUCTURED_REPORT = "structured_report"
+DEBATE_WHITEBOARD = "debate_whiteboard"
+VISUAL_ASSETS = "visual_assets"
+IMAGE_METADATA = "image_metadata"
+PUBLISHED_EPISODE = "published_episode"
+ARCHIVE_IMAGES = "archive_images"
+SELECTED_LANGUAGES = "selected_languages"
+ACTIVE_LANGUAGES = "active_languages"
+RAW_SEARCH_RESULTS = "raw_search_results"
+PUBLISHED_MYSTERY_ID = "published_mystery_id"
+INVESTIGATION_QUERY = "investigation_query"
+PIPELINE_RUN_ID = "pipeline_run_id"
+
+
+# ---------------------------------------------------------------------------
+# 動的キー（言語/API サフィックス付き）
+# ---------------------------------------------------------------------------
+def collected_documents_key(lang: str) -> str:
+    """Aggregator が集約した資料キー（言語別）。"""
+    return f"collected_documents_{lang}"
+
+
+def scholar_analysis_key(lang: str) -> str:
+    """Scholar 分析レポートキー（言語別）。"""
+    return f"scholar_analysis_{lang}"
+
+
+def translation_result_key(lang: str) -> str:
+    """Translator 翻訳結果キー（言語別）。"""
+    return f"translation_result_{lang}"
+
+
+def raw_search_results_key(identifier: str) -> str:
+    """Librarian 検索結果キー（API/言語別）。"""
+    return f"raw_search_results_{identifier}"

--- a/tests/unit/test_dynamic_scholar_block.py
+++ b/tests/unit/test_dynamic_scholar_block.py
@@ -3,9 +3,9 @@
 
 from mystery_agents.agents.dynamic_scholar_block import (
     MAX_DEBATE_ITERATIONS,
-    _is_meaningful,
     create_dynamic_scholar_block,
 )
+from shared.constants import is_meaningful as _is_meaningful
 
 
 class TestDynamicScholarBlockCreation:


### PR DESCRIPTION
## Summary

- `shared/state_keys.py` を新設し、14個の固定キー定数と4個の動的キー生成関数を定義
- 15ファイル（agents/ 7ファイル + tools/ 5ファイル + shared/orchestrator.py + テスト2ファイル）のマジックストリングを定数参照に置換
- ADK の `output_key` パラメータや instruction 内の `{placeholder}` は対象外（妥当な文字列リテラル）

### 変更概要

| カテゴリ | 変更内容 |
|---------|---------|
| 新規ファイル | `shared/state_keys.py` — ランタイム用セッション状態キー定数 |
| agents/ | `agent.py`, `pipeline_gate.py`, `language_gate.py`, `dynamic_scholar_block.py`, `dynamic_polymath_block.py`, `publisher.py`, `aggregator.py` |
| tools/ | `librarian_tools.py`, `publisher_tools.py`, `scholar_tools.py`, `search_metadata.py`, `document_inventory.py`, `debate_tools.py` |
| shared/ | `orchestrator.py` |
| tests/ | `test_dynamic_scholar_block.py`（import 先修正） |

### 定数一覧

**固定キー**: `MYSTERY_REPORT`, `CREATIVE_CONTENT`, `STRUCTURED_REPORT`, `DEBATE_WHITEBOARD`, `VISUAL_ASSETS`, `IMAGE_METADATA`, `PUBLISHED_EPISODE`, `ARCHIVE_IMAGES`, `SELECTED_LANGUAGES`, `ACTIVE_LANGUAGES`, `RAW_SEARCH_RESULTS`, `PUBLISHED_MYSTERY_ID`, `INVESTIGATION_QUERY`, `PIPELINE_RUN_ID`

**動的キー関数**: `collected_documents_key(lang)`, `scholar_analysis_key(lang)`, `translation_result_key(lang)`, `raw_search_results_key(identifier)`

## Test plan

- [x] 全 1197 ユニットテスト パス
- [x] ruff lint パス
- [x] `from mystery_agents.agent import root_agent` import 整合性確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)