### PR TITLE
feat: Podcast 20分化 — Firestore データ活用 + 15分ナレーション指示

### DIFF
--- a/podcast_agents/agents/script_planner.py
+++ b/podcast_agents/agents/script_planner.py
@@ -21,9 +21,9 @@ from ..tools.script_tools import save_script_outline
 # Storyteller が作成したブログ記事を分析し、ポッドキャスト脚本の詳細なアウトラインを設計する専門家です。
 #
 # ## あなたの役割
-# ブログ原稿（{creative_content}）を読み込み、約5分のポッドキャストエピソード（約750語）の
-# セグメント構成を設計します。このアウトラインは後続の Scriptwriter Agent が各セグメントを
-# 逐次執筆するためのブループリントとなります。
+# ブログ原稿（{creative_content}）と補助材料を読み込み、約15分のポッドキャストエピソード
+# （約2250語）のセグメント構成を設計します。このアウトラインは後続の Scriptwriter Agent が
+# 各セグメントを逐次執筆するためのブループリントとなります。
 #
 # ## 最重要ルール：資料に基づかないコンテンツは生成しない
 # セッション状態の {creative_content} を確認してください。
@@ -40,8 +40,24 @@ from ..tools.script_tools import save_script_outline
 # 空の場合はデフォルトの構成で設計してください。
 #
 # ## 入力
-# - {creative_content}: Storyteller が作成したブログ原稿
+# - {creative_content}: Storyteller が作成したブログ原稿（主要ソース）
+# - {mystery_report}: Armchair Polymath の統合分析テキスト（分析の深掘り用）
+# - {evidence_summary}: 一次資料の証拠サマリー（直接引用用）
+# - {story_hooks}: ナラティブフック一覧（フック設計用）
+# - {research_questions}: 未解決の研究課題一覧（締め括りの問い用）
 # - {custom_instructions}: 管理者からのカスタム指示（空の場合あり）
+#
+# ## 補助材料の活用ガイダンス
+# ブログ原稿 ({creative_content}) が主要ソースです。以下の補助材料は深みと具体性を加えるために使います：
+# - **mystery_report**: Polymath の学際分析。ブログ記事より詳細な矛盾の考察や言語横断の知見を含む。
+#   Act II（証拠分析）と Act IIII（統合考察）の key_points を豊かにするために活用する。
+# - **evidence_summary**: 一次資料の出典・日付・抜粋の構造化データ。
+#   各 Act で具体的な引用ポイントを計画する際に参照する。
+# - **story_hooks**: Polymath が特定したナラティブフック。
+#   Overview のオープニングフックや各 Act の転換点に活用する。
+# - **research_questions**: 未解決の問い。
+#   Act IIII のサインオフで「残された謎」として使い、リスナーの余韻を深める。
+# 補助材料が空の場合は、ブログ原稿のみからアウトラインを設計してください。
 #
 # ## 固定 5 セグメント構成（厳守）
 # エピソードは**必ず以下の 5 セグメント**で構成します。セグメント数を増減しないでください。
@@ -54,12 +70,12 @@ from ..tools.script_tools import save_script_outline
 # | act_iii | Act III | 民俗学・地元伝承・怪異的要素 |
 # | act_iiii | Act IIII | 統合考察・仮説提示 + エピソードのサインオフ |
 #
-# ## 語数配分（合計 ~750 語 / ~5 分）
-# - overview: ~100 語（固定挨拶を含む）
-# - act_i: ~150 語
-# - act_ii: ~175 語
-# - act_iii: ~175 語
-# - act_iiii: ~150 語（サインオフを含む）
+# ## 語数配分（合計 ~2250 語 / ~15 分）
+# - overview: ~200 語（固定挨拶を含む）
+# - act_i: ~450 語
+# - act_ii: ~600 語
+# - act_iii: ~550 語
+# - act_iiii: ~450 語（サインオフを含む）
 #
 # ## Overview のフック技法
 # オープニングフック（固定挨拶の直後）は、10秒以内にリスナーの注意を掴まなければならない。
@@ -99,8 +115,8 @@ for podcast episodes. Your outline serves as the blueprint for the Scriptwriter 
 which will write each segment one by one.
 
 ## Your Role
-Read the blog article from {creative_content} and design the segment structure
-for a ~5-minute podcast episode (~750 words total).
+Read the blog article from {creative_content} and supplementary materials, then design
+the segment structure for a ~15-minute podcast episode (~2250 words total).
 
 ## Critical Rule: Do Not Generate Content Without Source Material
 Check {creative_content} in the session state.
@@ -119,8 +135,26 @@ the outline design. Examples:
 If empty, use the default structure.
 
 ## Input
-- {creative_content}: Blog article written by the Storyteller
+- {creative_content}: Blog article written by the Storyteller (primary source)
+- {mystery_report}: Armchair Polymath's integrated analysis text (for deeper analysis)
+- {evidence_summary}: Structured summary of primary source evidence (for direct citations)
+- {story_hooks}: List of narrative hooks (for hook design)
+- {research_questions}: List of unresolved research questions (for closing questions)
 - {custom_instructions}: Admin's custom instructions (may be empty)
+
+## How to Use Supplementary Materials
+The blog article ({creative_content}) is your primary source. Use the supplementary
+materials below to add depth and specificity:
+- **mystery_report**: The Polymath's interdisciplinary analysis. Contains more detailed
+  contradiction analysis and cross-linguistic insights than the blog article.
+  Use it to enrich key_points for Act II (evidence analysis) and Act IIII (synthesis).
+- **evidence_summary**: Structured data with source titles, dates, and excerpts.
+  Reference it when planning specific citation points in each Act.
+- **story_hooks**: Narrative hooks identified by the Polymath.
+  Use them for the Overview's opening hook and turning points in each Act.
+- **research_questions**: Unresolved questions.
+  Use them in Act IIII's sign-off as "lingering mysteries" to deepen the listener's afterglow.
+If any supplementary material is empty, design the outline from the blog article alone.
 
 ## Fixed 5-Segment Structure (MANDATORY)
 Every episode MUST have exactly these 5 segments. Do NOT add or remove segments.
@@ -133,12 +167,12 @@ Every episode MUST have exactly these 5 segments. Do NOT add or remove segments.
 | act_iii | Act III | Folklore, local legends, uncanny elements |
 | act_iiii | Act IIII | Synthesis, hypothesis, sign-off |
 
-## Word Allocation (~750 words total / ~5 minutes)
-- overview: ~100 words (including fixed greeting)
-- act_i: ~150 words
-- act_ii: ~175 words
-- act_iii: ~175 words
-- act_iiii: ~150 words (including sign-off)
+## Word Allocation (~2250 words total / ~15 minutes)
+- overview: ~200 words (including fixed greeting)
+- act_i: ~450 words
+- act_ii: ~600 words
+- act_iii: ~550 words
+- act_iiii: ~450 words (including sign-off)
 
 ## Hook Technique for Overview
 The opening hook (after the fixed greeting) must seize the listener's attention within 10 seconds.
@@ -157,8 +191,10 @@ Do NOT plan a generic "introduce the topic" opener.
 ## Outline Design Guidelines
 1. Identify the key narrative elements: historical facts, folklore elements,
    evidence, mystery hooks, resolution/speculation
-2. Map blog content to the 5 fixed segments
+2. Map blog content and supplementary materials to the 5 fixed segments
 3. Follow the word targets above (redistribute slightly if needed)
+4. Plan more key_points per segment than the short version — each Act now has
+   room for 4-6 key_points with concrete details from the source material
 
 ## MANDATORY: Call save_script_outline
 After designing the outline, you MUST call `save_script_outline` with a JSON string:
@@ -166,46 +202,46 @@ After designing the outline, you MUST call `save_script_outline` with a JSON str
 ```json
 {{
   "episode_title": "Episode title - hinting at both fact and the uncanny",
-  "estimated_duration_minutes": 5,
-  "total_word_target": 750,
+  "estimated_duration_minutes": 15,
+  "total_word_target": 2250,
   "segments": [
     {{
       "type": "overview",
       "label": "Overview",
-      "key_points": ["Fixed greeting", "Specific hook question from the blog", "Set the scene"],
-      "word_target": 100,
+      "key_points": ["Fixed greeting", "Specific hook question from the blog", "Set the scene", "Brief roadmap of the episode"],
+      "word_target": 200,
       "source_sections": ["opening paragraph of blog"],
       "tone_notes": "Curiosity — after greeting, hook with a provocative question"
     }},
     {{
       "type": "act_i",
       "label": "Act I",
-      "key_points": ["Date and location", "Key figures involved"],
-      "word_target": 150,
+      "key_points": ["Date and location", "Key figures involved", "Social/political context", "The world before the anomaly"],
+      "word_target": 450,
       "source_sections": ["historical context section"],
       "tone_notes": "Grounding — scholarly, establishing credibility"
     }},
     {{
       "type": "act_ii",
       "label": "Act II",
-      "key_points": ["Central discrepancy", "Evidence analysis"],
-      "word_target": 175,
-      "source_sections": ["evidence section"],
+      "key_points": ["Central discrepancy", "Evidence A details", "Evidence B details", "Cross-reference analysis", "What the contradiction implies"],
+      "word_target": 600,
+      "source_sections": ["evidence section", "mystery_report analysis"],
       "tone_notes": "Tension — contradictions mount, detective mode"
     }},
     {{
       "type": "act_iii",
       "label": "Act III",
-      "key_points": ["Local beliefs", "Cultural context"],
-      "word_target": 175,
+      "key_points": ["Local beliefs", "Cultural context", "Folklore-fact correlation", "The uncanny pattern"],
+      "word_target": 550,
       "source_sections": ["folklore section"],
       "tone_notes": "Unease — the uncanny emerges, folklore blurs the line"
     }},
     {{
       "type": "act_iiii",
       "label": "Act IIII",
-      "key_points": ["Synthesis of evidence and folklore", "Hypothesis", "Lingering questions"],
-      "word_target": 150,
+      "key_points": ["Synthesis of evidence and folklore", "Hypothesis", "Alternative explanations", "Lingering questions from research_questions"],
+      "word_target": 450,
       "source_sections": ["analysis/synthesis section", "conclusion"],
       "tone_notes": "Lingering dread — sign-off with more questions than answers"
     }}

--- a/podcast_agents/agents/scriptwriter.py
+++ b/podcast_agents/agents/scriptwriter.py
@@ -22,7 +22,8 @@ from ..tools.script_tools import save_segment, finalize_script
 # 逐次執筆する専門家です。
 #
 # ## あなたの役割
-# ブログ原稿（{creative_content}）とアウトライン（{script_outline}）を読み込み、
+# ブログ原稿（{creative_content}）、アウトライン（{script_outline}）、
+# および補助材料（{mystery_report}, {evidence_summary}）を読み込み、
 # 各セグメントを1つずつ執筆して save_segment ツールで保存します。
 # 全セグメント完了後、finalize_script を呼んで最終スクリプトを組み立てます。
 #
@@ -41,9 +42,24 @@ from ..tools.script_tools import save_segment, finalize_script
 # 空の場合はデフォルトのスタイルで作成してください。
 #
 # ## 入力
-# - {creative_content}: Storyteller が作成したブログ原稿
+# - {creative_content}: Storyteller が作成したブログ原稿（主要ソース）
 # - {script_outline}: Script Planner が設計したセグメントアウトライン
+# - {mystery_report}: Armchair Polymath の統合分析テキスト（深掘り・補助材料）
+# - {evidence_summary}: 一次資料の証拠サマリー（直接引用・補助材料）
 # - {custom_instructions}: 管理者からのカスタム指示（空の場合あり）
+#
+# ## 補助材料の活用
+# ブログ原稿 ({creative_content}) とアウトライン ({script_outline}) が主要ソースです。
+# 以下の補助材料は、セグメントの語数ターゲットを満たすために深みと具体性を加えるために使います：
+# - **mystery_report**: ブログ記事より詳細な分析・考察を含む。特に Act II と Act IIII で
+#   矛盾の深掘りや代替仮説の検討に活用する。
+# - **evidence_summary**: 一次資料の出典・日付・抜粋を含む。具体的な引用（「資料 A は
+#   X と述べている」）に活用する。
+# 補助材料が空の場合は、ブログ原稿のみから執筆してください。
+#
+# ## 語数ターゲット
+# 全5セグメント合計で約2250語を目標にしてください。
+# 各セグメントのアウトラインに指定された word_target を目安にしてください。
 #
 # ## 固定 5 セグメント構成（厳守）
 # 以下の 5 セグメントを**この順番で**1つずつ執筆してください：
@@ -58,7 +74,7 @@ from ..tools.script_tools import save_segment, finalize_script
 # 上記 5 セグメントのそれぞれについて、**1つずつ**以下を実行してください：
 #
 # 1. アウトラインからそのセグメントの key_points, word_target, tone_notes を読む
-# 2. ブログ原稿の該当部分を参照しながらナレーションテキストを執筆する
+# 2. ブログ原稿の該当部分と補助材料を参照しながらナレーションテキストを執筆する
 # 3. `save_segment` ツールを呼び出して保存する
 # 4. 次のセグメントに進む
 #
@@ -131,7 +147,7 @@ from ..tools.script_tools import save_segment, finalize_script
 #
 # ## 音声向けペーシングルール
 # 分析や議論が3〜4文続いたら、以下のいずれか1つを挿入する：
-# - ブログ記事からの具体的な引用またはデータポイント
+# - ブログ記事または証拠サマリーからの具体的な引用またはデータポイント
 # - 日付・場所・人物に紐づいた具体的な感覚的ディテール
 # - リスナーの注意を再び引きつけるレトリカル・クエスチョン
 # 音声リスナーは段落を読み返すことができない。具体的なものに定期的に着地させること。
@@ -180,8 +196,9 @@ You write podcast scripts segment by segment, following the outline designed
 by the Script Planner.
 
 ## Your Role
-Read the blog article from {creative_content} and the segment outline from
-{script_outline}, then write each segment one at a time using the save_segment tool.
+Read the blog article from {creative_content}, the segment outline from
+{script_outline}, and the supplementary materials ({mystery_report}, {evidence_summary}),
+then write each segment one at a time using the save_segment tool.
 After all segments are saved, call finalize_script to assemble the final script.
 
 ## Critical Rule: Failure Marker Check
@@ -199,9 +216,25 @@ Examples: "Make it scarier", "Focus on this particular fact", "More jokes please
 If empty, use the default style.
 
 ## Input
-- {creative_content}: Blog article written by the Storyteller
+- {creative_content}: Blog article written by the Storyteller (primary source)
 - {script_outline}: Segment outline designed by the Script Planner
+- {mystery_report}: Armchair Polymath's integrated analysis text (supplementary — for deeper analysis)
+- {evidence_summary}: Structured summary of primary source evidence (supplementary — for direct citations)
 - {custom_instructions}: Admin's custom instructions (may be empty)
+
+## Additional Source Material
+The blog article ({creative_content}) and outline ({script_outline}) are your primary sources.
+Use the supplementary materials below to add depth and meet the word targets:
+- **mystery_report**: Contains more detailed contradiction analysis, cross-linguistic insights,
+  and alternative hypotheses than the blog article. Draw on it especially for Act II
+  (evidence deep-dive) and Act IIII (synthesis and alternative explanations).
+- **evidence_summary**: Contains source titles, dates, and excerpts from primary sources.
+  Use it for concrete citations ("According to [source_title], dated [source_date]...").
+If supplementary materials are empty, write from the blog article alone.
+
+## Word Target
+Aim for ~2250 words total across the 5 segments.
+Follow the outline's word_target for each segment.
 
 ## Fixed 5-Segment Structure (MANDATORY)
 Write exactly these 5 segments IN THIS ORDER:
@@ -289,7 +322,7 @@ to maintain narrative momentum across the audio gap.
 
 ## Pacing Rule for Audio
 After every 3-4 sentences of analysis or argument, insert ONE of:
-- A specific quote or data point from the blog article
+- A specific quote or data point from the blog article or evidence_summary
 - A concrete sensory detail anchored to a date, place, or person
 - A rhetorical question that re-engages the listener
 Audio listeners cannot re-read a paragraph. Ground them regularly in something concrete.

--- a/podcast_agents/cli.py
+++ b/podcast_agents/cli.py
@@ -11,6 +11,7 @@ Usage:
 """
 
 import asyncio
+import json
 import sys
 from pathlib import Path
 
@@ -33,6 +34,58 @@ from shared.pipeline_run import create_pipeline_run
 
 
 PIPELINE_TIMEOUT_SECONDS = 1200  # 20分
+
+# Evidence 型フィールドのキー（人間可読テキスト整形用）
+_EVIDENCE_FIELDS = (
+    "source_title", "source_date", "source_type", "source_language",
+    "relevant_excerpt", "source_url", "location_context",
+)
+
+
+def _format_single_evidence(label: str, evidence: dict) -> str:
+    """単一の Evidence オブジェクトを人間可読テキストに整形する。"""
+    lines = [f"### {label}"]
+    for field in _EVIDENCE_FIELDS:
+        value = evidence.get(field)
+        if value:
+            lines.append(f"- {field}: {value}")
+    # フィールドが1つもなければ空文字を返す
+    return "\n".join(lines) if len(lines) > 1 else ""
+
+
+def _format_evidence_summary(mystery: dict) -> str:
+    """mystery ドキュメントの evidence フィールドを人間可読テキストに整形する。
+
+    Evidence A, Evidence B, Additional Evidence を統合し、
+    ScriptPlanner / Scriptwriter が証拠を直接引用できるテキストを生成する。
+    空の場合は空文字列を返す。
+    """
+    sections: list[str] = []
+
+    # Evidence A
+    ev_a = mystery.get("evidence_a")
+    if ev_a and isinstance(ev_a, dict):
+        text = _format_single_evidence("Evidence A", ev_a)
+        if text:
+            sections.append(text)
+
+    # Evidence B
+    ev_b = mystery.get("evidence_b")
+    if ev_b and isinstance(ev_b, dict):
+        text = _format_single_evidence("Evidence B", ev_b)
+        if text:
+            sections.append(text)
+
+    # Additional Evidence
+    additional = mystery.get("additional_evidence")
+    if additional and isinstance(additional, list):
+        for i, ev in enumerate(additional, 1):
+            if isinstance(ev, dict):
+                text = _format_single_evidence(f"Additional Evidence {i}", ev)
+                if text:
+                    sections.append(text)
+
+    return "\n\n".join(sections)
 
 
 async def generate_script(
@@ -109,6 +162,17 @@ async def generate_script(
             initial_state={
                 "creative_content": narrative_content,
                 "custom_instructions": custom_instructions,
+                # Polymath 統合分析テキスト（最も情報量が多い補助材料）
+                "mystery_report": mystery.get("mystery_report", ""),
+                # 証拠サマリー（evidence_a/b/additional を整形）
+                "evidence_summary": _format_evidence_summary(mystery),
+                # ナラティブフック・未解決の研究課題
+                "story_hooks": json.dumps(
+                    mystery.get("story_hooks", []), ensure_ascii=False,
+                ),
+                "research_questions": json.dumps(
+                    mystery.get("research_questions", []), ensure_ascii=False,
+                ),
                 # 後続エージェントの instruction プレースホルダー解決用に初期化
                 # ScriptPlanner/Scriptwriter が output_key で上書きする
                 "script_outline": "",

--- a/tests/unit/test_podcast_cli_helpers.py
+++ b/tests/unit/test_podcast_cli_helpers.py
@@ -1,0 +1,112 @@
+"""Unit tests for podcast_agents/cli.py — _format_evidence_summary ヘルパー関数。
+
+仕様:
+- Evidence 型フィールドを人間可読テキストに整形する
+- フルデータ / 部分データ / 空データの3パターンで正しく動作する
+"""
+
+import pytest
+
+from podcast_agents.cli import _format_evidence_summary
+
+
+class TestFormatEvidenceSummary:
+    """_format_evidence_summary() のテスト。"""
+
+    def test_full_data(self):
+        """Should format all evidence fields when fully populated."""
+        mystery = {
+            "evidence_a": {
+                "source_title": "Boston Globe Archive",
+                "source_date": "1892-03-15",
+                "source_type": "newspaper",
+                "source_language": "en",
+                "relevant_excerpt": "The ship was last seen leaving the harbor at dawn.",
+                "source_url": "https://example.com/globe",
+                "location_context": "Boston Harbor, Massachusetts",
+            },
+            "evidence_b": {
+                "source_title": "Harbor Master's Log",
+                "source_date": "1892-03-15",
+                "source_type": "official_record",
+                "source_language": "en",
+                "relevant_excerpt": "No vessel recorded entering or leaving port on this date.",
+                "source_url": "https://example.com/harbor",
+                "location_context": "Boston Harbor, Massachusetts",
+            },
+            "additional_evidence": [
+                {
+                    "source_title": "Local Folklore Collection",
+                    "source_date": "1920",
+                    "source_type": "folklore",
+                    "source_language": "en",
+                    "relevant_excerpt": "Old fishermen spoke of a ghost ship.",
+                    "source_url": "https://example.com/folklore",
+                    "location_context": "Coastal New England",
+                },
+            ],
+        }
+        result = _format_evidence_summary(mystery)
+
+        # Evidence A のフィールドが含まれる
+        assert "Boston Globe Archive" in result
+        assert "1892-03-15" in result
+        assert "The ship was last seen leaving the harbor at dawn." in result
+
+        # Evidence B のフィールドが含まれる
+        assert "Harbor Master's Log" in result
+        assert "No vessel recorded entering or leaving port on this date." in result
+
+        # Additional evidence が含まれる
+        assert "Local Folklore Collection" in result
+        assert "Old fishermen spoke of a ghost ship." in result
+
+    def test_partial_data_only_evidence_a(self):
+        """Should handle mystery with only evidence_a (no evidence_b or additional)."""
+        mystery = {
+            "evidence_a": {
+                "source_title": "Archive Record",
+                "relevant_excerpt": "A single piece of evidence.",
+            },
+        }
+        result = _format_evidence_summary(mystery)
+
+        assert "Archive Record" in result
+        assert "A single piece of evidence." in result
+        # evidence_b / additional がなくてもエラーにならない
+        assert result != ""
+
+    def test_empty_mystery(self):
+        """Should return empty string when mystery has no evidence fields."""
+        result = _format_evidence_summary({})
+        assert result == ""
+
+    def test_empty_evidence_objects(self):
+        """Should return empty string when evidence fields are empty dicts."""
+        mystery = {
+            "evidence_a": {},
+            "evidence_b": {},
+            "additional_evidence": [],
+        }
+        result = _format_evidence_summary(mystery)
+        assert result == ""
+
+    def test_additional_evidence_multiple_items(self):
+        """Should format all items in additional_evidence list."""
+        mystery = {
+            "additional_evidence": [
+                {
+                    "source_title": "Source One",
+                    "relevant_excerpt": "First excerpt.",
+                },
+                {
+                    "source_title": "Source Two",
+                    "relevant_excerpt": "Second excerpt.",
+                },
+            ],
+        }
+        result = _format_evidence_summary(mystery)
+        assert "Source One" in result
+        assert "Source Two" in result
+        assert "First excerpt." in result
+        assert "Second excerpt." in result


### PR DESCRIPTION
## Summary

現在 ~8分の Podcast を ~20分に引き上げるため、以下の2つの施策を実施。

- **Firestore データ活用**: `cli.py` で `load_mystery()` 取得済みの mystery ドキュメントから `mystery_report`（Polymath 統合分析）、`evidence_summary`（一次資料サマリー）、`story_hooks`、`research_questions` を podcast session state に追加。Firestore からの読み取りのみで、ブログパイプラインへの影響なし
- **15分ナレーション指示**: ScriptPlanner の語数配分を ~750語/~5分 → ~2250語/~15分 に引き上げ。固定要素（INTRO/OUTRO 音楽、遷移音、AI 開示 TTS）の ~3分と合わせて合計 ~18.5分 ≈ 約20分

### 変更ファイル
| ファイル | 変更内容 |
|---------|---------|
| `podcast_agents/cli.py` | `_format_evidence_summary` ヘルパー追加、`initial_state` に4キー追加 |
| `podcast_agents/agents/script_planner.py` | 語数配分更新（~2250語）、補助材料活用ガイダンス追加 |
| `podcast_agents/agents/scriptwriter.py` | `mystery_report`/`evidence_summary` 参照セクション追加 |
| `tests/unit/test_podcast_cli_helpers.py` | `_format_evidence_summary` の5テスト追加 |

## Test plan

- [x] `pytest tests/unit/ -v` — 全 1247 テスト通過（新規5テスト含む）
- [ ] 公開済み mystery に対して `python -m podcast_agents script <mystery_id>` を実行し、語数 ~2250 前後を確認
- [ ] 音声生成して尺が ~18-20分前後であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)