### PR TITLE
refactor: orchestrator ヘルパー抽出（_extract_mystery_id 純粋関数化）

### DIFF
--- a/shared/orchestrator.py
+++ b/shared/orchestrator.py
@@ -165,6 +165,35 @@ def _detect_gate_failure(session_state: dict) -> tuple[str, dict]:
     }
 
 
+def _extract_mystery_id(session_state: dict) -> str | None:
+    """セッション状態から mystery_id を抽出する純粋関数。
+
+    優先順位:
+    1. PUBLISHED_MYSTERY_ID（ツールが直接書き込んだ値）
+    2. PUBLISHED_EPISODE テキストからの JSON パース
+    3. PUBLISHED_EPISODE dict からの取得
+    """
+    # 優先: ツールがセッション状態に直接書き込んだ mystery_id
+    mystery_id = session_state.get(PUBLISHED_MYSTERY_ID)
+    if mystery_id:
+        return mystery_id
+
+    # フォールバック: published_episode から抽出
+    published = session_state.get(PUBLISHED_EPISODE, "")
+    if isinstance(published, str):
+        text = published.strip()
+        if text.startswith("{"):
+            try:
+                published_data = json.loads(text)
+                return published_data.get("mystery_id")
+            except (json.JSONDecodeError, AttributeError):
+                pass
+    elif isinstance(published, dict):
+        return published.get("mystery_id")
+
+    return None
+
+
 @dataclass
 class PipelineResult:
     """パイプライン実行結果"""
@@ -434,22 +463,7 @@ async def run_pipeline(
             # mystery_id 抽出（blog パイプラインのみ）
             mystery_id = None
             if run_type == "blog" and session_state:
-                # 優先: ツールがセッション状態に直接書き込んだ mystery_id
-                mystery_id = session_state.get(PUBLISHED_MYSTERY_ID)
-
-                # フォールバック: published_episode テキストから抽出
-                if not mystery_id:
-                    published = session_state.get(PUBLISHED_EPISODE, "")
-                    if isinstance(published, str):
-                        text = published.strip()
-                        if text.startswith("{"):
-                            try:
-                                published_data = json.loads(text)
-                                mystery_id = published_data.get("mystery_id")
-                            except (json.JSONDecodeError, AttributeError):
-                                pass
-                    elif isinstance(published, dict):
-                        mystery_id = published.get("mystery_id")
+                mystery_id = _extract_mystery_id(session_state)
 
             # mystery_id をコンテキストに追加
             if mystery_id:

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1,6 +1,7 @@
 """Unit tests for shared/orchestrator.py"""
 
 import asyncio
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -9,9 +10,11 @@ from shared.orchestrator import (
     PipelineResult,
     _build_state_summary,
     _detect_gate_failure,
+    _extract_mystery_id,
     _format_exception_group,
     run_pipeline,
 )
+from shared.state_keys import PUBLISHED_EPISODE, PUBLISHED_MYSTERY_ID
 from tests.fakes import FakeInMemorySessionService
 
 
@@ -952,6 +955,67 @@ class TestErrorRemainingAgents:
         error_detail = mock_error.call_args[1]["error_detail"]
         assert "pipeline_log" in error_detail
         assert isinstance(error_detail["pipeline_log"], list)
+
+
+class TestExtractMysteryId:
+    """_extract_mystery_id: セッション状態から mystery_id を抽出する純粋関数。"""
+
+    def test_from_published_mystery_id_key(self):
+        """Should return mystery_id from PUBLISHED_MYSTERY_ID (priority 1)."""
+        state = {PUBLISHED_MYSTERY_ID: "OCC-US-BOS-20260207143025"}
+        assert _extract_mystery_id(state) == "OCC-US-BOS-20260207143025"
+
+    def test_from_published_episode_json_string(self):
+        """Should extract mystery_id from PUBLISHED_EPISODE JSON string (fallback)."""
+        state = {
+            PUBLISHED_EPISODE: json.dumps({
+                "status": "success",
+                "mystery_id": "HIS-GB-EDI-20260301120000",
+            }),
+        }
+        assert _extract_mystery_id(state) == "HIS-GB-EDI-20260301120000"
+
+    def test_from_published_episode_dict(self):
+        """Should extract mystery_id from PUBLISHED_EPISODE dict."""
+        state = {
+            PUBLISHED_EPISODE: {
+                "status": "success",
+                "mystery_id": "FLK-JP-KYO-20260315090000",
+            },
+        }
+        assert _extract_mystery_id(state) == "FLK-JP-KYO-20260315090000"
+
+    def test_published_mystery_id_takes_priority(self):
+        """Should prefer PUBLISHED_MYSTERY_ID over PUBLISHED_EPISODE."""
+        state = {
+            PUBLISHED_MYSTERY_ID: "OCC-US-BOS-20260207143025",
+            PUBLISHED_EPISODE: json.dumps({"mystery_id": "WRONG-ID"}),
+        }
+        assert _extract_mystery_id(state) == "OCC-US-BOS-20260207143025"
+
+    def test_empty_state_returns_none(self):
+        """Should return None for empty session state."""
+        assert _extract_mystery_id({}) is None
+
+    def test_no_mystery_id_in_published_episode(self):
+        """Should return None when PUBLISHED_EPISODE has no mystery_id."""
+        state = {PUBLISHED_EPISODE: json.dumps({"status": "error"})}
+        assert _extract_mystery_id(state) is None
+
+    def test_invalid_json_returns_none(self):
+        """Should return None when PUBLISHED_EPISODE is invalid JSON."""
+        state = {PUBLISHED_EPISODE: "not valid json"}
+        assert _extract_mystery_id(state) is None
+
+    def test_non_json_text_returns_none(self):
+        """Should return None when PUBLISHED_EPISODE is plain text."""
+        state = {PUBLISHED_EPISODE: "Pipeline completed successfully"}
+        assert _extract_mystery_id(state) is None
+
+    def test_empty_string_published_episode(self):
+        """Should return None when PUBLISHED_EPISODE is empty string."""
+        state = {PUBLISHED_EPISODE: ""}
+        assert _extract_mystery_id(state) is None
 
 
 class TestBuildStateSummary:


### PR DESCRIPTION
## Summary

- `run_pipeline()` 内の mystery_id 抽出ロジック（15行）を `_extract_mystery_id()` 純粋関数に抽出
- 9パターンの単体テストを追加（Runner モック不要で直接検証可能に）
- 振る舞い変更なし

**テストカバレッジ:**
- PUBLISHED_MYSTERY_ID からの取得（優先）
- PUBLISHED_EPISODE JSON 文字列からのパース（フォールバック）
- PUBLISHED_EPISODE dict からの取得
- 優先順位の検証（両方ある場合）
- 空入力 / 不正 JSON / プレーンテキスト / mystery_id 欠落

## Test plan

- [x] `python -m pytest tests/unit/ -v` — 全 1235 テスト合格
- [x] `ruff check shared/orchestrator.py tests/unit/test_orchestrator.py` — lint クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)