### PR TITLE
fix: テストファイル2本の未使用 pytest import を削除（ruff F401）

### DIFF
--- a/tests/unit/test_evidence_relevance.py
+++ b/tests/unit/test_evidence_relevance.py
@@ -7,8 +7,6 @@
 import json
 import logging
 
-import pytest
-
 from tests.fakes import make_archive_doc, make_tool_context
 
 

--- a/tests/unit/test_podcast_cli_helpers.py
+++ b/tests/unit/test_podcast_cli_helpers.py
@@ -5,8 +5,6 @@
 - フルデータ / 部分データ / 空データの3パターンで正しく動作する
 """
 
-import pytest
-
 from podcast_agents.cli import _format_evidence_summary
 
 


### PR DESCRIPTION
## Summary
- `tests/unit/test_evidence_relevance.py` と `tests/unit/test_podcast_cli_helpers.py` から未使用の `import pytest` を削除
- CI の ruff F401 エラーを解消

## Test plan
- [x] `ruff check` でエラーなし確認済み
- [x] 対象テスト17件全パス確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)