### PR TITLE
fix: 証拠の妥当性検証 — キーワード無一致 false positive の多層防御

### DIFF
--- a/mystery_agents/agents/polymath_instructions.py
+++ b/mystery_agents/agents/polymath_instructions.py
@@ -92,6 +92,10 @@ Armchair Polymath の instruction を構成する3つのセクション
 #    文書だけでなく、全アーカイブの全文書を表示する。証拠選定を確定する前に確認し、
 #    機関アーカイブの価値ある一次資料が Scholar の分析で簡潔にしか言及されていない
 #    可能性を考慮する。
+# 5. **主題的関連性は妥協不可**: すべての証拠（evidence_a, evidence_b, additional_evidence）は
+#    調査対象のミステリーと直接的かつ実質的な関連を持たなければならない。
+#    語呂合わせ、比喩、同音異義語、テーマ的類推でのみ繋がるソースは有効な証拠ではない。
+#    文書のタイトルが調査対象と関連しない場合、解釈的つながりがどれほど巧みでも選択しない。
 #
 # ## 文字数
 # **5,000〜10,000 words（英語）** — このレポートは Storyteller への唯一の入力である。
@@ -373,6 +377,12 @@ to see all documents collected by the Librarian, organized by archive.
    not just what was prominent in the Scholar analyses. Check it before finalizing evidence
    selection — there may be valuable primary sources from institutional archives that
    the Scholars mentioned only briefly.
+
+5. **Topical relevance is non-negotiable**: Every piece of evidence (evidence_a, evidence_b,
+   additional_evidence) must have a direct, substantive connection to the mystery under
+   investigation. A source connected only through wordplay, metaphor, homonym, or thematic
+   analogy is NOT valid evidence. If a document's title does not relate to the investigation
+   subject, do not select it — regardless of how clever the interpretive connection may seem.
 
 ## Save Structured Report (MANDATORY)
 

--- a/mystery_agents/agents/scholar_instructions.py
+++ b/mystery_agents/agents/scholar_instructions.py
@@ -26,6 +26,13 @@ Multilingual Scholar の instruction テンプレートを定義する。
 # - 解釈に影響する OCR アーティファクトや判読不能箇所に注意する
 # - `raw_text` がないドキュメント（メタデータのみ）でも、タイトル・サマリー・日付から分析可能
 #
+# ## 分析フレームワーク 0.5: ソース関連性検証
+# - 各ドキュメントを分析する前に、調査テーマとの主題的関連性を確認する
+# - アーカイブ API 検索は false positive を返すことがある（無関係な同音異義語やメタデータフィールドでのマッチ）
+# - ドキュメントのタイトルと説明文が調査テーマと明確な関連性を持たない場合:
+#   "FALSE POSITIVE: [タイトル] — 調査と無関係（キーワードの同音異義語またはメタデータマッチの可能性）"とフラグする
+# - false positive ドキュメントに基づいて分析結論を構築してはならない
+#
 # ## 分析フレームワーク 5: ソースカバレッジ評価
 # - デジタル化範囲: この時代・地域の {language_name} 語資料のうちデジタル化済みの割合
 # - OCR 品質: 当該時代の文書のOCR信頼性（活字体変遷、印刷品質、手書き文書）
@@ -68,6 +75,13 @@ INSUFFICIENT_DATA: No {language_name}-language documents available for analysis.
 - Compare specific passages across documents to identify textual discrepancies
 - Note OCR artifacts or illegible sections that may affect interpretation
 - Documents without `raw_text` (metadata only) can still be analyzed via title, summary, and date
+
+### 0.5 Source Relevance Verification
+- Before analyzing each document, verify it is topically relevant to the investigation theme.
+- Archive API searches may return false positives (documents matching on unrelated homonyms or metadata fields).
+- If a document's title and description have no clear connection to the investigation theme, flag it as:
+  "FALSE POSITIVE: [title] — appears unrelated to the investigation (possible keyword homonym or metadata match)"
+- Do NOT build analysis conclusions on false positive documents.
 
 ### 1. Source Analysis
 - Analyze {language_name}-language sources for their unique perspective on the investigation theme

--- a/mystery_agents/tools/document_inventory.py
+++ b/mystery_agents/tools/document_inventory.py
@@ -126,6 +126,7 @@ def get_document_inventory(tool_context: Optional[ToolContext] = None) -> str:
                 "source_url": url,
                 "date": doc.get("date"),
                 "language": doc.get("language", ""),
+                "keywords_matched": len(doc.get("keywords_matched", [])),
             }
             by_archive[archive_name].append(entry)
             total += 1

--- a/mystery_agents/tools/librarian_tools.py
+++ b/mystery_agents/tools/librarian_tools.py
@@ -55,7 +55,8 @@ def _accumulate_archive_images(
             "thumbnail_url": d.get("thumbnail_url"),
         }
         for d in docs_dicts
-        if d.get("thumbnail_url") or d.get("image_url")
+        if (d.get("thumbnail_url") or d.get("image_url"))
+        and d.get("keywords_matched")
     ]
     if images_with_urls:
         existing_images = tool_context.state.get(ARCHIVE_IMAGES, [])

--- a/mystery_agents/tools/publisher_tools.py
+++ b/mystery_agents/tools/publisher_tools.py
@@ -35,12 +35,29 @@ from shared.state_keys import (
     translation_result_key,
 )
 
+from mystery_agents.tools.scholar_tools import _build_url_index
 from mystery_agents.tools.search_metadata import get_search_metadata as _get_search_metadata
 
 from .image_upload import _upload_images_internal
 from .publisher_utils import _extract_json_from_text, _generate_mystery_id
 
 logger = logging.getLogger(__name__)
+
+
+def _audit_evidence_relevance(data: dict, tool_context: ToolContext) -> None:
+    """証拠の妥当性を監査ログに記録する（ブロッキングなし）。"""
+    url_index = _build_url_index(tool_context)
+    if not url_index:
+        return
+    for key in ("evidence_a", "evidence_b"):
+        ev = data.get(key, {})
+        url = ev.get("source_url", "")
+        raw = url_index.get(url)
+        if raw and not raw.get("keywords_matched"):
+            logger.warning(
+                "証拠妥当性監査: %s はキーワード無一致 (title: %s)",
+                key, raw.get("title", "unknown"),
+            )
 
 
 def publish_mystery(
@@ -342,6 +359,10 @@ def publish_mystery(
         data.setdefault("research_questions", [])
         data.setdefault("story_hooks", [])
         data.setdefault("pipeline_log", [])
+
+        # 証拠妥当性の監査ログ（ブロッキングなし、ログ記録のみ）
+        if tool_context is not None:
+            _audit_evidence_relevance(data, tool_context)
 
         mystery_id = data["mystery_id"]
         db.collection("mysteries").document(mystery_id).set(data)

--- a/mystery_agents/tools/scholar_tools.py
+++ b/mystery_agents/tools/scholar_tools.py
@@ -119,6 +119,15 @@ def _validate_evidence_grounding(
             raw_source_type = raw_doc.get("source_type")
             if raw_source_type:
                 ev["archive_source"] = raw_source_type
+
+            # キーワード妥当性チェック
+            kw_matched = raw_doc.get("keywords_matched", [])
+            ev["_kw_match_count"] = len(kw_matched)
+            if not kw_matched:
+                warnings.append(
+                    f"{label}: キーワード無一致 — false positive の可能性 "
+                    f"(title: {raw_doc.get('title', 'unknown')})"
+                )
         else:
             warnings.append(
                 f"{label}: source_url not found in collected documents"
@@ -234,6 +243,21 @@ def save_structured_report(
     # 証拠グラウンディング検証（URL 照合 + メタデータ修正）
     grounding_warnings = _validate_evidence_grounding(report_data, tool_context)
     warnings.extend(grounding_warnings)
+
+    # additional_evidence: キーワード無一致の項目を除外
+    additional = report_data.get("additional_evidence", [])
+    before_kw_filter = len(additional)
+    additional = [ev for ev in additional if ev.pop("_kw_match_count", 1) > 0]
+    kw_removed = before_kw_filter - len(additional)
+    if kw_removed:
+        warnings.append(f"additional_evidence: {kw_removed} 件除外 (キーワード無一致)")
+    report_data["additional_evidence"] = additional
+
+    # evidence_a / evidence_b の一時フィールドをクリーンアップ
+    for key in ("evidence_a", "evidence_b"):
+        ev = report_data.get(key)
+        if ev and isinstance(ev, dict):
+            ev.pop("_kw_match_count", None)
 
     # Store structured report in session state
     tool_context.state[STRUCTURED_REPORT] = report_data

--- a/mystery_agents/tools/search_orchestration.py
+++ b/mystery_agents/tools/search_orchestration.py
@@ -92,6 +92,17 @@ def _search_single_source(
     return key, docs, total_hits, error, fallback_used
 
 
+def _filter_irrelevant_documents(
+    docs: list[ArchiveDocument],
+) -> tuple[list[ArchiveDocument], int]:
+    """keywords_matched が空のドキュメントを除外する。"""
+    filtered = [d for d in docs if d.keywords_matched]
+    removed = len(docs) - len(filtered)
+    if removed > 0:
+        logger.info("キーワード無一致ドキュメント除外: %d 件", removed)
+    return filtered, removed
+
+
 def _rank_documents(
     docs: list[ArchiveDocument],
 ) -> list[ArchiveDocument]:
@@ -101,6 +112,8 @@ def _rank_documents(
     ラウンドロビンで各ソースから1件ずつ取り出して最終リストを構築する。
     これにより、メタデータ豊富な特定ソースが上位を独占するのを防ぐ。
     """
+    docs, _ = _filter_irrelevant_documents(docs)
+
     # ソースごとにグループ化して各グループ内でランキング
     by_source: dict[str, list[ArchiveDocument]] = defaultdict(list)
     for doc in docs:

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -67,5 +67,5 @@ def make_archive_doc(
         language=SourceLanguage.EN,
         location="Test",
         source_type=source_type,
-        keywords_matched=keywords_matched or [],
+        keywords_matched=keywords_matched if keywords_matched is not None else ["test"],
     )

--- a/tests/unit/test_evidence_relevance.py
+++ b/tests/unit/test_evidence_relevance.py
@@ -1,0 +1,332 @@
+"""証拠の妥当性検証テスト。
+
+多層防御（Librarian フィルタ → Scholar ツール検証 → Publisher 監査ログ）
+による false positive 排除をテストする。
+"""
+
+import json
+import logging
+
+import pytest
+
+from tests.fakes import make_archive_doc, make_tool_context
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: Librarian ハードフィルタ
+# ---------------------------------------------------------------------------
+
+
+class TestFilterIrrelevantDocuments:
+    """_filter_irrelevant_documents のテスト。"""
+
+    def test_filter_removes_zero_match_docs(self):
+        """keywords_matched が空のドキュメントを除外する。"""
+        from mystery_agents.tools.search_orchestration import _filter_irrelevant_documents
+
+        docs = [
+            make_archive_doc(url="https://example.com/1", keywords_matched=["key1"]),
+            make_archive_doc(url="https://example.com/2", keywords_matched=[]),
+        ]
+        result, removed = _filter_irrelevant_documents(docs)
+        assert len(result) == 1
+        assert result[0].source_url == "https://example.com/1"
+        assert removed == 1
+
+    def test_filter_keeps_positive_match_docs(self):
+        """1つ以上のキーワード一致があるドキュメントを保持する。"""
+        from mystery_agents.tools.search_orchestration import _filter_irrelevant_documents
+
+        docs = [
+            make_archive_doc(url="https://example.com/1", keywords_matched=["a"]),
+            make_archive_doc(url="https://example.com/2", keywords_matched=["a", "b"]),
+        ]
+        result, removed = _filter_irrelevant_documents(docs)
+        assert len(result) == 2
+        assert removed == 0
+
+    def test_filter_empty_input(self):
+        """空リスト → 空リスト。"""
+        from mystery_agents.tools.search_orchestration import _filter_irrelevant_documents
+
+        result, removed = _filter_irrelevant_documents([])
+        assert result == []
+        assert removed == 0
+
+    def test_filter_all_zero_match(self):
+        """全件0一致 → 空リスト。"""
+        from mystery_agents.tools.search_orchestration import _filter_irrelevant_documents
+
+        docs = [
+            make_archive_doc(url="https://example.com/1", keywords_matched=[]),
+            make_archive_doc(url="https://example.com/2", keywords_matched=[]),
+        ]
+        result, removed = _filter_irrelevant_documents(docs)
+        assert result == []
+        assert removed == 2
+
+
+class TestRankDocumentsExcludesZeroMatch:
+    """_rank_documents 経由での0一致ドキュメント排除テスト。"""
+
+    def test_rank_documents_excludes_zero_match(self):
+        """_rank_documents 経由で0一致 doc が結果に含まれない。"""
+        from mystery_agents.tools.search_orchestration import _rank_documents
+
+        docs = [
+            make_archive_doc(url="https://example.com/1", keywords_matched=["key"]),
+            make_archive_doc(url="https://example.com/2", keywords_matched=[]),
+            make_archive_doc(url="https://example.com/3", keywords_matched=["a", "b"]),
+        ]
+        result = _rank_documents(docs)
+        urls = [d.source_url for d in result]
+        assert "https://example.com/2" not in urls
+        assert len(result) == 2
+
+
+class TestAccumulateImagesExcludesZeroMatch:
+    """_accumulate_archive_images の0一致フィルタテスト。"""
+
+    def test_accumulate_images_excludes_zero_match(self):
+        """keywords_matched が空のドキュメントの画像は蓄積されない。"""
+        from mystery_agents.tools.librarian_tools import _accumulate_archive_images
+
+        ctx = make_tool_context()
+        docs_dicts = [
+            {
+                "title": "Relevant",
+                "source_url": "https://example.com/1",
+                "source_type": "loc_digital",
+                "thumbnail_url": "https://example.com/thumb1.jpg",
+                "keywords_matched": ["key1"],
+            },
+            {
+                "title": "Irrelevant",
+                "source_url": "https://example.com/2",
+                "source_type": "europeana",
+                "thumbnail_url": "https://example.com/thumb2.jpg",
+                "keywords_matched": [],
+            },
+        ]
+        _accumulate_archive_images(ctx, docs_dicts)
+        images = ctx.state.get("archive_images", [])
+        assert len(images) == 1
+        assert images[0]["title"] == "Relevant"
+
+
+# ---------------------------------------------------------------------------
+# Layer 3: Scholar ツール検証 + Polymath インベントリ
+# ---------------------------------------------------------------------------
+
+
+class TestGroundingWarnsZeroKeywordMatch:
+    """_validate_evidence_grounding のキーワード検証テスト。"""
+
+    def test_grounding_warns_zero_keyword_match(self):
+        """0一致 evidence に警告が生成される。"""
+        from mystery_agents.tools.scholar_tools import _validate_evidence_grounding
+
+        ctx = make_tool_context(state={
+            "raw_search_results": [
+                {
+                    "documents": [
+                        {
+                            "source_url": "https://example.com/1",
+                            "title": "Irrelevant French Textile",
+                            "keywords_matched": [],
+                        },
+                    ],
+                },
+            ],
+        })
+        report_data = {
+            "evidence_a": {"source_url": "https://example.com/1"},
+        }
+        warnings = _validate_evidence_grounding(report_data, ctx)
+        assert any("キーワード無一致" in w for w in warnings)
+
+    def test_grounding_no_warn_positive_match(self):
+        """1+一致 evidence に警告なし。"""
+        from mystery_agents.tools.scholar_tools import _validate_evidence_grounding
+
+        ctx = make_tool_context(state={
+            "raw_search_results": [
+                {
+                    "documents": [
+                        {
+                            "source_url": "https://example.com/1",
+                            "title": "Relevant Document",
+                            "keywords_matched": ["tichborne"],
+                        },
+                    ],
+                },
+            ],
+        })
+        report_data = {
+            "evidence_a": {"source_url": "https://example.com/1"},
+        }
+        warnings = _validate_evidence_grounding(report_data, ctx)
+        assert not any("キーワード無一致" in w for w in warnings)
+
+
+class TestAdditionalEvidenceZeroMatchRemoved:
+    """save_structured_report の additional_evidence ポストフィルタテスト。"""
+
+    def test_additional_evidence_zero_match_removed(self):
+        """additional_evidence の0一致項目が除外される。"""
+        from mystery_agents.tools.scholar_tools import save_structured_report
+
+        ctx = make_tool_context(state={
+            "_inventory_consulted": True,
+            "_word_count_verified": True,
+            "raw_search_results": [
+                {
+                    "documents": [
+                        {
+                            "source_url": "https://example.com/relevant",
+                            "title": "Relevant Doc",
+                            "keywords_matched": ["key1"],
+                        },
+                        {
+                            "source_url": "https://example.com/irrelevant",
+                            "title": "Irrelevant Doc",
+                            "keywords_matched": [],
+                        },
+                    ],
+                },
+            ],
+        })
+        report = {
+            "classification": "HIS",
+            "country_code": "GB",
+            "region_code": "LHR",
+            "title": "Test",
+            "summary": "Test",
+            "additional_evidence": [
+                {
+                    "source_url": "https://example.com/relevant",
+                    "relevant_excerpt": "Some text",
+                },
+                {
+                    "source_url": "https://example.com/irrelevant",
+                    "relevant_excerpt": "Some text",
+                },
+            ],
+        }
+        result = json.loads(save_structured_report(json.dumps(report), ctx))
+        assert result["status"] == "success"
+        # structured_report が保存されていることを確認
+        saved = ctx.state.get("structured_report", {})
+        assert len(saved["additional_evidence"]) == 1
+        assert saved["additional_evidence"][0]["source_url"] == "https://example.com/relevant"
+
+    def test_evidence_ab_zero_match_warned_not_removed(self):
+        """evidence_a/b は警告のみ、除外されない。"""
+        from mystery_agents.tools.scholar_tools import save_structured_report
+
+        ctx = make_tool_context(state={
+            "_inventory_consulted": True,
+            "_word_count_verified": True,
+            "raw_search_results": [
+                {
+                    "documents": [
+                        {
+                            "source_url": "https://example.com/a",
+                            "title": "Zero Match A",
+                            "keywords_matched": [],
+                        },
+                    ],
+                },
+            ],
+        })
+        report = {
+            "classification": "HIS",
+            "country_code": "GB",
+            "region_code": "LHR",
+            "title": "Test",
+            "summary": "Test",
+            "evidence_a": {
+                "source_url": "https://example.com/a",
+                "relevant_excerpt": "Some text",
+            },
+        }
+        result = json.loads(save_structured_report(json.dumps(report), ctx))
+        assert result["status"] == "success"
+        # evidence_a は除外されない
+        saved = ctx.state.get("structured_report", {})
+        assert saved["evidence_a"]["source_url"] == "https://example.com/a"
+        # 警告が生成されている
+        assert any("キーワード無一致" in w for w in result["warnings"])
+
+
+class TestInventoryIncludesKeywordsMatched:
+    """document_inventory に keywords_matched カウントが含まれるテスト。"""
+
+    def test_inventory_includes_keywords_matched(self):
+        """インベントリに keywords_matched カウントが含まれる。"""
+        from mystery_agents.tools.document_inventory import get_document_inventory
+
+        ctx = make_tool_context(state={
+            "raw_search_results": [
+                {
+                    "documents": [
+                        {
+                            "source_url": "https://example.com/doc1",
+                            "title": "Doc 1",
+                            "source_type": "loc_digital",
+                            "language": "en",
+                            "keywords_matched": ["key1", "key2"],
+                        },
+                        {
+                            "source_url": "https://example.com/doc2",
+                            "title": "Doc 2",
+                            "source_type": "europeana",
+                            "language": "de",
+                            "keywords_matched": [],
+                        },
+                    ],
+                },
+            ],
+        })
+        result = json.loads(get_document_inventory(ctx))
+        assert result["status"] == "ok"
+        # 全アーカイブの全文書で keywords_matched カウントを確認
+        for archive_docs in result["by_archive"].values():
+            for doc in archive_docs:
+                assert "keywords_matched" in doc
+                assert isinstance(doc["keywords_matched"], int)
+
+
+# ---------------------------------------------------------------------------
+# Layer 4: Publisher 監査ログ
+# ---------------------------------------------------------------------------
+
+
+class TestPublisherAuditLog:
+    """Publisher 監査ログのテスト。"""
+
+    def test_publisher_audit_logs_zero_match(self, caplog):
+        """Publisher 監査ログが0一致を検出する。"""
+        from mystery_agents.tools.publisher_tools import _audit_evidence_relevance
+
+        ctx = make_tool_context(state={
+            "raw_search_results": [
+                {
+                    "documents": [
+                        {
+                            "source_url": "https://example.com/bad",
+                            "title": "Irrelevant French Textile",
+                            "keywords_matched": [],
+                        },
+                    ],
+                },
+            ],
+        })
+        data = {
+            "evidence_a": {"source_url": "https://example.com/bad"},
+            "evidence_b": {"source_url": "https://example.com/missing"},
+        }
+        with caplog.at_level(logging.WARNING):
+            _audit_evidence_relevance(data, ctx)
+        assert any("証拠妥当性監査" in r.message for r in caplog.records)
+        assert any("evidence_a" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

HIS-GB-LHR-20260227230600（ティッチボーン事件）で、Europeana からの無関係な検索結果（フランスの繊維製造イラスト集）が `evidence_b` として採用された問題を、4層の多層防御で解決する。

**根本原因**: キーワード一致ゼロの false positive が Librarian → Scholar → Polymath → Publisher のパイプライン全体を素通りした。

### 変更内容

- **L1 Librarian（ハードフィルタ）**: `_filter_irrelevant_documents` で `keywords_matched` が空のドキュメントを除外。`_accumulate_archive_images` にも同条件を追加
- **L2 Scholar（ソフトインストラクション）**: `BASE_SCHOLAR_INSTRUCTION` に Source Relevance Verification セクション追加（false positive を検出・フラグ）
- **L3 Polymath（インストラクション + ツール検証）**: 選定原則5「主題的関連性は妥協不可」追加。`_validate_evidence_grounding` にキーワード検証追加。`additional_evidence` のキーワード無一致項目をポストフィルタ。`document_inventory` に `keywords_matched` カウント表示
- **L4 Publisher（監査ログ）**: `_audit_evidence_relevance` 関数追加。Firestore 書き込み前にキーワード無一致を警告ログに記録（ブロッキングなし）

### テスト

- 新規テスト: `tests/unit/test_evidence_relevance.py`（12テスト）
- 既存テスト: 1242テスト全パス（回帰なし）

## Test plan

- [x] `python -m pytest tests/unit/test_evidence_relevance.py -v` — 12/12 passed
- [x] `python -m pytest tests/unit/ -v` — 1242/1242 passed
- [ ] 次回パイプライン実行時に pipeline.log で "キーワード無一致ドキュメント除外" ログを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)