### PR TITLE
feat: Storyteller LLM メタデータを Firestore に永続化

### DIFF
--- a/mystery_agents/agents/storyteller.py
+++ b/mystery_agents/agents/storyteller.py
@@ -25,6 +25,7 @@ from shared.model_config import (
     STORYTELLER_MODELS,
     create_storyteller_model,
 )
+from shared.state_keys import STORYTELLER_LLM_METADATA
 
 from .storyteller_instructions import STORYTELLER_INSTRUCTION
 
@@ -159,7 +160,7 @@ def _storyteller_after_model(
             metadata["prompt_tokens"],
             metadata["output_tokens"],
         )
-        callback_context.state["storyteller_llm_metadata"] = metadata
+        callback_context.state[STORYTELLER_LLM_METADATA] = metadata
         return None
 
     # 異常応答: メタデータをログ + セッション状態に記録
@@ -189,7 +190,7 @@ def _storyteller_after_model(
         metadata["error_code"],
         extra=metadata,
     )
-    callback_context.state["storyteller_llm_metadata"] = metadata
+    callback_context.state[STORYTELLER_LLM_METADATA] = metadata
     return None
 
 

--- a/mystery_agents/tools/publisher_tools.py
+++ b/mystery_agents/tools/publisher_tools.py
@@ -29,6 +29,7 @@ from shared.state_keys import (
     IMAGE_METADATA,
     MYSTERY_REPORT,
     PUBLISHED_MYSTERY_ID,
+    STORYTELLER_LLM_METADATA,
     STRUCTURED_REPORT,
     collected_documents_key,
     scholar_analysis_key,
@@ -320,6 +321,12 @@ def publish_mystery(
             data["storyteller"] = tool_context.state.get("storyteller", "claude")
         else:
             data.setdefault("storyteller", "claude")
+
+        # ストーリーテラー LLM メタデータ（モデル情報 + トークン使用量）
+        if tool_context is not None:
+            storyteller_meta = tool_context.state.get(STORYTELLER_LLM_METADATA)
+            if storyteller_meta and isinstance(storyteller_meta, dict):
+                data["storyteller_llm_metadata"] = storyteller_meta
 
         # スキーマバージョン（ドキュメント構造の世代管理）
         data["schema_version"] = SCHEMA_VERSION

--- a/packages/shared/src/types/mystery.ts
+++ b/packages/shared/src/types/mystery.ts
@@ -271,11 +271,27 @@ export interface FirestorePodcast {
   error_message?: string | null;
 }
 
+/** ストーリーテラー LLM メタデータ（使用モデル・トークン数・エラー情報） */
+export interface StorytellerLlmMetadata {
+  storyteller: string;
+  display_name: string;
+  model_id: string;
+  actual_model?: string | null;
+  prompt_tokens?: number | null;
+  output_tokens?: number | null;
+  finish_reason?: string | null;
+  error_code?: string | null;
+  error_message?: string | null;
+  has_content?: boolean;
+}
+
 export interface FirestoreMystery extends MysteryReport {
   /** スキーマバージョン: 1 = legacy (*_ja/*_en), 2 = translations map */
   schema_version?: number;
   /** 記事を執筆したストーリーテラー（LLM）の識別子 */
   storyteller?: string;
+  /** ストーリーテラー LLM メタデータ（モデル情報 + トークン使用量） */
+  storyteller_llm_metadata?: StorytellerLlmMetadata;
   /** ステータス: pending, translating, published, archived */
   status: MysteryStatus;
   /** 作成日時（Firestoreタイムスタンプ） */

--- a/shared/orchestrator.py
+++ b/shared/orchestrator.py
@@ -31,6 +31,7 @@ from shared.state_keys import (
     PIPELINE_RUN_ID,
     PUBLISHED_EPISODE,
     PUBLISHED_MYSTERY_ID,
+    STORYTELLER_LLM_METADATA,
     STRUCTURED_REPORT,
 )
 from shared.search_metrics import extract_search_metrics, save_search_metrics
@@ -137,7 +138,7 @@ def _detect_gate_failure(session_state: dict) -> tuple[str, dict]:
     detail = _build_state_summary(session_state)
 
     # LLM メタデータがあれば追加（安全フィルタ等の原因特定用）
-    llm_meta = session_state.get("storyteller_llm_metadata")
+    llm_meta = session_state.get(STORYTELLER_LLM_METADATA)
     if llm_meta:
         detail["storyteller_llm_metadata"] = llm_meta
 

--- a/shared/state_keys.py
+++ b/shared/state_keys.py
@@ -30,6 +30,7 @@ RAW_SEARCH_RESULTS = "raw_search_results"
 PUBLISHED_MYSTERY_ID = "published_mystery_id"
 INVESTIGATION_QUERY = "investigation_query"
 PIPELINE_RUN_ID = "pipeline_run_id"
+STORYTELLER_LLM_METADATA = "storyteller_llm_metadata"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -14,7 +14,7 @@ from shared.orchestrator import (
     _format_exception_group,
     run_pipeline,
 )
-from shared.state_keys import PUBLISHED_EPISODE, PUBLISHED_MYSTERY_ID
+from shared.state_keys import PUBLISHED_EPISODE, PUBLISHED_MYSTERY_ID, STORYTELLER_LLM_METADATA
 from tests.fakes import FakeInMemorySessionService
 
 
@@ -627,10 +627,10 @@ class TestDetectGateFailure:
         state = {
             "mystery_report": "A valid analysis...",
             "creative_content": "",
-            "storyteller_llm_metadata": llm_meta,
+            STORYTELLER_LLM_METADATA: llm_meta,
         }
         _, detail = _detect_gate_failure(state)
-        assert detail["storyteller_llm_metadata"] == llm_meta
+        assert detail[STORYTELLER_LLM_METADATA] == llm_meta
         assert detail["failed_stage"] == "storyteller"
 
     def test_no_storyteller_llm_metadata_when_absent(self):
@@ -640,7 +640,7 @@ class TestDetectGateFailure:
             "creative_content": "",
         }
         _, detail = _detect_gate_failure(state)
-        assert "storyteller_llm_metadata" not in detail
+        assert STORYTELLER_LLM_METADATA not in detail
 
 
 class TestGateFailureIntegration:

--- a/tests/unit/test_publisher_tools.py
+++ b/tests/unit/test_publisher_tools.py
@@ -1141,6 +1141,72 @@ class TestPublishMysteryStructuredDataExtension:
         assert "confidence_rationale" not in saved
 
 
+class TestPublishMysteryStorytellerMetadata:
+    """storyteller_llm_metadata の Firestore 保存テスト。"""
+
+    @patch("mystery_agents.tools.image_upload.get_storage_bucket")
+    @patch("mystery_agents.tools.publisher_tools.get_firestore_client")
+    def test_saves_storyteller_llm_metadata(self, mock_get_db, mock_get_bucket):
+        """state の storyteller_llm_metadata が Firestore に保存される。"""
+        mock_db = MagicMock()
+        mock_get_db.return_value = mock_db
+        mock_get_bucket.return_value = MagicMock()
+
+        llm_meta = {
+            "storyteller": "claude",
+            "display_name": "Claude Sonnet 4.5",
+            "model_id": "claude-sonnet-4-5-20250929",
+            "actual_model": "claude-sonnet-4-5-20250929",
+            "prompt_tokens": 8000,
+            "output_tokens": 3000,
+        }
+        state = {"storyteller_llm_metadata": llm_meta}
+        tool_context = MagicMock()
+        tool_context.state = state
+
+        result = publish_mystery(_make_mystery_json(), "", tool_context)
+        assert json.loads(result)["status"] == "success"
+
+        saved = mock_db.collection.return_value.document.return_value.set.call_args[0][0]
+        assert saved["storyteller_llm_metadata"] == llm_meta
+
+    @patch("mystery_agents.tools.image_upload.get_storage_bucket")
+    @patch("mystery_agents.tools.publisher_tools.get_firestore_client")
+    def test_no_metadata_when_absent(self, mock_get_db, mock_get_bucket):
+        """storyteller_llm_metadata がない場合はフィールドが設定されない。"""
+        mock_db = MagicMock()
+        mock_get_db.return_value = mock_db
+        mock_get_bucket.return_value = MagicMock()
+
+        state = {}
+        tool_context = MagicMock()
+        tool_context.state = state
+
+        result = publish_mystery(_make_mystery_json(), "", tool_context)
+        assert json.loads(result)["status"] == "success"
+
+        saved = mock_db.collection.return_value.document.return_value.set.call_args[0][0]
+        assert "storyteller_llm_metadata" not in saved
+
+    @patch("mystery_agents.tools.image_upload.get_storage_bucket")
+    @patch("mystery_agents.tools.publisher_tools.get_firestore_client")
+    def test_ignores_non_dict_metadata(self, mock_get_db, mock_get_bucket):
+        """storyteller_llm_metadata が dict でない場合は無視される。"""
+        mock_db = MagicMock()
+        mock_get_db.return_value = mock_db
+        mock_get_bucket.return_value = MagicMock()
+
+        state = {"storyteller_llm_metadata": "not a dict"}
+        tool_context = MagicMock()
+        tool_context.state = state
+
+        result = publish_mystery(_make_mystery_json(), "", tool_context)
+        assert json.loads(result)["status"] == "success"
+
+        saved = mock_db.collection.return_value.document.return_value.set.call_args[0][0]
+        assert "storyteller_llm_metadata" not in saved
+
+
 class TestSourceCoverageProgrammaticOverwrite:
     """source_coverage の API フィールドが raw_search_results から programmatic に上書きされるテスト。"""
 

--- a/tests/unit/test_storyteller.py
+++ b/tests/unit/test_storyteller.py
@@ -11,6 +11,7 @@ from mystery_agents.agents.storyteller import (
     _storyteller_after_model,
     _storyteller_before_model,
 )
+from shared.state_keys import STORYTELLER_LLM_METADATA
 
 
 def _make_llm_response(
@@ -64,7 +65,7 @@ class TestStorytellerAfterModel:
         result = _storyteller_after_model(ctx, response)
 
         assert result is None
-        metadata = ctx.state["storyteller_llm_metadata"]
+        metadata = ctx.state[STORYTELLER_LLM_METADATA]
         assert "storyteller" in metadata
         assert "display_name" in metadata
 
@@ -76,7 +77,7 @@ class TestStorytellerAfterModel:
 
         _storyteller_after_model(ctx, response)
 
-        metadata = ctx.state["storyteller_llm_metadata"]
+        metadata = ctx.state[STORYTELLER_LLM_METADATA]
         assert metadata["actual_model"] == "claude-sonnet-4-5-20250929"
 
     def test_actual_model_none_when_not_available(self):
@@ -87,7 +88,7 @@ class TestStorytellerAfterModel:
 
         _storyteller_after_model(ctx, response)
 
-        metadata = ctx.state["storyteller_llm_metadata"]
+        metadata = ctx.state[STORYTELLER_LLM_METADATA]
         assert metadata["actual_model"] is None
 
     def test_actual_model_in_error_metadata(self):
@@ -101,7 +102,7 @@ class TestStorytellerAfterModel:
 
         _storyteller_after_model(ctx, response)
 
-        metadata = ctx.state["storyteller_llm_metadata"]
+        metadata = ctx.state[STORYTELLER_LLM_METADATA]
         assert metadata["actual_model"] == "deepseek/deepseek-r1"
 
     def test_empty_response_records_metadata(self, caplog):
@@ -117,7 +118,7 @@ class TestStorytellerAfterModel:
             result = _storyteller_after_model(ctx, response)
 
         assert result is None
-        metadata = ctx.state["storyteller_llm_metadata"]
+        metadata = ctx.state[STORYTELLER_LLM_METADATA]
         assert metadata["has_content"] is False
         assert metadata["prompt_tokens"] == 5000
         assert metadata["output_tokens"] == 0
@@ -146,7 +147,7 @@ class TestStorytellerAfterModel:
             result = _storyteller_after_model(ctx, response)
 
         assert result is None
-        metadata = ctx.state["storyteller_llm_metadata"]
+        metadata = ctx.state[STORYTELLER_LLM_METADATA]
         assert metadata["error_code"] == "SAFETY_FILTER"
         assert metadata["error_message"] == "Content blocked by safety filter"
         assert metadata["finish_reason"] == "SAFETY"
@@ -160,7 +161,7 @@ class TestStorytellerAfterModel:
         result = _storyteller_after_model(ctx, response)
 
         assert result is None
-        metadata = ctx.state["storyteller_llm_metadata"]
+        metadata = ctx.state[STORYTELLER_LLM_METADATA]
         assert metadata["prompt_tokens"] is None
         assert metadata["output_tokens"] is None
 


### PR DESCRIPTION
## Summary
- Storyteller の `after_model_callback` が記録する LLM メタデータ（モデル ID、トークン使用量、エラー情報等）を Publisher 経由で Firestore の `storyteller_llm_metadata` フィールドに永続化
- v3 の LLM ローテーション機能（使用回数均等化）の土台となるデータ蓄積
- マジックストリング `"storyteller_llm_metadata"` を `STORYTELLER_LLM_METADATA` 定数に統一

## 変更ファイル（8ファイル）
| ファイル | 変更内容 |
|---------|---------|
| `shared/state_keys.py` | `STORYTELLER_LLM_METADATA` 定数追加 |
| `mystery_agents/tools/publisher_tools.py` | セッション状態からメタデータ読み取り → Firestore 保存 |
| `mystery_agents/agents/storyteller.py` | マジックストリング → 定数置換 + import 追加 |
| `shared/orchestrator.py` | マジックストリング → 定数置換 + import 追加 |
| `packages/shared/src/types/mystery.ts` | `StorytellerLlmMetadata` interface + `FirestoreMystery` フィールド追加 |
| `tests/unit/test_publisher_tools.py` | `TestPublishMysteryStorytellerMetadata` 3テスト追加 |
| `tests/unit/test_storyteller.py` | マジックストリング → 定数置換 |
| `tests/unit/test_orchestrator.py` | マジックストリング → 定数置換 |

## Test plan
- [x] `pytest tests/unit/test_publisher_tools.py` — 新規3テスト含む全パス
- [x] `pytest tests/unit/test_storyteller.py` — 定数置換後も全パス
- [x] `pytest tests/unit/test_orchestrator.py` — 定数置換後も全パス
- [x] `pytest tests/unit/` — 1267テスト全パス（回帰なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)