### PR TITLE
fix: Librarian ソースキー不一致修正（wellcome/ndl）

### DIFF
--- a/mystery_agents/agents/api_librarians.py
+++ b/mystery_agents/agents/api_librarians.py
@@ -196,7 +196,7 @@ API_CONFIGS: dict[str, dict] = {
             "   - Use appropriate kanji/hiragana for historical topics\n"
             "   - Include both modern and historical terminology\n"
             '2. Call **search_archives** with:\n'
-            '   - `sources="ndl_search"`, `language="ja"`\n'
+            '   - `sources="ndl"`, `language="ja"`\n'
             '   - `reference_keywords="番町, 皿屋敷, 江戸"`\n'
             '   - `keywords="怪談, 幽霊, 心霊現象, 民間伝承"`\n'
             "3. Date filtering is OPTIONAL"
@@ -265,7 +265,7 @@ API_CONFIGS: dict[str, dict] = {
             "   Generate medical/belief terms → `keywords`\n"
             "   - Include historical medical terms alongside modern equivalents\n"
             '2. Call **search_archives** with:\n'
-            '   - `sources="wellcome_collection"`, `language="en"`\n'
+            '   - `sources="wellcome"`, `language="en"`\n'
             '   - `reference_keywords="Salem, Pendle, 1692"`\n'
             '   - `keywords="witchcraft trial, possession, exorcism, folk remedy"`\n'
             "3. Date filtering is OPTIONAL"

--- a/tests/unit/test_api_librarians.py
+++ b/tests/unit/test_api_librarians.py
@@ -76,3 +76,23 @@ class TestAPILibrarianFactory:
             agent = create_api_librarian(api_key)
             # MagicMock 環境では .name がモックされるため repr で検証
             assert f"librarian_{api_key}" in repr(agent)
+
+    def test_instruction_source_keys_exist_in_registry(self):
+        """instruction 内の sources= 値がソースレジストリに登録済みであること。"""
+        import re
+
+        from mystery_agents.tools.source_registry import get_all_sources
+
+        registry_keys = set(get_all_sources().keys())
+        pattern = re.compile(r'sources="([^"]+)"')
+
+        for api_key, config in API_CONFIGS.items():
+            strategy = config.get("search_strategy", "")
+            match = pattern.search(strategy)
+            if match:
+                source_refs = [s.strip() for s in match.group(1).split(",")]
+                for src in source_refs:
+                    assert src in registry_keys, (
+                        f"API '{api_key}' の instruction が参照する "
+                        f"sources=\"{src}\" はソースレジストリに未登録"
+                    )


### PR DESCRIPTION
## Summary
- Librarian instruction 内の `sources="wellcome_collection"` を `sources="wellcome"` に修正（ソースレジストリの登録キーと不一致だった）
- 同様に `sources="ndl_search"` を `sources="ndl"` に修正
- 回帰テスト追加: 全 API Librarian の instruction 内 `sources=` 値がソースレジストリに登録済みであることを検証

## Background
記事 HIS-DE-HAJ-20260228142041 のパイプライン実行分析で発見。Wellcome Collection API と NDL Search API が instruction で指定されたソースキーとレジストリの登録キーが不一致のため、実質未検索だった。

## Test plan
- [x] `pytest tests/unit/test_api_librarians.py -v` — 全17テスト PASSED
- [ ] 修正前のソースキーに戻すと `test_instruction_source_keys_exist_in_registry` が FAIL することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)