### PR TITLE
fix: Librarian 画像収集時にプレースホルダー画像を除外する

### DIFF
--- a/mystery_agents/tools/librarian_tools.py
+++ b/mystery_agents/tools/librarian_tools.py
@@ -11,6 +11,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
+import requests
+
 from google.adk.tools.tool_context import ToolContext
 from shared.keyword_translator import translate_keywords
 from shared.state_keys import (
@@ -35,11 +37,32 @@ from .source_registry import get_all_sources, resolve_newspaper_sources
 
 logger = logging.getLogger(__name__)
 
+# 画像バリデーション: この閾値未満はプレースホルダーとみなす
+MIN_IMAGE_BYTES = 5000
+
 # 並列実行の最大ワーカー数
 _MAX_WORKERS = 6
 
 # 全ソース合計のドキュメント上限
 _TOTAL_DOCS_CAP = 30
+
+
+def _validate_image_url(url: str, timeout: float = 5.0) -> bool:
+    """HEAD リクエストで画像 URL の有効性を検証する。
+
+    Europeana サムネイル API 等が返す白いプレースホルダー画像（1211バイト等）を
+    Content-Length ヘッダで検出し、除外する。
+    """
+    try:
+        resp = requests.head(url, timeout=timeout, allow_redirects=True)
+        if resp.status_code != 200:
+            return False
+        content_length = resp.headers.get("Content-Length")
+        if content_length is not None and int(content_length) < MIN_IMAGE_BYTES:
+            return False
+        return True
+    except (requests.RequestException, ValueError):
+        return False
 
 
 def _accumulate_archive_images(
@@ -59,9 +82,23 @@ def _accumulate_archive_images(
         if (d.get("thumbnail_url") or d.get("image_url"))
         and d.get("keywords_matched")
     ]
-    if images_with_urls:
+
+    # 画像 URL の有効性検証: プレースホルダー画像を除外する
+    validated = []
+    for img in images_with_urls:
+        thumb = img.get("thumbnail_url")
+        full = img.get("image_url")
+        if thumb and not _validate_image_url(thumb):
+            img["thumbnail_url"] = None
+        if full and not _validate_image_url(full):
+            img["image_url"] = None
+        # 両方 None なら蓄積しない
+        if img.get("thumbnail_url") or img.get("image_url"):
+            validated.append(img)
+
+    if validated:
         existing_images = tool_context.state.get(ARCHIVE_IMAGES, [])
-        existing_images.extend(images_with_urls)
+        existing_images.extend(validated)
         tool_context.state[ARCHIVE_IMAGES] = existing_images
 
 

--- a/tests/unit/test_evidence_relevance.py
+++ b/tests/unit/test_evidence_relevance.py
@@ -7,6 +7,8 @@
 import json
 import logging
 
+import responses
+
 from tests.fakes import make_archive_doc, make_tool_context
 
 
@@ -85,9 +87,16 @@ class TestRankDocumentsExcludesZeroMatch:
 class TestAccumulateImagesExcludesZeroMatch:
     """_accumulate_archive_images の0一致フィルタテスト。"""
 
+    @responses.activate
     def test_accumulate_images_excludes_zero_match(self):
         """keywords_matched が空のドキュメントの画像は蓄積されない。"""
         from mystery_agents.tools.librarian_tools import _accumulate_archive_images
+
+        # 画像バリデーションの HEAD リクエストをモック（正常画像）
+        responses.add(
+            responses.HEAD, "https://example.com/thumb1.jpg",
+            status=200, headers={"Content-Length": "40000"},
+        )
 
         ctx = make_tool_context()
         docs_dicts = [
@@ -110,6 +119,129 @@ class TestAccumulateImagesExcludesZeroMatch:
         images = ctx.state.get("archive_images", [])
         assert len(images) == 1
         assert images[0]["title"] == "Relevant"
+
+
+# ---------------------------------------------------------------------------
+# Layer 1.5: 画像 URL バリデーション（プレースホルダー除外）
+# ---------------------------------------------------------------------------
+
+
+class TestValidateImageUrl:
+    """_validate_image_url のテスト。"""
+
+    @responses.activate
+    def test_small_placeholder_rejected(self):
+        """Content-Length が閾値未満のプレースホルダー画像は無効と判定される。"""
+        from mystery_agents.tools.librarian_tools import _validate_image_url
+
+        url = "https://api.europeana.eu/thumbnail/v3/400/placeholder.jpg"
+        responses.add(
+            responses.HEAD, url,
+            status=200, headers={"Content-Length": "1211"},
+        )
+        assert _validate_image_url(url) is False
+
+    @responses.activate
+    def test_normal_image_accepted(self):
+        """正常なサイズの画像は有効と判定される。"""
+        from mystery_agents.tools.librarian_tools import _validate_image_url
+
+        url = "https://example.com/real-image.jpg"
+        responses.add(
+            responses.HEAD, url,
+            status=200, headers={"Content-Length": "40000"},
+        )
+        assert _validate_image_url(url) is True
+
+    @responses.activate
+    def test_no_content_length_accepted(self):
+        """Content-Length ヘッダなしは有効とみなす（判定不能のため許容）。"""
+        from mystery_agents.tools.librarian_tools import _validate_image_url
+
+        url = "https://example.com/streaming-image.jpg"
+        responses.add(responses.HEAD, url, status=200)
+        assert _validate_image_url(url) is True
+
+    @responses.activate
+    def test_http_error_rejected(self):
+        """HTTP 404 は無効と判定される。"""
+        from mystery_agents.tools.librarian_tools import _validate_image_url
+
+        url = "https://example.com/missing.jpg"
+        responses.add(responses.HEAD, url, status=404)
+        assert _validate_image_url(url) is False
+
+    @responses.activate
+    def test_network_error_rejected(self):
+        """ネットワークエラーは無効と判定される。"""
+        from mystery_agents.tools.librarian_tools import _validate_image_url
+        from requests.exceptions import ConnectionError
+
+        url = "https://unreachable.example.com/image.jpg"
+        responses.add(
+            responses.HEAD, url,
+            body=ConnectionError("Connection refused"),
+        )
+        assert _validate_image_url(url) is False
+
+
+class TestAccumulateImagesValidation:
+    """_accumulate_archive_images の画像バリデーション統合テスト。"""
+
+    @responses.activate
+    def test_placeholder_thumbnail_excluded(self):
+        """小さいプレースホルダー画像のみの場合、ドキュメントが除外される。"""
+        from mystery_agents.tools.librarian_tools import _accumulate_archive_images
+
+        responses.add(
+            responses.HEAD, "https://api.europeana.eu/thumbnail/placeholder.jpg",
+            status=200, headers={"Content-Length": "1211"},
+        )
+
+        ctx = make_tool_context()
+        docs_dicts = [
+            {
+                "title": "Gallica Document",
+                "source_url": "https://gallica.bnf.fr/doc1",
+                "source_type": "europeana",
+                "thumbnail_url": "https://api.europeana.eu/thumbnail/placeholder.jpg",
+                "keywords_matched": ["key1"],
+            },
+        ]
+        _accumulate_archive_images(ctx, docs_dicts)
+        images = ctx.state.get("archive_images", [])
+        assert len(images) == 0
+
+    @responses.activate
+    def test_invalid_thumbnail_valid_image_url_kept(self):
+        """thumbnail 無効 + image_url 有効 → image_url のみで蓄積される。"""
+        from mystery_agents.tools.librarian_tools import _accumulate_archive_images
+
+        responses.add(
+            responses.HEAD, "https://api.europeana.eu/thumbnail/placeholder.jpg",
+            status=200, headers={"Content-Length": "1211"},
+        )
+        responses.add(
+            responses.HEAD, "https://example.com/full-image.jpg",
+            status=200, headers={"Content-Length": "80000"},
+        )
+
+        ctx = make_tool_context()
+        docs_dicts = [
+            {
+                "title": "Mixed Validity",
+                "source_url": "https://example.com/doc",
+                "source_type": "europeana",
+                "thumbnail_url": "https://api.europeana.eu/thumbnail/placeholder.jpg",
+                "image_url": "https://example.com/full-image.jpg",
+                "keywords_matched": ["key1"],
+            },
+        ]
+        _accumulate_archive_images(ctx, docs_dicts)
+        images = ctx.state.get("archive_images", [])
+        assert len(images) == 1
+        assert images[0]["thumbnail_url"] is None
+        assert images[0]["image_url"] == "https://example.com/full-image.jpg"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Europeana サムネイル API が Gallica/BnF 等の一部ソースに対して返す白いプレースホルダー画像（1211バイト）を `_validate_image_url()` で HEAD リクエストの `Content-Length` を使って検出
- `_accumulate_archive_images` に組み込み、無効な画像 URL を `None` に置換し、両方 `None` なら `archive_images` から除外
- `_validate_image_url` 単体テスト 5 件 + `_accumulate_archive_images` 統合テスト 2 件を追加

## 判定ロジック
| 条件 | 結果 |
|------|------|
| HTTP 200 以外 | 無効 |
| `Content-Length` あり & 5KB 未満 | 無効（プレースホルダー） |
| `Content-Length` なし | 有効（判定不能のため許容） |
| ネットワークエラー | 無効 |

## Test plan
- [x] `pytest tests/unit/test_evidence_relevance.py -v` — 全 19 テストパス
- [x] `pytest tests/unit/ -v` — 全 1335 テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)