### PR TITLE
fix: Armchair Polymath count_words 無限ループ修正

### DIFF
--- a/mystery_agents/agents/armchair_polymath.py
+++ b/mystery_agents/agents/armchair_polymath.py
@@ -73,6 +73,9 @@ def log_polymath_tool_call(tool, args, tool_context):
                 cw_count,
                 _MAX_COUNT_WORDS_CALLS,
             )
+            # save_structured_report が _word_count_verified を要求するため、
+            # short-circuit 時にもフラグを設定して無限ループを防止する
+            tool_context.state["_word_count_verified"] = True
             return {
                 "word_count": "(skipped)",
                 "within_range": True,

--- a/tests/unit/test_armchair_polymath.py
+++ b/tests/unit/test_armchair_polymath.py
@@ -79,6 +79,9 @@ class TestCountWordsLimiter:
         assert result is not None
         assert result["within_range"] is True
         assert "save_structured_report" in result["message"]
+        # short-circuit 時に _word_count_verified が設定され、
+        # save_structured_report のフラグチェックを通過できること
+        assert mock_tool_context.state["_word_count_verified"] is True
 
     def test_does_not_limit_other_tools(
         self, mock_other_tool, mock_tool_context,
@@ -115,3 +118,4 @@ class TestCountWordsLimiter:
         )
         assert result is not None
         assert result["within_range"] is True
+        assert mock_tool_context.state["_word_count_verified"] is True


### PR DESCRIPTION
## Summary

- Armchair Polymath の `count_words` → `save_structured_report` ピンポンループ（12分超・15+ツールコール浪費）を修正
- `before_tool_callback` の short-circuit パスで `_word_count_verified` フラグが未設定だったため、`save_structured_report` がフラグチェックで拒否 → LLM が `count_words` を再呼び出し → 無限ループ
- short-circuit 時にフラグを設定する1行追加で解消

## 変更内容

| ファイル | 変更 |
|---|---|
| `mystery_agents/agents/armchair_polymath.py` | short-circuit ブロックに `tool_context.state["_word_count_verified"] = True` を追加 |
| `tests/unit/test_armchair_polymath.py` | 既存の short-circuit テスト2件にフラグ検証アサーションを追加 |

## Test plan

- [x] `pytest tests/unit/test_armchair_polymath.py -v` — 6/6 PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)