### PR TITLE
fix: ラテン文字言語のキーワード言語誤判定を修正

### DIFF
--- a/mystery_agents/tools/search_orchestration.py
+++ b/mystery_agents/tools/search_orchestration.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 from typing import Optional
 
 from google.adk.tools.tool_context import ToolContext
+from shared.constants import LATIN_SCRIPT_LANGUAGES
 from shared.keyword_translator import translate_keywords
 from shared.state_keys import SELECTED_LANGUAGES
 
@@ -121,12 +122,12 @@ def _rank_documents(
     return result
 
 
-def _is_likely_english(keyword: str) -> bool:
-    """キーワードが英語である可能性が高いかを簡易判定する。
+def _is_ascii_only(keyword: str) -> bool:
+    """キーワードが ASCII 文字のみで構成されているか判定する。
 
-    ASCII 文字のみで構成されるキーワードを英語候補とみなす。
+    ASCII 文字のみで構成されるキーワードを検出する。
     ドイツ語のウムラウト（ä,ö,ü）、フランス語のアクセント（é,è）等の
-    非 ASCII 文字を含む場合は非英語と判定する。
+    非 ASCII 文字を含む場合は False を返す。
     """
     return all(ord(c) < 128 for c in keyword)
 
@@ -134,10 +135,21 @@ def _is_likely_english(keyword: str) -> bool:
 def _log_keyword_language_mismatch(
     keywords: list[str], language: str
 ) -> None:
-    """非英語 Librarian が英語キーワードのみで検索していないかログ出力する。"""
-    ascii_only = [kw for kw in keywords if _is_likely_english(kw)]
+    """非英語 Librarian が英語キーワードのみで検索していないかログ出力する。
+
+    ラテン文字言語（de, es, fr 等）は ASCII のみのキーワードでも正当な
+    ネイティブ語である可能性が高いため DEBUG レベルに抑制する。
+    非ラテン文字言語（ja, ko 等）では WARNING を維持する。
+    """
+    ascii_only = [kw for kw in keywords if _is_ascii_only(kw)]
     if len(ascii_only) == len(keywords) and keywords:
-        logger.warning(
+        log_level = (
+            logging.DEBUG
+            if language in LATIN_SCRIPT_LANGUAGES
+            else logging.WARNING
+        )
+        logger.log(
+            log_level,
             "キーワード言語不一致: language=%s だが全キーワードが ASCII のみ "
             "(ネイティブ言語キーワード未使用の可能性): %s",
             language,
@@ -184,8 +196,12 @@ def _translate_keywords_for_source(
     if primary_lang == "en":
         return None
 
+    # ラテン文字言語ソースは ASCII キーワードが正当なネイティブ語の可能性が高い → スキップ
+    if primary_lang in LATIN_SCRIPT_LANGUAGES:
+        return None
+
     # 非 ASCII キーワードが1つでもあればネイティブ言語が既に含まれている
-    if not all(_is_likely_english(kw) for kw in keyword_list):
+    if not all(_is_ascii_only(kw) for kw in keyword_list):
         return None
 
     # 英語キーワードをソースのネイティブ言語に翻訳

--- a/shared/constants.py
+++ b/shared/constants.py
@@ -22,6 +22,11 @@ DEFAULT_SELECTED_LANGUAGES: list[str] = sorted(ALLOWED_LANGUAGES)
 # Translator が翻訳する対象言語（英語から各言語へ）
 TRANSLATION_LANGUAGES: list[str] = ["ja", "es", "de"]
 
+# ラテン文字系言語（ASCII ヒューリスティックで英語と区別不能）
+LATIN_SCRIPT_LANGUAGES: frozenset[str] = frozenset({
+    "de", "es", "fr", "nl", "pt", "en",
+})
+
 # ---------------------------------------------------------------------------
 # ステータス / スキーマ
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_librarian_tools.py
+++ b/tests/unit/test_librarian_tools.py
@@ -11,7 +11,7 @@ from mystery_agents.tools.librarian_tools import (
     search_newspapers,
 )
 from mystery_agents.tools.search_orchestration import (
-    _is_likely_english,
+    _is_ascii_only,
     _log_keyword_language_mismatch,
     _rank_documents,
     _search_single_source,
@@ -736,47 +736,72 @@ class TestNewspaperDispatcher:
 # === キーワード言語診断ログのテスト ===
 
 
-class TestIsLikelyEnglish:
-    """_is_likely_english のテスト"""
+class TestIsAsciiOnly:
+    """_is_ascii_only のテスト"""
 
-    def test_ascii_keyword_is_english(self):
-        """ASCII のみのキーワードは英語と判定される。"""
-        assert _is_likely_english("nightmare") is True
-        assert _is_likely_english("sleep paralysis") is True
+    def test_ascii_keyword_returns_true(self):
+        """ASCII のみのキーワードは True を返す。"""
+        assert _is_ascii_only("nightmare") is True
+        assert _is_ascii_only("sleep paralysis") is True
 
-    def test_german_keyword_is_not_english(self):
-        """ウムラウト含むキーワードは非英語と判定される。"""
-        assert _is_likely_english("Alpträume") is False
-        assert _is_likely_english("Ärzte") is False
+    def test_umlaut_keyword_returns_false(self):
+        """ウムラウト含むキーワードは False を返す。"""
+        assert _is_ascii_only("Alpträume") is False
+        assert _is_ascii_only("Ärzte") is False
 
-    def test_french_keyword_is_not_english(self):
-        """アクセント含むキーワードは非英語と判定される。"""
-        assert _is_likely_english("cauchemar médical") is False
+    def test_accent_keyword_returns_false(self):
+        """アクセント含むキーワードは False を返す。"""
+        assert _is_ascii_only("cauchemar médical") is False
 
-    def test_dutch_keyword_is_not_english(self):
-        """オランダ語特有のアクセントを含むキーワード。"""
-        assert _is_likely_english("geneeskunde") is True  # ASCII のみだが正しいオランダ語
-        assert _is_likely_english("coöperatie") is False
+    def test_dutch_mixed_keyword(self):
+        """オランダ語: ASCII のみなら True、非 ASCII があれば False。"""
+        assert _is_ascii_only("geneeskunde") is True
+        assert _is_ascii_only("coöperatie") is False
 
     def test_empty_string(self):
         """空文字列は ASCII のみ扱い。"""
-        assert _is_likely_english("") is True
+        assert _is_ascii_only("") is True
 
 
 class TestLogKeywordLanguageMismatch:
     """_log_keyword_language_mismatch のテスト"""
 
-    def test_warning_for_all_ascii_keywords_non_english_lang(self, caplog):
-        """非英語言語で全キーワードが ASCII のみの場合に警告が出る。"""
+    def test_no_warning_for_latin_script_language(self, caplog):
+        """ラテン文字言語（de）で全キーワードが ASCII → WARNING は出ない。"""
         import logging
 
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.DEBUG):
             _log_keyword_language_mismatch(
                 ["nightmare", "sleep paralysis"], "de"
             )
 
+        # WARNING レベルのログは出ないこと
+        warning_records = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert not warning_records
+
+    def test_debug_log_for_latin_script_language(self, caplog):
+        """ラテン文字言語（de）で全キーワードが ASCII → DEBUG ログが出力される。"""
+        import logging
+
+        with caplog.at_level(logging.DEBUG):
+            _log_keyword_language_mismatch(
+                ["nightmare", "sleep paralysis"], "de"
+            )
+
+        debug_records = [r for r in caplog.records if r.levelno == logging.DEBUG]
+        assert any("キーワード言語不一致" in r.message for r in debug_records)
+
+    def test_warning_for_non_latin_script_language(self, caplog):
+        """非ラテン文字言語（ja）で全キーワードが ASCII → WARNING が出る。"""
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            _log_keyword_language_mismatch(
+                ["nightmare", "sleep paralysis"], "ja"
+            )
+
         assert "キーワード言語不一致" in caplog.text
-        assert "de" in caplog.text
+        assert "ja" in caplog.text
 
     def test_no_warning_for_native_keywords(self, caplog):
         """ネイティブ言語キーワードが含まれる場合は警告なし。"""
@@ -943,21 +968,15 @@ class TestMultilingualKeywordExpansion:
 class TestTranslateKeywordsForSource:
     """_translate_keywords_for_source のテスト。"""
 
-    def test_ddb_english_keywords_triggers_translation(self):
-        """DDB（de 単一言語）に英語キーワード → 翻訳が呼ばれる。"""
+    def test_ddb_latin_script_skips_translation(self):
+        """DDB（de: ラテン文字言語）に ASCII キーワード → 翻訳スキップ（None）。"""
         from mystery_agents.tools.search_orchestration import _translate_keywords_for_source
 
         ddb_source = _make_mock_source(
             source_key="ddb", supported_languages={"de"},
         )
-        with patch(
-            "mystery_agents.tools.search_orchestration.translate_keywords",
-            return_value={"de": ["Geist", "Spuk"]},
-        ) as mock_translate:
-            result = _translate_keywords_for_source(["ghost", "haunting"], ddb_source)
-
-        assert result == ["Geist", "Spuk"]
-        mock_translate.assert_called_once_with(["ghost", "haunting"], "en", ["de"])
+        result = _translate_keywords_for_source(["ghost", "haunting"], ddb_source)
+        assert result is None
 
     def test_ndl_english_keywords_triggers_translation(self):
         """NDL（ja 単一言語）に英語キーワード → 翻訳が呼ばれる。"""
@@ -1011,31 +1030,31 @@ class TestTranslateKeywordsForSource:
         """翻訳失敗時 → None（元キーワードで続行）。"""
         from mystery_agents.tools.search_orchestration import _translate_keywords_for_source
 
-        ddb_source = _make_mock_source(
-            source_key="ddb", supported_languages={"de"},
+        ndl_source = _make_mock_source(
+            source_key="ndl", supported_languages={"ja"},
         )
         with patch(
             "mystery_agents.tools.search_orchestration.translate_keywords",
             return_value={},
         ):
-            result = _translate_keywords_for_source(["ghost"], ddb_source)
+            result = _translate_keywords_for_source(["ghost"], ndl_source)
 
         assert result is None
 
-    def test_mismatch_warning_logged(self, caplog):
-        """不一致検出 + 自動翻訳成功時に WARNING ログが出力される。"""
+    def test_mismatch_warning_logged_for_non_latin(self, caplog):
+        """非ラテン文字ソース（NDL）で不一致検出時に WARNING ログが出力される。"""
         import logging
 
         from mystery_agents.tools.search_orchestration import _translate_keywords_for_source
 
-        ddb_source = _make_mock_source(
-            source_key="ddb", supported_languages={"de"},
+        ndl_source = _make_mock_source(
+            source_key="ndl", supported_languages={"ja"},
         )
         with patch(
             "mystery_agents.tools.search_orchestration.translate_keywords",
-            return_value={"de": ["Geist"]},
+            return_value={"ja": ["幽霊"]},
         ):
             with caplog.at_level(logging.WARNING):
-                _translate_keywords_for_source(["ghost"], ddb_source)
+                _translate_keywords_for_source(["ghost"], ndl_source)
 
         assert "キーワード言語不一致" in caplog.text or "自動翻訳" in caplog.text


### PR DESCRIPTION
## Summary

- `_is_likely_english()` が ASCII チェックのみでドイツ語 "Volksmagie", "Zauberei" 等も英語と誤判定 → 不要な WARNING + Translation API 呼び出し（403 エラー）が発生していた
- `LATIN_SCRIPT_LANGUAGES` 定数を追加し、文字体系に応じた判定分岐を導入
- `_is_likely_english` → `_is_ascii_only` にリネーム（関数の実際の意味に合わせて）

## 変更内容

| ファイル | 変更 |
|---------|------|
| `shared/constants.py` | `LATIN_SCRIPT_LANGUAGES` 定数追加 |
| `mystery_agents/tools/search_orchestration.py` | 3関数修正（リネーム + ログレベル分岐 + 翻訳スキップ） |
| `tests/unit/test_librarian_tools.py` | テスト更新（17テスト全パス） |

## 動作変更

| 言語タイプ | ログレベル | 翻訳 |
|-----------|-----------|------|
| ラテン文字（de/es/fr/nl/pt） | DEBUG（抑制） | スキップ |
| 非ラテン文字（ja 等） | WARNING（維持） | 実行 |

## Test plan

- [x] 対象テスト 17件パス（`pytest -k "AsciiOnly or LogKeyword or TranslateKeywords"`）
- [x] 全ユニットテスト 1237件パス（リグレッションなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)