### PR TITLE
feat: エージェント別 temperature 設定（役割に応じた精度・創造性バランス）

### DIFF
--- a/alchemist_agents/agents/alchemist.py
+++ b/alchemist_agents/agents/alchemist.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 from google.adk.agents import LlmAgent
+from google.genai import types
 
 from shared.model_config import create_pro_model
 
@@ -246,6 +247,7 @@ def create_alchemist() -> LlmAgent:
             "themes, regional character, and uncanny elements into visual designs."
         ),
         instruction=ALCHEMIST_INSTRUCTION,
+        generate_content_config=types.GenerateContentConfig(temperature=0.8),
         tools=[save_design_proposal],
         output_key="design_proposals",
         include_contents="none",

--- a/alchemist_agents/agents/alchemist_renderer.py
+++ b/alchemist_agents/agents/alchemist_renderer.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 from google.adk.agents import LlmAgent
+from google.genai import types
 
 from shared.model_config import create_pro_model
 
@@ -98,6 +99,7 @@ def create_alchemist_renderer() -> LlmAgent:
             "for each product type."
         ),
         instruction=ALCHEMIST_RENDERER_INSTRUCTION,
+        generate_content_config=types.GenerateContentConfig(temperature=0.6),
         tools=[generate_design_asset],
         output_key="render_summary",
         include_contents="none",

--- a/mystery_agents/agents/armchair_polymath.py
+++ b/mystery_agents/agents/armchair_polymath.py
@@ -123,6 +123,7 @@ def create_armchair_polymath() -> LlmAgent:
         tools=POLYMATH_TOOLS,
         output_key="mystery_report",  # 既存と同じキー → 下流互換性維持
         generate_content_config=types.GenerateContentConfig(
+            temperature=0.5,
             max_output_tokens=POLYMATH_MAX_OUTPUT_TOKENS,
         ),
         before_tool_callback=log_polymath_tool_call,

--- a/mystery_agents/agents/convergence_checker.py
+++ b/mystery_agents/agents/convergence_checker.py
@@ -8,6 +8,7 @@ Flash モデルを使用し、コストを最小限に抑える。
 """
 
 from google.adk.agents import LlmAgent
+from google.genai import types
 
 from shared.model_config import create_flash_model
 
@@ -36,6 +37,7 @@ def create_convergence_checker() -> LlmAgent:
             "debate loop if no significant new arguments are being introduced."
         ),
         instruction=_CONVERGENCE_CHECKER_INSTRUCTION,
+        generate_content_config=types.GenerateContentConfig(temperature=0.1),
         tools=[check_debate_convergence],
     )
 

--- a/mystery_agents/agents/dynamic_polymath_block.py
+++ b/mystery_agents/agents/dynamic_polymath_block.py
@@ -253,6 +253,7 @@ class DynamicPolymathBlock(BaseAgent):
             tools=POLYMATH_TOOLS,
             output_key="mystery_report",
             generate_content_config=types.GenerateContentConfig(
+                temperature=0.5,
                 max_output_tokens=POLYMATH_MAX_OUTPUT_TOKENS,
             ),
             before_tool_callback=log_polymath_tool_call,

--- a/mystery_agents/agents/illustrator.py
+++ b/mystery_agents/agents/illustrator.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 from google.adk.agents import LlmAgent
+from google.genai import types
 
 from shared.model_config import create_pro_model
 from google.adk.tools.base_tool import BaseTool
@@ -288,6 +289,7 @@ def create_illustrator() -> LlmAgent:
             "Validates generated images against article content for consistency."
         ),
         instruction=ILLUSTRATOR_INSTRUCTION,
+        generate_content_config=types.GenerateContentConfig(temperature=0.6),
         tools=[generate_image, validate_image],
         output_key="visual_assets",
         include_contents="none",

--- a/mystery_agents/agents/language_librarians.py
+++ b/mystery_agents/agents/language_librarians.py
@@ -9,6 +9,7 @@ collected_documents_{lang} に結果を保存する。
 """
 
 from google.adk.agents import LlmAgent
+from google.genai import types
 
 from shared.model_config import create_flash_model
 
@@ -238,6 +239,7 @@ def create_librarian(lang_code: str) -> LlmAgent:
             f"Searches {sources_hint} for {config['language_name']} primary sources."
         ),
         instruction=instruction,
+        generate_content_config=types.GenerateContentConfig(temperature=0.3),
         tools=tools,
         output_key=f"collected_documents_{lang_code}",
     )

--- a/mystery_agents/agents/language_scholars.py
+++ b/mystery_agents/agents/language_scholars.py
@@ -15,6 +15,7 @@ mode="analysis" で分析モード、mode="debate" で討論モードのエー�
 """
 
 from google.adk.agents import LlmAgent
+from google.genai import types
 
 from shared.language_names import get_language_name
 from shared.model_config import create_pro_model
@@ -192,6 +193,7 @@ def create_scholar(
                 f"of {config['language_name']}-language sources."
             ),
             instruction=instruction,
+            generate_content_config=types.GenerateContentConfig(temperature=0.4),
             tools=[],  # save_structured_report は呼び出さない
             output_key=f"scholar_analysis_{lang_code}",
         )
@@ -218,6 +220,7 @@ def create_scholar(
                     f"using the shared debate whiteboard."
                 ),
                 instruction=instruction,
+                generate_content_config=types.GenerateContentConfig(temperature=0.7),
                 tools=[append_to_whiteboard],
                 # DynamicScholarBlock がゲートを担当するため callback 不要
             )
@@ -236,6 +239,7 @@ def create_scholar(
                     f"using the shared debate whiteboard."
                 ),
                 instruction=instruction,
+                generate_content_config=types.GenerateContentConfig(temperature=0.7),
                 tools=[append_to_whiteboard],
                 before_agent_callback=make_debate_gate(lang_code),
             )
@@ -288,6 +292,7 @@ def create_multilingual_scholar(
                 f"to discover patterns invisible to single-language analysis."
             ),
             instruction=instruction,
+            generate_content_config=types.GenerateContentConfig(temperature=0.4),
             tools=[],
             output_key="scholar_analysis_multilingual",
         )
@@ -311,6 +316,7 @@ def create_multilingual_scholar(
                 f"({language_list_short}). Challenges and enriches Named Scholar analyses."
             ),
             instruction=instruction,
+            generate_content_config=types.GenerateContentConfig(temperature=0.7),
             tools=[append_to_whiteboard],
         )
     else:

--- a/mystery_agents/agents/storyteller.py
+++ b/mystery_agents/agents/storyteller.py
@@ -212,6 +212,7 @@ def create_storyteller(storyteller: str = DEFAULT_STORYTELLER) -> LlmAgent:
             "an English blog article that interweaves fact and legend."
         ),
         instruction=STORYTELLER_INSTRUCTION,
+        generate_content_config=types.GenerateContentConfig(temperature=0.9),
         tools=[],
         output_key="creative_content",
         include_contents="none",

--- a/mystery_agents/agents/translator.py
+++ b/mystery_agents/agents/translator.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 from google.adk.agents import LlmAgent
+from google.genai import types
 
 from shared.model_config import create_flash_model
 
@@ -128,6 +129,7 @@ def create_translator(target_lang: str) -> LlmAgent:
             f"Maintains historical terminology accuracy and Fact × Folklore nuance."
         ),
         instruction=instruction,
+        generate_content_config=types.GenerateContentConfig(temperature=0.2),
         output_key=f"translation_result_{target_lang}",
         include_contents="none",
     )

--- a/podcast_agents/agents/podcast_translator.py
+++ b/podcast_agents/agents/podcast_translator.py
@@ -8,6 +8,7 @@ Output: podcast_script_ja (日本語訳テキスト)
 """
 
 from google.adk.agents import LlmAgent
+from google.genai import types
 
 from shared.model_config import create_flash_model
 
@@ -89,6 +90,7 @@ def create_podcast_translator() -> LlmAgent:
             "Preserves segment structure and SFX/BGM cues while translating narration."
         ),
         instruction=PODCAST_TRANSLATOR_INSTRUCTION,
+        generate_content_config=types.GenerateContentConfig(temperature=0.2),
         output_key="podcast_script_ja",
     )
 

--- a/podcast_agents/agents/script_planner.py
+++ b/podcast_agents/agents/script_planner.py
@@ -11,6 +11,7 @@ Output: script_outline (テキスト), structured_outline (JSON via tool)
 """
 
 from google.adk.agents import LlmAgent
+from google.genai import types
 
 from shared.model_config import create_flash_model
 
@@ -278,6 +279,7 @@ def create_script_planner() -> LlmAgent:
             "the structural blueprint for the Scriptwriter's segment-by-segment generation."
         ),
         instruction=SCRIPT_PLANNER_INSTRUCTION,
+        generate_content_config=types.GenerateContentConfig(temperature=0.3),
         tools=[save_script_outline],
         output_key="script_outline",
     )

--- a/podcast_agents/agents/scriptwriter.py
+++ b/podcast_agents/agents/scriptwriter.py
@@ -11,6 +11,7 @@ Output: podcast_script (テキスト), structured_script (JSON via finalize_scri
 """
 
 from google.adk.agents import LlmAgent
+from google.genai import types
 
 from shared.model_config import create_pro_model
 
@@ -382,6 +383,7 @@ def create_scriptwriter() -> LlmAgent:
             "for each segment and finalize_script to assemble the final structured script."
         ),
         instruction=SCRIPTWRITER_INSTRUCTION,
+        generate_content_config=types.GenerateContentConfig(temperature=0.8),
         tools=[save_segment, finalize_script],
         output_key="podcast_script",
     )


### PR DESCRIPTION
## Summary

- 全エージェントが Gemini デフォルト temperature=1.0 で動作していた問題を修正
- 各エージェントの機能カテゴリ（精密/分析/創造）に応じた temperature を設定
- 既存パターン（Curator 1.2, API Librarian 0.3）と同じ `generate_content_config` 方式で統一

### 設定値一覧

| カテゴリ | エージェント | temp | 理由 |
|---|---|---|---|
| 精密・忠実系 | Translator (3言語) | 0.2 | 訳語一貫性 |
| | PodcastTranslator | 0.2 | 同上 |
| | ConvergenceChecker | 0.1 | 収束判定は決定論的 |
| | LanguageLibrarian | 0.3 | API Librarian と統一 |
| 分析・構造系 | Scholar (分析) | 0.4 | 再現可能な学際分析 |
| | Scholar (討論) | 0.7 | 多様な反論・補強 |
| | Multilingual Scholar (分析/討論) | 0.4 / 0.7 | Named Scholar と同基準 |
| | ArmchairPolymath | 0.5 | 分析的だが意外な接続も必要 |
| | DynamicPolymathBlock内Polymath | 0.5 | 同上 |
| | ScriptPlanner | 0.3 | アウトライン構造の一貫性 |
| 創造系 | Storyteller | 0.9 | 毎回ユニークな語り口 |
| | Scriptwriter | 0.8 | 音声向け独自表現 |
| | Illustrator | 0.6 | プロンプト生成のクリエイティビティ |
| | Alchemist | 0.8 | デザイン提案の多様性 |
| | AlchemistRenderer | 0.6 | 画像生成プロンプト |

### 変更なし（既存設定済み）
- Curator: 1.2
- API Librarian: 0.3（PR #398）

## Test plan

- [x] `pytest tests/unit/ -v` — 全 1292 テストパス
- [x] `grep -rn "temperature=" mystery_agents/ podcast_agents/ alchemist_agents/ curator_agents/` で全エージェントの設定を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)