### PR TITLE
fix: test_scholar_tools 4テスト失敗を修正

### DIFF
--- a/mystery_agents/tools/scholar_tools.py
+++ b/mystery_agents/tools/scholar_tools.py
@@ -244,14 +244,15 @@ def save_structured_report(
     grounding_warnings = _validate_evidence_grounding(report_data, tool_context)
     warnings.extend(grounding_warnings)
 
-    # additional_evidence: キーワード無一致の項目を除外
-    additional = report_data.get("additional_evidence", [])
-    before_kw_filter = len(additional)
-    additional = [ev for ev in additional if ev.pop("_kw_match_count", 1) > 0]
-    kw_removed = before_kw_filter - len(additional)
-    if kw_removed:
-        warnings.append(f"additional_evidence: {kw_removed} 件除外 (キーワード無一致)")
-    report_data["additional_evidence"] = additional
+    # additional_evidence: キーワード無一致の項目を除外（フィールドが存在する場合のみ）
+    additional = report_data.get("additional_evidence")
+    if additional is not None:
+        before_kw_filter = len(additional)
+        additional = [ev for ev in additional if ev.pop("_kw_match_count", 1) > 0]
+        kw_removed = before_kw_filter - len(additional)
+        if kw_removed:
+            warnings.append(f"additional_evidence: {kw_removed} 件除外 (キーワード無一致)")
+        report_data["additional_evidence"] = additional
 
     # evidence_a / evidence_b の一時フィールドをクリーンアップ
     for key in ("evidence_a", "evidence_b"):

--- a/tests/unit/test_scholar_tools.py
+++ b/tests/unit/test_scholar_tools.py
@@ -582,6 +582,7 @@ class TestEvidenceGrounding:
                     "source_url": "https://example.com/base",
                     "date": "1800-01-01",
                     "source_type": "dpla",
+                    "keywords_matched": ["keyword"],
                 }],
             }],
             "raw_search_results_ja": [{
@@ -590,6 +591,7 @@ class TestEvidenceGrounding:
                     "source_url": "https://ndl.go.jp/ja/1",
                     "date": "1900-05-01",
                     "source_type": "ndl",
+                    "keywords_matched": ["キーワード"],
                 }],
             }],
         })


### PR DESCRIPTION
## Summary

PR #385「証拠の妥当性検証 — キーワード無一致 false positive の多層防御」で導入した変更が既存テスト4本を壊していた問題を修正。

**根本原因2つ:**
- `additional_evidence` のキーワードフィルターが、フィールド未設定時にも `additional_evidence: []` を無条件代入 → 完全一致アサーション3本が失敗
- テストフィクスチャの raw document に `keywords_matched` フィールドが欠落 → キーワード無一致の false positive 警告が発生

**修正内容:**
- `scholar_tools.py`: `additional_evidence` が `None` でない場合のみフィルター処理を実行するようガード追加
- `test_scholar_tools.py`: `test_grounding_uses_base_and_lang_keys` のフィクスチャに `keywords_matched` フィールドを追加

## Test plan

- [x] `pytest tests/unit/test_scholar_tools.py -v` — 全33テスト pass 確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)