### PR TITLE
fix: Podcast "Untitled Episode" 表示バグを3層防御で修正

### DIFF
--- a/podcast_agents/cli.py
+++ b/podcast_agents/cli.py
@@ -161,6 +161,7 @@ async def generate_script(
             user_message=f"以下のブログ記事からポッドキャストを作成してください: {title}",
             initial_state={
                 "creative_content": narrative_content,
+                "mystery_title": title,
                 "custom_instructions": custom_instructions,
                 # Polymath 統合分析テキスト（最も情報量が多い補助材料）
                 "mystery_report": mystery.get("mystery_report", ""),

--- a/podcast_agents/tools/script_tools.py
+++ b/podcast_agents/tools/script_tools.py
@@ -48,6 +48,10 @@ def save_script_outline(
     # バリデーション
     warnings: list[str] = []
 
+    episode_title = data.get("episode_title", "").strip()
+    if not episode_title:
+        warnings.append("episode_title is missing or empty")
+
     segments = data.get("segments")
     if not segments or not isinstance(segments, list):
         return json.dumps(
@@ -196,7 +200,10 @@ def finalize_script(
 
     # structured_outline からメタデータ取得
     outline = tool_context.state.get("structured_outline", {})
-    episode_title = outline.get("episode_title", "Untitled Episode")
+    episode_title = outline.get("episode_title", "").strip()
+    if not episode_title:
+        # mystery_title（cli.py が initial_state にセット）をフォールバック
+        episode_title = tool_context.state.get("mystery_title", "Untitled Episode")
     estimated_duration = outline.get("estimated_duration_minutes", 20)
 
     # 最終スクリプト組み立て

--- a/tests/unit/test_script_planner_tools.py
+++ b/tests/unit/test_script_planner_tools.py
@@ -141,6 +141,37 @@ class TestSaveScriptOutline:
         assert result_data["status"] == "success"
         assert any("key_points" in w for w in result_data["warnings"])
 
+    def test_warns_on_missing_episode_title(self):
+        """episode_title が未設定の場合に warning を返す。"""
+        ctx = make_tool_context()
+        outline = {
+            "segments": [
+                {"type": "intro", "label": "Intro", "key_points": ["Hook"], "word_target": 300},
+            ],
+        }
+
+        result = save_script_outline(json.dumps(outline), ctx)
+        result_data = json.loads(result)
+
+        assert result_data["status"] == "success"
+        assert any("episode_title" in w for w in result_data["warnings"])
+
+    def test_warns_on_empty_episode_title(self):
+        """episode_title が空文字の場合に warning を返す。"""
+        ctx = make_tool_context()
+        outline = {
+            "episode_title": "  ",
+            "segments": [
+                {"type": "intro", "label": "Intro", "key_points": ["Hook"], "word_target": 300},
+            ],
+        }
+
+        result = save_script_outline(json.dumps(outline), ctx)
+        result_data = json.loads(result)
+
+        assert result_data["status"] == "success"
+        assert any("episode_title" in w for w in result_data["warnings"])
+
 
 class TestSaveSegment:
     """save_segment() のテスト。"""
@@ -399,3 +430,38 @@ class TestFinalizeScript:
         # デフォルト値が使われる
         script = ctx.state["structured_script"]
         assert "episode_title" in script
+
+    def test_falls_back_to_mystery_title_when_outline_has_no_episode_title(self):
+        """outline に episode_title がない場合、mystery_title にフォールバックする。"""
+        ctx = self._make_ctx(
+            segments=self._make_segments(),
+            outline={"estimated_duration_minutes": 20},
+        )
+        ctx.state["mystery_title"] = "The Haunting of Salem Archives"
+
+        finalize_script(ctx)
+
+        assert ctx.state["structured_script"]["episode_title"] == "The Haunting of Salem Archives"
+
+    def test_falls_back_to_mystery_title_when_episode_title_is_empty(self):
+        """episode_title が空文字の場合、mystery_title にフォールバックする。"""
+        ctx = self._make_ctx(
+            segments=self._make_segments(),
+            outline={"episode_title": "  ", "estimated_duration_minutes": 20},
+        )
+        ctx.state["mystery_title"] = "The Haunting of Salem Archives"
+
+        finalize_script(ctx)
+
+        assert ctx.state["structured_script"]["episode_title"] == "The Haunting of Salem Archives"
+
+    def test_falls_back_to_untitled_when_no_title_sources(self):
+        """outline にも mystery_title にもない場合、"Untitled Episode" にフォールバックする。"""
+        ctx = self._make_ctx(
+            segments=self._make_segments(),
+            outline={"estimated_duration_minutes": 20},
+        )
+
+        finalize_script(ctx)
+
+        assert ctx.state["structured_script"]["episode_title"] == "Untitled Episode"

--- a/web-admin/src/components/podcast-card.tsx
+++ b/web-admin/src/components/podcast-card.tsx
@@ -26,7 +26,7 @@ export function PodcastCard({ podcast }: PodcastCardProps) {
         <div className="mb-3">
           <div className="flex items-center gap-2 text-sm text-foreground/80 mb-1">
             <FileText className="w-3.5 h-3.5 text-gold" />
-            <span>{podcast.script.episode_title}</span>
+            <span>{podcast.script.episode_title && podcast.script.episode_title !== "Untitled Episode" ? podcast.script.episode_title : podcast.mystery_title}</span>
           </div>
           {podcast.script.estimated_duration_minutes > 0 && (
             <div className="flex items-center gap-1.5 text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary

ScriptPlanner（LLM）が `save_script_outline` ツール呼び出し時に `episode_title` を含めなかった場合、`finalize_script` のフォールバック値 `"Untitled Episode"` が Firestore に保存され、web-admin にそのまま表示される問題を修正。

3層の防御で「Untitled Episode」の表示を防ぐ:

- **`podcast_agents/cli.py`**: `initial_state` に `mystery_title` を追加（フォールバック用）
- **`podcast_agents/tools/script_tools.py`**: `save_script_outline` で `episode_title` 欠落時に warning を返すように変更
- **`podcast_agents/tools/script_tools.py`**: `finalize_script` で outline に `episode_title` がない場合 `mystery_title` にフォールバック
- **`web-admin/src/components/podcast-card.tsx`**: `episode_title` が空または `"Untitled Episode"` の場合に `mystery_title` を表示

## Test plan

- [x] `save_script_outline` で `episode_title` 未設定時に warning が返ることを確認
- [x] `save_script_outline` で `episode_title` 空文字時に warning が返ることを確認
- [x] `finalize_script` で outline に `episode_title` がなく `mystery_title` がある場合のフォールバック確認
- [x] `finalize_script` で `episode_title` 空文字時に `mystery_title` にフォールバックすることを確認
- [x] `finalize_script` で両方ない場合に `"Untitled Episode"` にフォールバックすることを確認
- [x] 既存テスト 26 件が引き続きパスすることを確認（全 31 件パス）
- [x] TypeScript 型チェック通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)