### PR TITLE
feat: GA4 カスタムイベントトラッキング（view_mystery / view_archive）

### DIFF
--- a/web-public/src/app/[lang]/archive/[[...page]]/page.tsx
+++ b/web-public/src/app/[lang]/archive/[[...page]]/page.tsx
@@ -14,6 +14,7 @@ import { isValidLang, SUPPORTED_LANGS } from "@/lib/i18n/config"
 import type { SupportedLang } from "@/lib/i18n/config"
 import { getDictionary } from "@/lib/i18n/dictionaries"
 import { buildOgpMetadata, buildAlternates } from "@/lib/seo"
+import { ArchivePageTracker } from "@/components/trackers/archive-page-tracker"
 
 export async function generateStaticParams() {
   const mysteries = await getPublishedMysteries(1000)
@@ -99,6 +100,7 @@ export default async function ArchivePage({
   return (
     <div className="min-h-screen flex flex-col film-grain">
       <Header lang={lang as SupportedLang} nav={dict.nav} />
+      <ArchivePageTracker pageNumber={currentPage} lang={lang} />
 
       <main className="flex-1">
         <section className="py-16 md:py-24">

--- a/web-public/src/app/[lang]/mystery/[id]/page.tsx
+++ b/web-public/src/app/[lang]/mystery/[id]/page.tsx
@@ -8,6 +8,7 @@ import { Breadcrumb } from "@/components/breadcrumb"
 import { RelatedArticles } from "@/components/related-articles"
 import { ShareButtons } from "@/components/share-buttons"
 import { ArticleJsonLd } from "@/components/article-json-ld"
+import { MysteryPageTracker } from "@/components/trackers/mystery-page-tracker"
 import { getMysteryById, getPublishedMysteryIds, getAllPublishedMysteriesMap } from "@ghost/shared/src/lib/firestore/queries"
 import { Share2 } from "lucide-react"
 import { localizeMystery, getTranslatedExcerpt } from "@ghost/shared/src/lib/localize"
@@ -200,6 +201,13 @@ export default async function MysteryDetailPage({
             datePublished={mystery.publishedAt?.toISOString()}
             dateModified={mystery.updatedAt?.toISOString()}
             imageUrl={mystery.images?.hero}
+            lang={lang}
+          />
+
+          <MysteryPageTracker
+            mysteryId={mystery.mystery_id}
+            classification={mystery.mystery_id.slice(0, 3).toUpperCase()}
+            confidenceLevel={mystery.confidence_level}
             lang={lang}
           />
 

--- a/web-public/src/components/trackers/archive-page-tracker.tsx
+++ b/web-public/src/components/trackers/archive-page-tracker.tsx
@@ -1,0 +1,21 @@
+"use client"
+
+import { useEffect } from "react"
+import { pushEvent } from "@/lib/analytics"
+
+interface ArchivePageTrackerProps {
+  pageNumber: number
+  lang: string
+}
+
+export function ArchivePageTracker({ pageNumber, lang }: ArchivePageTrackerProps) {
+  useEffect(() => {
+    pushEvent({
+      event: "view_archive",
+      page_number: pageNumber,
+      content_language: lang,
+    })
+  }, [pageNumber, lang])
+
+  return null
+}

--- a/web-public/src/components/trackers/mystery-page-tracker.tsx
+++ b/web-public/src/components/trackers/mystery-page-tracker.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import { useEffect } from "react"
+import { pushEvent } from "@/lib/analytics"
+
+interface MysteryPageTrackerProps {
+  mysteryId: string
+  classification: string
+  confidenceLevel: string
+  lang: string
+}
+
+export function MysteryPageTracker({
+  mysteryId,
+  classification,
+  confidenceLevel,
+  lang,
+}: MysteryPageTrackerProps) {
+  useEffect(() => {
+    pushEvent({
+      event: "view_mystery",
+      mystery_id: mysteryId,
+      classification,
+      confidence_level: confidenceLevel,
+      content_language: lang,
+    })
+  }, [mysteryId, classification, confidenceLevel, lang])
+
+  return null
+}

--- a/web-public/src/lib/analytics.ts
+++ b/web-public/src/lib/analytics.ts
@@ -1,0 +1,31 @@
+// GA4 カスタムイベント送信ユーティリティ
+// GTM の dataLayer.push を型安全にラップする
+
+interface ViewMysteryEvent {
+  event: "view_mystery"
+  mystery_id: string
+  classification: string
+  confidence_level: string
+  content_language: string
+}
+
+interface ViewArchiveEvent {
+  event: "view_archive"
+  page_number: number
+  content_language: string
+}
+
+type GA4Event = ViewMysteryEvent | ViewArchiveEvent
+
+export function pushEvent(event: GA4Event): void {
+  if (typeof window !== "undefined" && Array.isArray(window.dataLayer)) {
+    window.dataLayer.push(event)
+  }
+}
+
+// GTM の dataLayer は任意のオブジェクトを受け付ける
+declare global {
+  interface Window {
+    dataLayer?: unknown[]
+  }
+}


### PR DESCRIPTION
## Summary

- `dataLayer.push` による型安全な GA4 カスタムイベント送信ユーティリティ (`analytics.ts`) を追加
- 記事詳細ページで `view_mystery` イベント（mystery_id, classification, confidence_level, content_language）を送信
- アーカイブ一覧ページで `view_archive` イベント（page_number, content_language）を送信

## Test plan

- [ ] `npm run build` で TypeScript コンパイルが通ることを確認
- [ ] ブラウザ DevTools Console で `window.dataLayer` にイベントが push されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)