### PR TITLE
fix: retranslate.py の未使用変数 lint エラーを修正

### DIFF
--- a/scripts/retranslate.py
+++ b/scripts/retranslate.py
@@ -51,7 +51,7 @@ async def _run_translator(lang: str, creative_content: str, mystery_report: str)
     )
 
     # セッション作成（Translator は creative_content と mystery_report をセッション状態から参照する）
-    session = await session_service.create_session(
+    await session_service.create_session(
         app_name=f"retranslate_{lang}",
         user_id="retranslate_script",
         session_id=f"retranslate_{lang}",


### PR DESCRIPTION
## Summary
- `scripts/retranslate.py` の未使用変数 `session` を削除し、F841 lint エラーを解消

## Test plan
- [x] `ruff check` パス確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)