### PR TITLE
feat: 全エージェント横断トークン使用量追跡（pipeline_runs 永続化）

### DIFF
--- a/mystery_agents/agents/api_librarians.py
+++ b/mystery_agents/agents/api_librarians.py
@@ -14,6 +14,7 @@ from google.adk.agents import LlmAgent
 from google.genai import types
 
 from shared.model_config import create_flash_model
+from shared.token_tracker import create_token_tracking_callback
 
 from ..tools.librarian_tools import search_archives, search_newspapers
 from .librarian_instructions import BASE_INSTRUCTION as _BASE_INSTRUCTION
@@ -300,6 +301,7 @@ def create_api_librarian(api_key: str) -> LlmAgent:
         tools=tools,
         output_key=f"collected_documents_{api_key}",
         generate_content_config=types.GenerateContentConfig(temperature=0.3),
+        after_model_callback=create_token_tracking_callback(f"librarian_{api_key}"),
     )
 
 

--- a/mystery_agents/agents/armchair_polymath.py
+++ b/mystery_agents/agents/armchair_polymath.py
@@ -13,6 +13,7 @@ from google.adk.agents import LlmAgent
 from google.genai import types
 
 from shared.model_config import create_pro_model
+from shared.token_tracker import create_token_tracking_callback
 
 from ..tools.document_inventory import get_document_inventory
 from ..tools.openalex import search_academic_papers
@@ -127,6 +128,7 @@ def create_armchair_polymath() -> LlmAgent:
             max_output_tokens=POLYMATH_MAX_OUTPUT_TOKENS,
         ),
         before_tool_callback=log_polymath_tool_call,
+        after_model_callback=create_token_tracking_callback("armchair_polymath"),
     )
 
 

--- a/mystery_agents/agents/dynamic_polymath_block.py
+++ b/mystery_agents/agents/dynamic_polymath_block.py
@@ -27,6 +27,7 @@ from shared.state_keys import (
     WORD_COUNT_TIER,
     scholar_analysis_key,
 )
+from shared.token_tracker import create_token_tracking_callback
 
 from .armchair_polymath import (
     INSTRUCTION_BODY,
@@ -257,6 +258,7 @@ class DynamicPolymathBlock(BaseAgent):
                 max_output_tokens=POLYMATH_MAX_OUTPUT_TOKENS,
             ),
             before_tool_callback=log_polymath_tool_call,
+            after_model_callback=create_token_tracking_callback("armchair_polymath"),
         )
         async for event in polymath.run_async(ctx):
             yield event

--- a/mystery_agents/agents/illustrator.py
+++ b/mystery_agents/agents/illustrator.py
@@ -19,6 +19,7 @@ from google.adk.agents import LlmAgent
 from google.genai import types
 
 from shared.model_config import create_pro_model
+from shared.token_tracker import create_token_tracking_callback
 from google.adk.tools.base_tool import BaseTool
 from google.adk.tools.tool_context import ToolContext
 
@@ -294,6 +295,7 @@ def create_illustrator() -> LlmAgent:
         output_key="visual_assets",
         include_contents="none",
         before_tool_callback=_limit_tool_calls,
+        after_model_callback=create_token_tracking_callback("illustrator"),
     )
 
 

--- a/mystery_agents/agents/language_scholars.py
+++ b/mystery_agents/agents/language_scholars.py
@@ -19,6 +19,7 @@ from google.genai import types
 
 from shared.language_names import get_language_name
 from shared.model_config import create_pro_model
+from shared.token_tracker import create_token_tracking_callback
 
 from ..tools.debate_tools import append_to_whiteboard
 from .language_gate import make_debate_gate
@@ -196,6 +197,7 @@ def create_scholar(
             generate_content_config=types.GenerateContentConfig(temperature=0.4),
             tools=[],  # save_structured_report は呼び出さない
             output_key=f"scholar_analysis_{lang_code}",
+            after_model_callback=create_token_tracking_callback(f"scholar_{lang_code}"),
         )
     elif mode == "debate":
         if active_langs:
@@ -223,6 +225,7 @@ def create_scholar(
                 generate_content_config=types.GenerateContentConfig(temperature=0.7),
                 tools=[append_to_whiteboard],
                 # DynamicScholarBlock がゲートを担当するため callback 不要
+                after_model_callback=create_token_tracking_callback(f"scholar_{lang_code}_debate"),
             )
         else:
             # 静的討論（後方互換: LoopAgent ベースのパイプライン用）
@@ -242,6 +245,7 @@ def create_scholar(
                 generate_content_config=types.GenerateContentConfig(temperature=0.7),
                 tools=[append_to_whiteboard],
                 before_agent_callback=make_debate_gate(lang_code),
+                after_model_callback=create_token_tracking_callback(f"scholar_{lang_code}_debate"),
             )
     else:
         raise ValueError(f"Unknown mode: {mode!r}. Use 'analysis' or 'debate'.")
@@ -295,6 +299,7 @@ def create_multilingual_scholar(
             generate_content_config=types.GenerateContentConfig(temperature=0.4),
             tools=[],
             output_key="scholar_analysis_multilingual",
+            after_model_callback=create_token_tracking_callback("scholar_multilingual"),
         )
     elif mode == "debate":
         # Named Scholar の分析参照を動的構築
@@ -318,6 +323,7 @@ def create_multilingual_scholar(
             instruction=instruction,
             generate_content_config=types.GenerateContentConfig(temperature=0.7),
             tools=[append_to_whiteboard],
+            after_model_callback=create_token_tracking_callback("scholar_multilingual_debate"),
         )
     else:
         raise ValueError(f"Unknown mode: {mode!r}. Use 'analysis' or 'debate'.")

--- a/mystery_agents/agents/storyteller.py
+++ b/mystery_agents/agents/storyteller.py
@@ -26,6 +26,7 @@ from shared.model_config import (
     create_storyteller_model,
 )
 from shared.state_keys import STORYTELLER_LLM_METADATA
+from shared.token_tracker import track_tokens
 
 from .storyteller_instructions import STORYTELLER_INSTRUCTION
 
@@ -122,6 +123,9 @@ def _storyteller_after_model(
     llm_response: LlmResponse,
 ) -> LlmResponse | None:
     """Storyteller の LLM 応答メタデータを記録する。"""
+    # トークン使用量を共通ログに追記
+    track_tokens("storyteller", callback_context, llm_response)
+
     has_text = (
         llm_response.content
         and llm_response.content.parts

--- a/mystery_agents/agents/translator.py
+++ b/mystery_agents/agents/translator.py
@@ -19,6 +19,7 @@ from google.adk.agents import LlmAgent
 from google.genai import types
 
 from shared.model_config import create_flash_model
+from shared.token_tracker import create_token_tracking_callback
 
 from .translator_instructions import BASE_TRANSLATOR_INSTRUCTION as _BASE_TRANSLATOR_INSTRUCTION
 
@@ -132,6 +133,7 @@ def create_translator(target_lang: str) -> LlmAgent:
         generate_content_config=types.GenerateContentConfig(temperature=0.2),
         output_key=f"translation_result_{target_lang}",
         include_contents="none",
+        after_model_callback=create_token_tracking_callback(f"translator_{target_lang}"),
     )
 
 

--- a/packages/shared/src/types/mystery.ts
+++ b/packages/shared/src/types/mystery.ts
@@ -532,6 +532,23 @@ export interface FirestoreDesign {
 /**
  * パイプライン実行ステータス
  */
+/**
+ * エージェント別トークン使用量
+ */
+export interface AgentTokenMetrics {
+  calls: number;
+  prompt_tokens: number;
+  output_tokens: number;
+}
+
+/**
+ * パイプライン全体のトークンメトリクス
+ */
+export interface PipelineTokenMetrics {
+  by_agent: Record<string, AgentTokenMetrics>;
+  totals: AgentTokenMetrics;
+}
+
 export type PipelineRunStatus = "running" | "completed" | "error";
 
 /**
@@ -555,6 +572,8 @@ export interface PipelineRun {
   updated_at: Date;
   completed_at: Date | null;
   error_message: string | null;
+  /** 全エージェント横断トークン使用量 */
+  token_metrics?: PipelineTokenMetrics;
 }
 
 /**

--- a/podcast_agents/agents/podcast_translator.py
+++ b/podcast_agents/agents/podcast_translator.py
@@ -11,6 +11,7 @@ from google.adk.agents import LlmAgent
 from google.genai import types
 
 from shared.model_config import create_flash_model
+from shared.token_tracker import create_token_tracking_callback
 
 # === 日本語訳 ===
 # あなたは「Ghost in the Archive」プロジェクトのポッドキャスト脚本翻訳者です。
@@ -92,6 +93,7 @@ def create_podcast_translator() -> LlmAgent:
         instruction=PODCAST_TRANSLATOR_INSTRUCTION,
         generate_content_config=types.GenerateContentConfig(temperature=0.2),
         output_key="podcast_script_ja",
+        after_model_callback=create_token_tracking_callback("podcast_translator_ja"),
     )
 
 

--- a/podcast_agents/agents/script_planner.py
+++ b/podcast_agents/agents/script_planner.py
@@ -13,6 +13,8 @@ Output: script_outline (テキスト), structured_outline (JSON via tool)
 from google.adk.agents import LlmAgent
 from google.genai import types
 
+from shared.token_tracker import create_token_tracking_callback
+
 from shared.model_config import create_flash_model
 
 from ..tools.script_tools import save_script_outline
@@ -282,6 +284,7 @@ def create_script_planner() -> LlmAgent:
         generate_content_config=types.GenerateContentConfig(temperature=0.3),
         tools=[save_script_outline],
         output_key="script_outline",
+        after_model_callback=create_token_tracking_callback("script_planner"),
     )
 
 

--- a/podcast_agents/agents/scriptwriter.py
+++ b/podcast_agents/agents/scriptwriter.py
@@ -14,6 +14,7 @@ from google.adk.agents import LlmAgent
 from google.genai import types
 
 from shared.model_config import create_pro_model
+from shared.token_tracker import create_token_tracking_callback
 
 from ..tools.script_tools import save_segment, finalize_script
 
@@ -386,6 +387,7 @@ def create_scriptwriter() -> LlmAgent:
         generate_content_config=types.GenerateContentConfig(temperature=0.8),
         tools=[save_segment, finalize_script],
         output_key="podcast_script",
+        after_model_callback=create_token_tracking_callback("scriptwriter"),
     )
 
 

--- a/shared/orchestrator.py
+++ b/shared/orchestrator.py
@@ -35,6 +35,7 @@ from shared.state_keys import (
     STRUCTURED_REPORT,
 )
 from shared.search_metrics import extract_search_metrics, save_search_metrics
+from shared.token_tracker import extract_token_metrics, save_token_metrics
 from shared.pipeline_run import (
     create_pipeline_run,
     update_agent_started,
@@ -460,6 +461,11 @@ async def run_pipeline(
             if run_type == "blog":
                 search_metrics = extract_search_metrics(session_state)
                 save_search_metrics(run_id, search_metrics)
+
+            # トークンメトリクスの保存（全エージェント横断）
+            # blog / podcast 両方で実行
+            token_metrics = extract_token_metrics(session_state)
+            save_token_metrics(run_id, token_metrics)
 
             # mystery_id 抽出（blog パイプラインのみ）
             mystery_id = None

--- a/shared/state_keys.py
+++ b/shared/state_keys.py
@@ -33,6 +33,7 @@ PIPELINE_RUN_ID = "pipeline_run_id"
 STORYTELLER_LLM_METADATA = "storyteller_llm_metadata"
 WORD_COUNT_TIER = "_word_count_tier"
 SEARCH_LOG = "search_log"
+AGENT_TOKEN_LOG = "_agent_token_log"
 
 
 # ---------------------------------------------------------------------------

--- a/shared/token_tracker.py
+++ b/shared/token_tracker.py
@@ -1,0 +1,126 @@
+"""全エージェント横断トークン使用量追跡。
+
+各 LlmAgent の after_model_callback で呼び出し、セッション状態にトークン使用量を蓄積する。
+パイプライン完了後に orchestrator が集約して pipeline_runs に永続化する。
+
+既存の search_metrics パターン（セッション状態 → 抽出 → Firestore）を踏襲する。
+"""
+
+import logging
+from datetime import datetime, timezone
+
+from shared.state_keys import AGENT_TOKEN_LOG
+
+logger = logging.getLogger(__name__)
+
+
+def track_tokens(agent_name: str, callback_context, llm_response) -> None:
+    """トークン使用量をセッション状態に追記する。
+
+    after_model_callback 内から呼び出す低レベル関数。
+    usage_metadata がない場合は 0 でフォールバックする。
+
+    Args:
+        agent_name: エージェント識別名（例: "librarian_us_archives", "scholar_en"）
+        callback_context: ADK CallbackContext（state アクセス用）
+        llm_response: ADK LlmResponse（usage_metadata アクセス用）
+    """
+    usage = llm_response.usage_metadata if llm_response else None
+    prompt_tokens = getattr(usage, "prompt_token_count", 0) or 0
+    output_tokens = getattr(usage, "candidates_token_count", 0) or 0
+
+    entry = {
+        "agent": agent_name,
+        "prompt_tokens": prompt_tokens,
+        "output_tokens": output_tokens,
+    }
+
+    log = callback_context.state.get(AGENT_TOKEN_LOG)
+    if not isinstance(log, list):
+        log = []
+    log.append(entry)
+    callback_context.state[AGENT_TOKEN_LOG] = log
+
+
+def create_token_tracking_callback(agent_name: str):
+    """after_model_callback ファクトリ。agent_name をクロージャでバインドする。
+
+    Args:
+        agent_name: エージェント識別名
+
+    Returns:
+        after_model_callback 関数（None を返す = レスポンスを変更しない）
+    """
+    def _callback(callback_context, llm_response):
+        track_tokens(agent_name, callback_context, llm_response)
+        return None
+    return _callback
+
+
+def extract_token_metrics(session_state: dict) -> dict | None:
+    """_agent_token_log を集約して by_agent + totals を返す。
+
+    Args:
+        session_state: セッション状態辞書
+
+    Returns:
+        集約結果 dict、またはログがない場合は None
+    """
+    log = session_state.get(AGENT_TOKEN_LOG)
+    if not log or not isinstance(log, list):
+        return None
+
+    by_agent: dict[str, dict] = {}
+    for entry in log:
+        if not isinstance(entry, dict):
+            continue
+        agent = entry.get("agent", "unknown")
+        prompt = entry.get("prompt_tokens", 0)
+        output = entry.get("output_tokens", 0)
+
+        if agent not in by_agent:
+            by_agent[agent] = {"calls": 0, "prompt_tokens": 0, "output_tokens": 0}
+        by_agent[agent]["calls"] += 1
+        by_agent[agent]["prompt_tokens"] += prompt
+        by_agent[agent]["output_tokens"] += output
+
+    if not by_agent:
+        return None
+
+    totals = {
+        "calls": sum(a["calls"] for a in by_agent.values()),
+        "prompt_tokens": sum(a["prompt_tokens"] for a in by_agent.values()),
+        "output_tokens": sum(a["output_tokens"] for a in by_agent.values()),
+    }
+
+    return {"by_agent": by_agent, "totals": totals}
+
+
+def save_token_metrics(run_id: str | None, metrics: dict | None) -> None:
+    """token_metrics を pipeline_runs ドキュメントに保存する（非ブロッキング）。
+
+    Args:
+        run_id: パイプライン実行ドキュメントの ID
+        metrics: extract_token_metrics() の戻り値。None なら何もしない。
+    """
+    if not run_id or metrics is None:
+        return
+    try:
+        from shared.firestore import get_firestore_client
+
+        db = get_firestore_client()
+        db.collection("pipeline_runs").document(run_id).update({
+            "token_metrics": metrics,
+            "updated_at": datetime.now(timezone.utc),
+        })
+        logger.info(
+            "トークンメトリクス保存: %s (エージェント数=%d, 総呼出=%d, 総入力=%d, 総出力=%d)",
+            run_id,
+            len(metrics.get("by_agent", {})),
+            metrics["totals"]["calls"],
+            metrics["totals"]["prompt_tokens"],
+            metrics["totals"]["output_tokens"],
+        )
+    except Exception:
+        # メトリクス保存失敗はパイプラインをブロックしない
+        logger.warning("Failed to save token metrics to Firestore", exc_info=True)

--- a/tests/unit/test_storyteller.py
+++ b/tests/unit/test_storyteller.py
@@ -11,7 +11,7 @@ from mystery_agents.agents.storyteller import (
     _storyteller_after_model,
     _storyteller_before_model,
 )
-from shared.state_keys import STORYTELLER_LLM_METADATA
+from shared.state_keys import AGENT_TOKEN_LOG, STORYTELLER_LLM_METADATA
 
 
 def _make_llm_response(
@@ -164,6 +164,37 @@ class TestStorytellerAfterModel:
         metadata = ctx.state[STORYTELLER_LLM_METADATA]
         assert metadata["prompt_tokens"] is None
         assert metadata["output_tokens"] is None
+
+    def test_token_log_appended_on_normal_response(self):
+        """正常応答時に _agent_token_log にも追記される。"""
+        ctx = _make_callback_context()
+        response = _make_llm_response(
+            text="A compelling narrative...",
+            prompt_tokens=5000,
+            output_tokens=3000,
+        )
+
+        _storyteller_after_model(ctx, response)
+
+        log = ctx.state[AGENT_TOKEN_LOG]
+        assert len(log) == 1
+        assert log[0]["agent"] == "storyteller"
+        assert log[0]["prompt_tokens"] == 5000
+        assert log[0]["output_tokens"] == 3000
+
+    def test_token_log_appended_on_error_response(self):
+        """異常応答時にも _agent_token_log に追記される。"""
+        ctx = _make_callback_context()
+        response = _make_llm_response(
+            error_code="SAFETY_FILTER",
+            prompt_tokens=3000,
+        )
+
+        _storyteller_after_model(ctx, response)
+
+        log = ctx.state[AGENT_TOKEN_LOG]
+        assert len(log) == 1
+        assert log[0]["agent"] == "storyteller"
 
 
 class TestStorytellerInstruction:

--- a/tests/unit/test_token_tracker.py
+++ b/tests/unit/test_token_tracker.py
@@ -1,0 +1,264 @@
+"""Unit tests for shared/token_tracker.py — 全エージェント横断トークン使用量追跡。"""
+
+from unittest.mock import MagicMock, patch
+
+from shared.state_keys import AGENT_TOKEN_LOG
+from shared.token_tracker import (
+    create_token_tracking_callback,
+    extract_token_metrics,
+    save_token_metrics,
+    track_tokens,
+)
+
+
+# ---------------------------------------------------------------------------
+# ヘルパー
+# ---------------------------------------------------------------------------
+
+def _make_callback_context(state: dict | None = None):
+    """テスト用 CallbackContext モック。"""
+    ctx = MagicMock()
+    ctx.state = state if state is not None else {}
+    return ctx
+
+
+def _make_llm_response(*, prompt_tokens: int | None = None, output_tokens: int | None = None):
+    """テスト用 LlmResponse モック。"""
+    resp = MagicMock()
+    if prompt_tokens is not None or output_tokens is not None:
+        resp.usage_metadata = MagicMock()
+        resp.usage_metadata.prompt_token_count = prompt_tokens
+        resp.usage_metadata.candidates_token_count = output_tokens
+    else:
+        resp.usage_metadata = None
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# track_tokens
+# ---------------------------------------------------------------------------
+
+class TestTrackTokens:
+    """track_tokens() のテスト。"""
+
+    def test_appends_entry_to_empty_state(self):
+        """空のセッション状態に最初のエントリを追記する。"""
+        ctx = _make_callback_context()
+        resp = _make_llm_response(prompt_tokens=100, output_tokens=50)
+
+        track_tokens("scholar_en", ctx, resp)
+
+        log = ctx.state[AGENT_TOKEN_LOG]
+        assert len(log) == 1
+        assert log[0] == {
+            "agent": "scholar_en",
+            "prompt_tokens": 100,
+            "output_tokens": 50,
+        }
+
+    def test_appends_to_existing_log(self):
+        """既存のログリストに追記する。"""
+        existing = [{"agent": "librarian_us", "prompt_tokens": 200, "output_tokens": 100}]
+        ctx = _make_callback_context({AGENT_TOKEN_LOG: existing})
+        resp = _make_llm_response(prompt_tokens=300, output_tokens=150)
+
+        track_tokens("scholar_de", ctx, resp)
+
+        log = ctx.state[AGENT_TOKEN_LOG]
+        assert len(log) == 2
+        assert log[1]["agent"] == "scholar_de"
+
+    def test_no_usage_metadata_falls_back_to_zero(self):
+        """usage_metadata が None の場合、トークン数は 0 にフォールバックする。"""
+        ctx = _make_callback_context()
+        resp = _make_llm_response()  # usage_metadata = None
+
+        track_tokens("illustrator", ctx, resp)
+
+        entry = ctx.state[AGENT_TOKEN_LOG][0]
+        assert entry["prompt_tokens"] == 0
+        assert entry["output_tokens"] == 0
+
+    def test_none_llm_response_falls_back_to_zero(self):
+        """llm_response 自体が None の場合も安全に処理する。"""
+        ctx = _make_callback_context()
+
+        track_tokens("translator_ja", ctx, None)
+
+        entry = ctx.state[AGENT_TOKEN_LOG][0]
+        assert entry["prompt_tokens"] == 0
+        assert entry["output_tokens"] == 0
+
+    def test_non_list_state_reinitializes(self):
+        """state に list でない値が入っている場合、新しいリストで上書きする。"""
+        ctx = _make_callback_context({AGENT_TOKEN_LOG: "corrupted"})
+        resp = _make_llm_response(prompt_tokens=50, output_tokens=25)
+
+        track_tokens("storyteller", ctx, resp)
+
+        log = ctx.state[AGENT_TOKEN_LOG]
+        assert isinstance(log, list)
+        assert len(log) == 1
+
+
+# ---------------------------------------------------------------------------
+# create_token_tracking_callback
+# ---------------------------------------------------------------------------
+
+class TestCreateTokenTrackingCallback:
+    """create_token_tracking_callback() のテスト。"""
+
+    def test_binds_agent_name_and_returns_none(self):
+        """agent_name をクロージャでバインドし、None を返す。"""
+        callback = create_token_tracking_callback("librarian_europeana")
+        ctx = _make_callback_context()
+        resp = _make_llm_response(prompt_tokens=500, output_tokens=250)
+
+        result = callback(ctx, resp)
+
+        assert result is None
+        assert ctx.state[AGENT_TOKEN_LOG][0]["agent"] == "librarian_europeana"
+
+    def test_different_agent_names_produce_independent_callbacks(self):
+        """異なる agent_name のコールバックは独立して動作する。"""
+        cb1 = create_token_tracking_callback("scholar_en")
+        cb2 = create_token_tracking_callback("scholar_de")
+        ctx = _make_callback_context()
+
+        cb1(ctx, _make_llm_response(prompt_tokens=100, output_tokens=50))
+        cb2(ctx, _make_llm_response(prompt_tokens=200, output_tokens=100))
+
+        agents = [e["agent"] for e in ctx.state[AGENT_TOKEN_LOG]]
+        assert agents == ["scholar_en", "scholar_de"]
+
+
+# ---------------------------------------------------------------------------
+# extract_token_metrics
+# ---------------------------------------------------------------------------
+
+class TestExtractTokenMetrics:
+    """extract_token_metrics() のテスト。"""
+
+    def test_empty_state_returns_none(self):
+        """ログがない場合は None を返す。"""
+        assert extract_token_metrics({}) is None
+
+    def test_empty_list_returns_none(self):
+        """空リストの場合は None を返す。"""
+        assert extract_token_metrics({AGENT_TOKEN_LOG: []}) is None
+
+    def test_single_agent_single_call(self):
+        """単一エージェント・単一呼出の集約。"""
+        state = {
+            AGENT_TOKEN_LOG: [
+                {"agent": "storyteller", "prompt_tokens": 1000, "output_tokens": 500},
+            ]
+        }
+        metrics = extract_token_metrics(state)
+
+        assert metrics["by_agent"]["storyteller"] == {
+            "calls": 1,
+            "prompt_tokens": 1000,
+            "output_tokens": 500,
+        }
+        assert metrics["totals"] == {
+            "calls": 1,
+            "prompt_tokens": 1000,
+            "output_tokens": 500,
+        }
+
+    def test_multiple_agents(self):
+        """複数エージェントの集約。"""
+        state = {
+            AGENT_TOKEN_LOG: [
+                {"agent": "scholar_en", "prompt_tokens": 500, "output_tokens": 300},
+                {"agent": "scholar_de", "prompt_tokens": 600, "output_tokens": 400},
+            ]
+        }
+        metrics = extract_token_metrics(state)
+
+        assert len(metrics["by_agent"]) == 2
+        assert metrics["totals"]["calls"] == 2
+        assert metrics["totals"]["prompt_tokens"] == 1100
+        assert metrics["totals"]["output_tokens"] == 700
+
+    def test_same_agent_multiple_calls_aggregated(self):
+        """同一エージェントの複数呼出が集約される。"""
+        state = {
+            AGENT_TOKEN_LOG: [
+                {"agent": "armchair_polymath", "prompt_tokens": 1000, "output_tokens": 500},
+                {"agent": "armchair_polymath", "prompt_tokens": 2000, "output_tokens": 1000},
+                {"agent": "armchair_polymath", "prompt_tokens": 3000, "output_tokens": 1500},
+            ]
+        }
+        metrics = extract_token_metrics(state)
+
+        polymath = metrics["by_agent"]["armchair_polymath"]
+        assert polymath["calls"] == 3
+        assert polymath["prompt_tokens"] == 6000
+        assert polymath["output_tokens"] == 3000
+
+    def test_non_dict_entries_skipped(self):
+        """dict でないエントリは無視される。"""
+        state = {
+            AGENT_TOKEN_LOG: [
+                "invalid",
+                {"agent": "storyteller", "prompt_tokens": 100, "output_tokens": 50},
+                42,
+            ]
+        }
+        metrics = extract_token_metrics(state)
+
+        assert metrics["totals"]["calls"] == 1
+
+    def test_non_list_log_returns_none(self):
+        """ログが list でない場合は None を返す。"""
+        assert extract_token_metrics({AGENT_TOKEN_LOG: "not a list"}) is None
+
+
+# ---------------------------------------------------------------------------
+# save_token_metrics
+# ---------------------------------------------------------------------------
+
+class TestSaveTokenMetrics:
+    """save_token_metrics() のテスト。"""
+
+    @patch("shared.firestore.get_firestore_client")
+    def test_saves_to_firestore(self, mock_get_client):
+        """Firestore に token_metrics を保存する。"""
+        mock_db = MagicMock()
+        mock_get_client.return_value = mock_db
+
+        metrics = {
+            "by_agent": {"storyteller": {"calls": 1, "prompt_tokens": 100, "output_tokens": 50}},
+            "totals": {"calls": 1, "prompt_tokens": 100, "output_tokens": 50},
+        }
+
+        save_token_metrics("run_123", metrics)
+
+        mock_db.collection.assert_called_once_with("pipeline_runs")
+        mock_db.collection().document.assert_called_once_with("run_123")
+        update_call = mock_db.collection().document().update
+        update_call.assert_called_once()
+        saved_data = update_call.call_args[0][0]
+        assert saved_data["token_metrics"] == metrics
+        assert "updated_at" in saved_data
+
+    def test_none_run_id_skips(self):
+        """run_id が None の場合は何もしない。"""
+        # Firestore import がないことを確認（例外が出ない）
+        save_token_metrics(None, {"totals": {}})
+
+    def test_none_metrics_skips(self):
+        """metrics が None の場合は何もしない。"""
+        save_token_metrics("run_123", None)
+
+    @patch("shared.firestore.get_firestore_client", side_effect=Exception("connection error"))
+    def test_firestore_error_does_not_block(self, mock_get_client):
+        """Firestore エラーはパイプラインをブロックしない。"""
+        metrics = {
+            "by_agent": {},
+            "totals": {"calls": 0, "prompt_tokens": 0, "output_tokens": 0},
+        }
+        # 例外が伝播しないことを確認
+        save_token_metrics("run_456", metrics)


### PR DESCRIPTION
## Summary
- 各 LlmAgent の `after_model_callback` でトークン使用量をセッション状態に蓄積し、パイプライン完了後に `pipeline_runs.token_metrics` に永続化
- 既存の `search_metrics` パターン（セッション状態 → 抽出 → Firestore）を踏襲
- blog / podcast 両パイプラインで動作

## 変更内容

### 新規ファイル
- `shared/token_tracker.py` — `track_tokens` / `create_token_tracking_callback` / `extract_token_metrics` / `save_token_metrics`
- `tests/unit/test_token_tracker.py` — 18テスト

### 変更ファイル（16ファイル）
- `shared/state_keys.py` — `AGENT_TOKEN_LOG` 定数追加
- `shared/orchestrator.py` — token_metrics 抽出・保存（blog/podcast 両方）
- `mystery_agents/agents/` — 7ファイルに `after_model_callback` 追加（api_librarians, language_scholars, dynamic_polymath_block, armchair_polymath, illustrator, translator, storyteller）
- `podcast_agents/agents/` — 3ファイルに `after_model_callback` 追加（script_planner, scriptwriter, podcast_translator）
- `packages/shared/src/types/mystery.ts` — `AgentTokenMetrics` / `PipelineTokenMetrics` 型定義 + `PipelineRun.token_metrics`
- `tests/unit/test_storyteller.py` — トークンログ追記検証2テスト追加

### Firestore データ構造（`pipeline_runs.token_metrics`）
```json
{
  "by_agent": {
    "librarian_us_archives": { "calls": 3, "prompt_tokens": 1200, "output_tokens": 800 },
    "scholar_en": { "calls": 1, "prompt_tokens": 5000, "output_tokens": 3000 },
    "armchair_polymath": { "calls": 5, "prompt_tokens": 15000, "output_tokens": 8000 }
  },
  "totals": { "calls": 15, "prompt_tokens": 45000, "output_tokens": 22000 }
}
```

## Test plan
- [x] `pytest tests/unit/test_token_tracker.py -v` — 18テスト全パス
- [x] `pytest tests/unit/test_storyteller.py -v` — トークンログ追記含む35テスト全パス
- [x] `pytest tests/unit/ -v` — 全1312テスト全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)