### PR TITLE
feat: Polymath 語数ティアをソース素材の豊富さに応じて動的決定

### DIFF
--- a/mystery_agents/agents/dynamic_polymath_block.py
+++ b/mystery_agents/agents/dynamic_polymath_block.py
@@ -7,10 +7,12 @@ DynamicScholarBlock と同じ BaseAgent パターン。
 Named Scholar + Multilingual Scholar の両方の分析結果を動的に参照。
 
 ゲート機能を内包: 全 Scholar 分析が空なら INSUFFICIENT_DATA を返す。
+語数ティア: ソース素材の豊富さに応じて語数要件を動的に決定する。
 """
 
 import logging
 from collections.abc import AsyncGenerator
+from typing import Any, NamedTuple
 
 from google.adk.agents import BaseAgent, LlmAgent
 from google.adk.agents.invocation_context import InvocationContext
@@ -19,7 +21,12 @@ from google.genai import types
 
 from shared.constants import is_meaningful
 from shared.model_config import create_pro_model
-from shared.state_keys import ACTIVE_LANGUAGES, scholar_analysis_key
+from shared.state_keys import (
+    ACTIVE_LANGUAGES,
+    RAW_SEARCH_RESULTS,
+    WORD_COUNT_TIER,
+    scholar_analysis_key,
+)
 
 from .armchair_polymath import (
     INSTRUCTION_BODY,
@@ -33,6 +40,105 @@ from .language_scholars import get_scholar_config
 from .pipeline_gate import _log_and_record_failure
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# 語数ティア定義
+# ---------------------------------------------------------------------------
+class WordCountTier(NamedTuple):
+    """語数ティア（min_words, max_words）。"""
+
+    min_words: int
+    max_words: int
+
+
+TIER_NORMAL = WordCountTier(5000, 10000)
+TIER_REDUCED = WordCountTier(2500, 5000)
+
+# ティア判定閾値
+QUALITY_DOC_THRESHOLD = 10  # keywords_matched 非空の文書数
+SCHOLAR_WORDS_THRESHOLD = 3000  # Scholar 分析合計語数
+
+
+def _count_quality_documents(state: dict[str, Any]) -> int:
+    """raw_search_results から keywords_matched 非空の文書数をカウントする（URL 重複排除）。"""
+    seen_urls: set[str] = set()
+
+    def _scan_results(results: list) -> None:
+        for result in results:
+            if not isinstance(result, dict):
+                continue
+            for doc in result.get("documents", []):
+                if not isinstance(doc, dict):
+                    continue
+                url = doc.get("source_url", "")
+                if not url or url in seen_urls:
+                    continue
+                if doc.get("keywords_matched"):
+                    seen_urls.add(url)
+
+    # ベースキー
+    base = state.get(RAW_SEARCH_RESULTS)
+    if base and isinstance(base, list):
+        _scan_results(base)
+
+    # 言語別キー（raw_search_results_{identifier}）
+    for key in list(state.keys()):
+        if key.startswith(RAW_SEARCH_RESULTS + "_") and key != RAW_SEARCH_RESULTS:
+            lang_results = state.get(key)
+            if lang_results and isinstance(lang_results, list):
+                _scan_results(lang_results)
+
+    return len(seen_urls)
+
+
+def _count_scholar_words(
+    state: dict[str, Any],
+    meaningful_langs: list[str],
+    has_multilingual: bool,
+) -> int:
+    """有意な Scholar 分析テキストの合計語数を返す。"""
+    total = 0
+    langs = list(meaningful_langs)
+    if has_multilingual:
+        langs.append("multilingual")
+
+    for lang in langs:
+        text = state.get(scholar_analysis_key(lang), "")
+        if not text or not is_meaningful(str(text)):
+            continue
+        total += len(str(text).split())
+
+    return total
+
+
+def assess_source_richness(
+    state: dict[str, Any],
+    meaningful_langs: list[str],
+    has_multilingual: bool,
+) -> WordCountTier:
+    """ソース素材の豊富さに応じて語数ティアを決定する。
+
+    A（質の高い文書数）< QUALITY_DOC_THRESHOLD **かつ**
+    B（Scholar 分析語数）< SCHOLAR_WORDS_THRESHOLD の場合のみ Reduced。
+    """
+    quality_docs = _count_quality_documents(state)
+    scholar_words = _count_scholar_words(state, meaningful_langs, has_multilingual)
+
+    if quality_docs < QUALITY_DOC_THRESHOLD and scholar_words < SCHOLAR_WORDS_THRESHOLD:
+        logger.info(
+            "語数ティア: Reduced（quality_docs=%d, scholar_words=%d）",
+            quality_docs,
+            scholar_words,
+        )
+        return TIER_REDUCED
+
+    logger.info(
+        "語数ティア: Normal（quality_docs=%d, scholar_words=%d）",
+        quality_docs,
+        scholar_words,
+    )
+    return TIER_NORMAL
 
 
 def _build_analyses_section(meaningful_langs: list[str], has_multilingual: bool = False) -> str:
@@ -124,9 +230,19 @@ class DynamicPolymathBlock(BaseAgent):
             " + multilingual" if has_multilingual else "",
         )
 
-        # アクティブ言語のみの instruction を動的に組み立て
+        # ティア決定 + セッション状態に保存
+        tier = assess_source_richness(state, meaningful_langs, has_multilingual)
+        state[WORD_COUNT_TIER] = {
+            "min_words": tier.min_words,
+            "max_words": tier.max_words,
+        }
+
+        # アクティブ言語のみの instruction を動的に組み立て（ティアを注入）
         analyses_section = _build_analyses_section(meaningful_langs, has_multilingual)
-        instruction = INSTRUCTION_PREAMBLE + "\n" + analyses_section + "\n" + INSTRUCTION_BODY
+        body = INSTRUCTION_BODY.replace(
+            "{__WORD_COUNT_MIN__}", str(tier.min_words)
+        ).replace("{__WORD_COUNT_MAX__}", str(tier.max_words))
+        instruction = INSTRUCTION_PREAMBLE + "\n" + analyses_section + "\n" + body
 
         # LlmAgent を生成・実行
         polymath = LlmAgent(

--- a/mystery_agents/agents/polymath_instructions.py
+++ b/mystery_agents/agents/polymath_instructions.py
@@ -98,9 +98,9 @@ Armchair Polymath の instruction を構成する3つのセクション
 #    文書のタイトルが調査対象と関連しない場合、解釈的つながりがどれほど巧みでも選択しない。
 #
 # ## 文字数
-# **5,000〜10,000 words（英語）** — このレポートは Storyteller への唯一の入力である。
+# **{__WORD_COUNT_MIN__}〜{__WORD_COUNT_MAX__} words（英語）** — このレポートは Storyteller への唯一の入力である。
 # 2,000〜3,500 語の記事を書くのに十分な詳細・証拠・分析を含めること。
-# Storyteller が詳細を創作せざるを得ない薄いレポートより、引用と分析が豊富な 7,000 語のレポートの方がはるかに価値がある。
+# Storyteller が詳細を創作せざるを得ない薄いレポートより、引用と分析が豊富なレポートの方がはるかに価値がある。
 #
 # ## confidence_level チェックリスト
 # HIGH（Confirmed Ghost）: 3+独立資料の矛盾 + API限界で説明不可 + 2+代替仮説を検討・棄却 + 再現可能
@@ -135,7 +135,7 @@ Armchair Polymath の instruction を構成する3つのセクション
 # - Storyteller が blockquote で直接使える形式で提供
 #
 # ## 語数検証（必須）
-# レポート完成後、`count_words` ツールに全文テキストと min_words=5000, max_words=10000 を渡して呼び出す。
+# レポート完成後、`count_words` ツールに全文テキストと min_words={__WORD_COUNT_MIN__}, max_words={__WORD_COUNT_MAX__} を渡して呼び出す。
 # - within_range が false の場合：語数を満たすようレポートを修正し、再度 count_words を呼ぶ。
 # - within_range が true の場合：count_words を再度呼ばず、直ちに save_structured_report に進む。
 #
@@ -270,10 +270,10 @@ Assess what existing scholarship may already cover this topic:
 - **Access bias**: Are the key primary sources held in institutions with restricted access, creating a skew in who has published on this topic?
 
 ## Word Count
-**5,000–10,000 words (English).** This report is the sole input for the Storyteller —
+**{__WORD_COUNT_MIN__}–{__WORD_COUNT_MAX__} words (English).** This report is the sole input for the Storyteller —
 it must contain enough detail, evidence, and analysis for a compelling 2,000–3,500 word article.
-Err on the side of thoroughness: a 7,000-word report with rich citations and nuanced analysis
-is far more valuable than a 3,000-word summary that forces the Storyteller to invent details.
+Err on the side of thoroughness: a report with rich citations and nuanced analysis
+is far more valuable than a thin summary that forces the Storyteller to invent details.
 
 ## Output Format
 Structure your integrated analysis as a "Mystery Report":
@@ -516,7 +516,7 @@ This call is mandatory — do NOT skip it.
 ## Word Count Verification (MANDATORY)
 
 After completing your report text, call `count_words` with your full report text
-and `min_words=5000`, `max_words=10000`.
+and `min_words={__WORD_COUNT_MIN__}`, `max_words={__WORD_COUNT_MAX__}`.
 - If `within_range` is **false**: revise your report to meet the word count, then call `count_words` again.
 - If `within_range` is **true**: do NOT call `count_words` again. Proceed immediately to `save_structured_report`.
 
@@ -526,6 +526,11 @@ NEVER leave `relevant_excerpt` as an empty string — items with empty excerpts 
 """
 
 # 後方互換: 全7言語の静的 instruction（シングルトン + テスト用）
+# プレースホルダーを Normal ティアのデフォルト値で置換
 ARMCHAIR_POLYMATH_INSTRUCTION = (
-    INSTRUCTION_PREAMBLE + STATIC_ANALYSES_SECTION + INSTRUCTION_BODY
+    INSTRUCTION_PREAMBLE
+    + STATIC_ANALYSES_SECTION
+    + INSTRUCTION_BODY.replace("{__WORD_COUNT_MIN__}", "5000").replace(
+        "{__WORD_COUNT_MAX__}", "10000"
+    )
 )

--- a/mystery_agents/tools/scholar_tools.py
+++ b/mystery_agents/tools/scholar_tools.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from google.adk.tools.tool_context import ToolContext
 
-from shared.state_keys import RAW_SEARCH_RESULTS, STRUCTURED_REPORT
+from shared.state_keys import RAW_SEARCH_RESULTS, STRUCTURED_REPORT, WORD_COUNT_TIER
 
 logger = logging.getLogger(__name__)
 
@@ -193,10 +193,14 @@ def save_structured_report(
 
     # 語数検証チェック
     if not tool_context.state.get("_word_count_verified"):
+        tier = tool_context.state.get(
+            WORD_COUNT_TIER, {"min_words": 5000, "max_words": 10000}
+        )
         return json.dumps(
             {
                 "status": "error",
-                "error": "count_words must be called with min_words=5000, max_words=10000 "
+                "error": f"count_words must be called with min_words={tier['min_words']}, "
+                f"max_words={tier['max_words']} "
                 "and the report must be within range before saving. "
                 "Call count_words first, then revise if needed.",
             },

--- a/shared/state_keys.py
+++ b/shared/state_keys.py
@@ -31,6 +31,7 @@ PUBLISHED_MYSTERY_ID = "published_mystery_id"
 INVESTIGATION_QUERY = "investigation_query"
 PIPELINE_RUN_ID = "pipeline_run_id"
 STORYTELLER_LLM_METADATA = "storyteller_llm_metadata"
+WORD_COUNT_TIER = "_word_count_tier"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_dynamic_polymath_block.py
+++ b/tests/unit/test_dynamic_polymath_block.py
@@ -1,7 +1,14 @@
 """Unit tests for DynamicPolymathBlock."""
 
 from mystery_agents.agents.dynamic_polymath_block import (
+    QUALITY_DOC_THRESHOLD,
+    SCHOLAR_WORDS_THRESHOLD,
+    TIER_NORMAL,
+    TIER_REDUCED,
     _build_analyses_section,
+    _count_quality_documents,
+    _count_scholar_words,
+    assess_source_richness,
     create_dynamic_polymath_block,
 )
 
@@ -99,3 +106,229 @@ class TestInstructionComposition:
         instruction = INSTRUCTION_PREAMBLE + "\n" + section + "\n" + INSTRUCTION_BODY
         assert "Armchair Polymath" in instruction
         assert "sardonic" in instruction
+
+
+class TestCountQualityDocuments:
+    """_count_quality_documents のテスト。"""
+
+    def test_counts_documents_with_keywords_matched(self):
+        """keywords_matched が非空の文書のみカウントする。"""
+        state = {
+            "raw_search_results_en": [
+                {
+                    "documents": [
+                        {"source_url": "https://a.com", "keywords_matched": ["kw1"]},
+                        {"source_url": "https://b.com", "keywords_matched": []},
+                        {"source_url": "https://c.com", "keywords_matched": ["kw2", "kw3"]},
+                    ],
+                }
+            ],
+        }
+        assert _count_quality_documents(state) == 2
+
+    def test_deduplicates_by_url(self):
+        """同一 URL が複数キーに出現しても1回のみカウントする。"""
+        state = {
+            "raw_search_results_en": [
+                {
+                    "documents": [
+                        {"source_url": "https://a.com", "keywords_matched": ["kw1"]},
+                    ],
+                }
+            ],
+            "raw_search_results_de": [
+                {
+                    "documents": [
+                        {"source_url": "https://a.com", "keywords_matched": ["kw1"]},
+                        {"source_url": "https://b.com", "keywords_matched": ["kw2"]},
+                    ],
+                }
+            ],
+        }
+        assert _count_quality_documents(state) == 2
+
+    def test_empty_state_returns_zero(self):
+        """空の state では 0 を返す。"""
+        assert _count_quality_documents({}) == 0
+
+    def test_base_and_lang_keys_both_scanned(self):
+        """ベースキー raw_search_results と言語別キーの両方を走査する。"""
+        state = {
+            "raw_search_results": [
+                {
+                    "documents": [
+                        {"source_url": "https://base.com", "keywords_matched": ["kw"]},
+                    ],
+                }
+            ],
+            "raw_search_results_ja": [
+                {
+                    "documents": [
+                        {"source_url": "https://ja.com", "keywords_matched": ["kw"]},
+                    ],
+                }
+            ],
+        }
+        assert _count_quality_documents(state) == 2
+
+    def test_missing_keywords_matched_treated_as_empty(self):
+        """keywords_matched キーがない文書はカウントしない。"""
+        state = {
+            "raw_search_results_en": [
+                {
+                    "documents": [
+                        {"source_url": "https://a.com"},
+                    ],
+                }
+            ],
+        }
+        assert _count_quality_documents(state) == 0
+
+
+class TestCountScholarWords:
+    """_count_scholar_words のテスト。"""
+
+    def test_sums_words_across_languages(self):
+        """複数言語の分析テキストの語数を合算する。"""
+        state = {
+            "scholar_analysis_en": "word " * 1000,  # 1000 words
+            "scholar_analysis_de": "word " * 500,   # 500 words
+        }
+        assert _count_scholar_words(state, ["en", "de"], False) == 1500
+
+    def test_includes_multilingual_when_flag_set(self):
+        """has_multilingual=True の場合、multilingual の語数も加算する。"""
+        state = {
+            "scholar_analysis_en": "word " * 1000,
+            "scholar_analysis_multilingual": "word " * 800,
+        }
+        assert _count_scholar_words(state, ["en"], True) == 1800
+
+    def test_excludes_multilingual_when_flag_false(self):
+        """has_multilingual=False の場合、multilingual は加算しない。"""
+        state = {
+            "scholar_analysis_en": "word " * 1000,
+            "scholar_analysis_multilingual": "word " * 800,
+        }
+        assert _count_scholar_words(state, ["en"], False) == 1000
+
+    def test_skips_failure_markers(self):
+        """失敗マーカーで始まる分析は語数に含めない。"""
+        state = {
+            "scholar_analysis_en": "word " * 1000,
+            "scholar_analysis_de": "INSUFFICIENT_DATA: No data available",
+        }
+        assert _count_scholar_words(state, ["en", "de"], False) == 1000
+
+    def test_empty_state_returns_zero(self):
+        """分析がない場合は 0 を返す。"""
+        assert _count_scholar_words({}, [], False) == 0
+
+
+class TestAssessSourceRichness:
+    """assess_source_richness のテスト。"""
+
+    def test_normal_tier_when_enough_documents(self):
+        """質の高い文書数が閾値以上なら Normal。"""
+        state = {
+            "raw_search_results_en": [
+                {
+                    "documents": [
+                        {"source_url": f"https://a.com/{i}", "keywords_matched": ["kw"]}
+                        for i in range(QUALITY_DOC_THRESHOLD)
+                    ],
+                }
+            ],
+            "scholar_analysis_en": "word " * 100,
+        }
+        tier = assess_source_richness(state, ["en"], False)
+        assert tier == TIER_NORMAL
+
+    def test_normal_tier_when_enough_scholar_words(self):
+        """Scholar 語数が閾値以上なら Normal（文書少でも）。"""
+        state = {
+            "raw_search_results_en": [
+                {
+                    "documents": [
+                        {"source_url": "https://a.com", "keywords_matched": ["kw"]},
+                    ],
+                }
+            ],
+            "scholar_analysis_en": "word " * SCHOLAR_WORDS_THRESHOLD,
+        }
+        tier = assess_source_richness(state, ["en"], False)
+        assert tier == TIER_NORMAL
+
+    def test_reduced_tier_when_both_below_threshold(self):
+        """文書数・Scholar 語数の両方が閾値未満なら Reduced。"""
+        state = {
+            "raw_search_results_en": [
+                {
+                    "documents": [
+                        {"source_url": f"https://a.com/{i}", "keywords_matched": ["kw"]}
+                        for i in range(QUALITY_DOC_THRESHOLD - 1)
+                    ],
+                }
+            ],
+            "scholar_analysis_en": "word " * (SCHOLAR_WORDS_THRESHOLD - 1),
+        }
+        tier = assess_source_richness(state, ["en"], False)
+        assert tier == TIER_REDUCED
+
+    def test_boundary_exactly_at_threshold_is_normal(self):
+        """ちょうど閾値の場合は Normal（>= 判定）。"""
+        state = {
+            "raw_search_results_en": [
+                {
+                    "documents": [
+                        {"source_url": f"https://a.com/{i}", "keywords_matched": ["kw"]}
+                        for i in range(QUALITY_DOC_THRESHOLD)
+                    ],
+                }
+            ],
+            "scholar_analysis_en": "word " * (SCHOLAR_WORDS_THRESHOLD - 1),
+        }
+        tier = assess_source_richness(state, ["en"], False)
+        assert tier == TIER_NORMAL
+
+    def test_empty_state_returns_reduced(self):
+        """空の state では Reduced を返す。"""
+        tier = assess_source_richness({}, [], False)
+        assert tier == TIER_REDUCED
+
+
+class TestInstructionCompositionWithTier:
+    """ティアによるプレースホルダー置換のテスト。"""
+
+    def test_placeholders_replaced_with_normal_tier(self):
+        """Normal ティアでプレースホルダーが 5000/10000 に置換される。"""
+        from mystery_agents.agents.armchair_polymath import (
+            INSTRUCTION_BODY,
+            INSTRUCTION_PREAMBLE,
+        )
+
+        section = _build_analyses_section(["en"])
+        body = INSTRUCTION_BODY.replace(
+            "{__WORD_COUNT_MIN__}", str(TIER_NORMAL.min_words)
+        ).replace("{__WORD_COUNT_MAX__}", str(TIER_NORMAL.max_words))
+        instruction = INSTRUCTION_PREAMBLE + "\n" + section + "\n" + body
+        assert "5000" in instruction or "5,000" in instruction
+        assert "10000" in instruction or "10,000" in instruction
+        assert "{__WORD_COUNT_MIN__}" not in instruction
+        assert "{__WORD_COUNT_MAX__}" not in instruction
+
+    def test_placeholders_replaced_with_reduced_tier(self):
+        """Reduced ティアでプレースホルダーが 2500/5000 に置換される。"""
+        from mystery_agents.agents.armchair_polymath import (
+            INSTRUCTION_BODY,
+            INSTRUCTION_PREAMBLE,
+        )
+
+        section = _build_analyses_section(["en"])
+        body = INSTRUCTION_BODY.replace(
+            "{__WORD_COUNT_MIN__}", str(TIER_REDUCED.min_words)
+        ).replace("{__WORD_COUNT_MAX__}", str(TIER_REDUCED.max_words))
+        instruction = INSTRUCTION_PREAMBLE + "\n" + section + "\n" + body
+        assert "2500" in instruction
+        assert "{__WORD_COUNT_MIN__}" not in instruction
+        assert "{__WORD_COUNT_MAX__}" not in instruction

--- a/tests/unit/test_scholar_tools.py
+++ b/tests/unit/test_scholar_tools.py
@@ -691,3 +691,34 @@ class TestWordCountVerifiedCheck:
         result_data = json.loads(result)
 
         assert result_data["status"] == "success"
+
+    def test_error_message_uses_default_tier_when_unset(self):
+        """ティア未設定時はデフォルト（5000/10000）がエラーメッセージに含まれる。"""
+        mock_ctx = MagicMock()
+        mock_ctx.state = {"_inventory_consulted": True}
+
+        report_data = {"title": "Test"}
+        result = save_structured_report(json.dumps(report_data), mock_ctx)
+        result_data = json.loads(result)
+
+        assert result_data["status"] == "error"
+        assert "5000" in result_data["error"]
+        assert "10000" in result_data["error"]
+
+    def test_error_message_uses_reduced_tier(self):
+        """Reduced ティア設定時はエラーメッセージに 2500/5000 が含まれる。"""
+        mock_ctx = MagicMock()
+        mock_ctx.state = {
+            "_inventory_consulted": True,
+            "_word_count_tier": {"min_words": 2500, "max_words": 5000},
+        }
+
+        report_data = {"title": "Test"}
+        result = save_structured_report(json.dumps(report_data), mock_ctx)
+        result_data = json.loads(result)
+
+        assert result_data["status"] == "error"
+        assert "2500" in result_data["error"]
+        assert "5000" in result_data["error"]
+        # デフォルト値が残っていないことを確認
+        assert "10000" not in result_data["error"]


### PR DESCRIPTION
## Summary

- ソース素材が薄い場合（文書数が少ない、1言語のみの分析等）に固定の 5,000〜10,000語 要件を満たせずパイプラインが失敗する問題を解決
- 質の高い文書数（A: `keywords_matched` 非空、URL 重複排除）と Scholar 分析合計語数（B）の AND 条件で語数ティアを動的決定
- Normal（5,000〜10,000語）: A >= 10 **または** B >= 3,000（デフォルト）
- Reduced（2,500〜5,000語）: A < 10 **かつ** B < 3,000

## 変更ファイル（6ファイル）

| ファイル | 変更内容 |
|---------|---------|
| `shared/state_keys.py` | `WORD_COUNT_TIER` 定数追加 |
| `mystery_agents/agents/dynamic_polymath_block.py` | `WordCountTier`, `assess_source_richness` 等の純粋関数 + `_run_async_impl` にティア注入 |
| `mystery_agents/agents/polymath_instructions.py` | 語数リテラルをプレースホルダー化（`{__WORD_COUNT_MIN__}` / `{__WORD_COUNT_MAX__}`） |
| `mystery_agents/tools/scholar_tools.py` | `save_structured_report` のエラーメッセージをティア対応 |
| `tests/unit/test_dynamic_polymath_block.py` | 15テスト追加（品質文書カウント、Scholar 語数、ティア判定、プレースホルダー置換） |
| `tests/unit/test_scholar_tools.py` | 2テスト追加（ティアデフォルト値、Reduced ティアエラーメッセージ） |

## Test plan

- [x] `pytest tests/unit/test_dynamic_polymath_block.py` — 28テスト全通過
- [x] `pytest tests/unit/test_scholar_tools.py` — 35テスト全通過
- [x] `pytest tests/unit/` — 全1286テスト通過（デグレなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)