### PR TITLE
feat: Librarian 全文取得追加 + Delpher 再追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -292,12 +292,12 @@ pending (EN原文 + 翻訳あり) → (Approve) → published
 #### ブログ作成パイプライン（`mystery_agents/`）
 
 ```
-ParallelAPILibrarians(5 API groups) → Aggregator → DynamicScholarBlock(分析+討論)
+ParallelAPILibrarians(6 API groups) → Aggregator → DynamicScholarBlock(分析+討論)
   → [PolymathGate] → ArmchairPolymath → [StorytellerGate] → Storyteller(EN)
   → [PostStoryGate] → Parallel(Illustrator, ParallelTranslators(3言語)) → Publisher → Firestore
 ```
 
-- API ベース Librarian（US Archives, Europeana, Internet Archive, NDL, Trove）がテーマに応じて自律検索
+- API ベース Librarian（US Archives, Europeana, Internet Archive, Delpher, NDL, Trove）がテーマに応じて自律検索
 - AggregatorAgent（LLM 不使用）が raw_search_results を言語別に集約 → `collected_documents_{lang}` に書き込み
 - DynamicScholarBlock（BaseAgent）が `active_languages` に基づき Scholar を動的生成
   - Phase 1: ドキュメントがある言語の Scholar のみ並列分析

--- a/mystery_agents/agent.py
+++ b/mystery_agents/agent.py
@@ -6,7 +6,7 @@ the multilingual investigation pipeline:
   BatchedAPILibrarians → Aggregator → DynamicScholarBlock
     → DynamicPolymathBlock → StorytellerBlock → PostStoryBlock
 
-API ベース Librarian（5グループ）を2バッチ（3+2）に分割して逐次実行し、
+API ベース Librarian（6グループ）を2バッチ（3+2）に分割して逐次実行し、
 Vertex AI QPM レートリミットを回避する。AggregatorAgent が検索結果を
 言語別に集約。DynamicScholarBlock が active_languages に基づき
 Scholar を動的に生成・実行し、分析→討論を一貫制御する。
@@ -50,7 +50,7 @@ if TYPE_CHECKING:
 # パイプライン説明文（build_pipeline 内で共有）
 _PIPELINE_DESCRIPTION = (
     "Ghost in the Archive multilingual blog creation pipeline. "
-    "Executes BatchedAPILibrarians(5 API groups in 2 batches) → Aggregator "
+    "Executes BatchedAPILibrarians(6 API groups in 2 batches) → Aggregator "
     "→ DynamicScholarBlock(analysis + debate) → DynamicPolymathBlock "
     "→ StorytellerBlock → PostStoryBlock "
     "to research, analyze, debate, create content, generate images, "
@@ -61,7 +61,7 @@ _PIPELINE_DESCRIPTION = (
     "Pipeline gates skip downstream agents when upstream stages fail."
 )
 
-# Vertex AI QPM 対策: 5並列 → 2バッチに分割して逐次実行
+# Vertex AI QPM 対策: 6並列 → 2バッチに分割して逐次実行
 # ParallelAgent は全 sub_agents を同時起動するため、5 Librarian が同時に
 # gemini-2.5-flash を呼び出すと QPM を超過する。SequentialAgent で
 # 2バッチに分けることで同時リクエスト数を半減させる。
@@ -166,7 +166,7 @@ def build_pipeline(storyteller: str = DEFAULT_STORYTELLER) -> SequentialAgent:
         before_agent_callback=make_post_story_gate(),
     )
 
-    # Librarian バッチ分割: 5並列 → 2バッチ（3+2）逐次実行
+    # Librarian バッチ分割: 6並列 → 2バッチ（3+2）逐次実行
     # Vertex AI QPM 超過を回避するため SequentialAgent でバッチを順番に実行
     batched_librarians = SequentialAgent(
         name="batched_api_librarians",

--- a/mystery_agents/agents/api_librarians.py
+++ b/mystery_agents/agents/api_librarians.py
@@ -167,6 +167,40 @@ API_CONFIGS: dict[str, dict] = {
         ),
         "has_newspapers": False,
     },
+    "delpher": {
+        "api_display_name": "KB/Delpher (Koninklijke Bibliotheek)",
+        "api_capabilities": (
+            "You manage **KB/Delpher** from the Koninklijke Bibliotheek (Royal Library of the Netherlands):\n"
+            "- Dutch historical newspapers, books, and periodicals from 1618 onwards\n"
+            "- SRU search protocol with Dublin Core metadata\n"
+            "- OCR fulltext available for many items via resolver URL\n"
+            "- Materials primarily in Dutch (some Latin, French, German)\n"
+            "- Strong for: Dutch colonial history, VOC (Dutch East India Company),\n"
+            "  maritime trade, Reformation, Dutch Golden Age, Indonesian history"
+        ),
+        "relevance_guidance": (
+            "Delpher is focused on Dutch-language historical materials.\n\n"
+            "**Search** if the theme has ANY connection to:\n"
+            "- Dutch history, culture, or colonial legacy\n"
+            "- VOC, Dutch East Indies, Suriname, Dutch Antilles\n"
+            "- Maritime history in the Atlantic and Indian Ocean\n"
+            "- European Reformation and religious conflicts\n"
+            "- Dutch Golden Age art, science, and exploration\n"
+            "- Indonesian, South African, or Caribbean colonial records\n\n"
+            "**Skip** if the theme has no plausible Dutch connection."
+        ),
+        "search_strategy": (
+            "1. Extract proper nouns/places → `reference_keywords` in Dutch\n"
+            "   Generate creative terms → `keywords` in Dutch\n"
+            "   - Use Dutch terminology for historical topics\n"
+            '2. Call **search_archives** with:\n'
+            '   - `sources="delpher"`, `language="nl"`\n'
+            '   - `reference_keywords="Batavia, VOC, Oost-Indië"`\n'
+            '   - `keywords="spookverhaal, geest, mysterie, onverklaard"`\n'
+            "3. Date filtering is OPTIONAL"
+        ),
+        "has_newspapers": False,
+    },
     "trove": {
         "api_display_name": "Trove (National Library of Australia)",
         "api_capabilities": (

--- a/mystery_agents/tools/chronicling_america.py
+++ b/mystery_agents/tools/chronicling_america.py
@@ -1,15 +1,20 @@
 """Chronicling America API ソース。
 
 LOC の loc.gov JSON API を使用して Chronicling America 新聞コレクションを検索する。
+ページ単位の OCR 全文テキスト取得にも対応。
 """
 
+import logging
 import re
 
+import requests
 
 from ..schemas.document import ArchiveDocument, SourceLanguage
 from .archive_source_base import ArchiveSearchResult, ArchiveSource
 from .search_utils import build_search_query
 from .source_registry import register_source
+
+logger = logging.getLogger(__name__)
 
 # 東海岸州リスト（新聞検索のデフォルトフィルタ）
 EAST_COAST_STATES = [
@@ -25,6 +30,86 @@ EAST_COAST_STATES = [
 ]
 
 BASE_URL = "https://www.loc.gov/search/"
+
+# 全文取得の上限設定
+_MAX_FULLTEXT_FETCHES = 5
+_FULLTEXT_TIMEOUT = 15
+_MAX_TEXT_LENGTH = 5000
+
+
+def _fetch_page_fulltext(
+    session: requests.Session, page_url: str
+) -> str | None:
+    """LOC ページ URL から OCR 全文テキストを取得する。
+
+    Args:
+        session: HTTP セッション
+        page_url: LOC ページ URL
+
+    Returns:
+        OCR テキスト（最大5000文字）。取得失敗時は None。
+    """
+    try:
+        sep = "&" if "?" in page_url else "?"
+        json_url = f"{page_url}{sep}fo=json"
+        resp = session.get(
+            json_url,
+            timeout=_FULLTEXT_TIMEOUT,
+            headers={"User-Agent": "GhostInTheArchive/1.0"},
+        )
+        if resp.status_code != 200:
+            return None
+        data = resp.json()
+        text = data.get("full_text", "")
+        return text.strip()[:_MAX_TEXT_LENGTH] if text else None
+    except (requests.RequestException, ValueError, KeyError) as e:
+        logger.debug("LOC page fulltext 取得失敗: %s", e)
+        return None
+
+
+def _fetch_item_fulltext(
+    session: requests.Session, item_url: str
+) -> str | None:
+    """LOC アイテム URL から OCR 全文テキストを取得する（2段階）。
+
+    Step 1: item URL + ?fo=json → JSON レスポンスの full_text フィールド
+    Step 2: full_text がない場合、resources の最初のページ URL を試す
+
+    Args:
+        session: HTTP セッション
+        item_url: LOC アイテム URL
+
+    Returns:
+        OCR テキスト（最大5000文字）。取得失敗時は None。
+    """
+    try:
+        sep = "&" if "?" in item_url else "?"
+        json_url = f"{item_url}{sep}fo=json"
+        resp = session.get(
+            json_url,
+            timeout=_FULLTEXT_TIMEOUT,
+            headers={"User-Agent": "GhostInTheArchive/1.0"},
+        )
+        if resp.status_code != 200:
+            return None
+        data = resp.json()
+
+        # 直接 full_text がある場合
+        full_text = data.get("full_text", "")
+        if full_text:
+            return full_text.strip()[:_MAX_TEXT_LENGTH]
+
+        # resources → 最初のページから full_text を取得
+        resources = data.get("resources", [])
+        if resources:
+            first_url = resources[0].get("url", "")
+            if first_url:
+                return _fetch_page_fulltext(session, first_url)
+
+        return None
+    except (requests.RequestException, ValueError, KeyError) as e:
+        logger.debug("LOC fulltext 取得失敗 (%s): %s", item_url, e)
+        return None
 
 
 class ChroniclingAmericaSource(ArchiveSource):
@@ -78,6 +163,8 @@ class ChroniclingAmericaSource(ArchiveSource):
         data = response.json()
 
         documents = []
+        # 全文取得対象の (index, url) ペア
+        fulltext_targets: list[tuple[int, str]] = []
         results = data.get("results", [])
 
         for item in results:
@@ -130,6 +217,17 @@ class ChroniclingAmericaSource(ArchiveSource):
                 ),
             )
             documents.append(doc)
+
+            # 全文取得候補に追加（上位5件まで）
+            if url and len(fulltext_targets) < _MAX_FULLTEXT_FETCHES:
+                fulltext_targets.append((len(documents) - 1, url))
+
+        # 全文テキストエンリッチメント（ベストエフォート）
+        for idx, item_url in fulltext_targets:
+            self._rate_limit()
+            text = _fetch_item_fulltext(self._session, item_url)
+            if text:
+                documents[idx].raw_text = text
 
         pagination = data.get("pagination", {})
         total_hits = pagination.get("total", pagination.get("of", 0))

--- a/mystery_agents/tools/delpher.py
+++ b/mystery_agents/tools/delpher.py
@@ -2,10 +2,13 @@
 
 SRU v1.2 プロトコルでオランダ語の歴史的新聞・書籍（1618年〜）を検索する。
 認証不要（API キー不要）。レスポンスは Dublin Core XML。
+resolver URL + :ocr サフィックスによる OCR 全文テキスト取得にも対応。
 """
 
 import logging
 import xml.etree.ElementTree as ET
+
+import requests
 
 from ..schemas.document import ArchiveDocument, SourceLanguage
 from .archive_source_base import ArchiveSearchResult, ArchiveSource
@@ -15,6 +18,42 @@ from .source_registry import register_source
 logger = logging.getLogger(__name__)
 
 BASE_URL = "https://jsru.kb.nl/sru/sru"
+
+# 全文取得の上限設定
+_MAX_FULLTEXT_FETCHES = 5
+_FULLTEXT_TIMEOUT = 15
+_MAX_TEXT_LENGTH = 5000
+
+
+def _fetch_ocr_text(
+    session: requests.Session, resolver_url: str
+) -> str | None:
+    """Delpher resolver URL から OCR テキストを取得する。
+
+    resolver URL に :ocr サフィックスを付けてリクエストする。
+
+    Args:
+        session: HTTP セッション
+        resolver_url: Delpher resolver URL（例: http://resolver.kb.nl/resolve?urn=...）
+
+    Returns:
+        OCR テキスト（最大5000文字）。取得失敗時は None。
+    """
+    try:
+        ocr_url = f"{resolver_url.rstrip('/')}:ocr"
+        resp = session.get(
+            ocr_url,
+            timeout=_FULLTEXT_TIMEOUT,
+            headers={"User-Agent": "GhostInTheArchive/1.0"},
+        )
+        if resp.status_code != 200:
+            logger.debug("Delpher OCR %d for %s", resp.status_code, resolver_url)
+            return None
+        text = resp.text.strip()
+        return text[:_MAX_TEXT_LENGTH] if text else None
+    except (requests.RequestException, ValueError) as e:
+        logger.debug("Delpher OCR 取得失敗 (%s): %s", resolver_url, e)
+        return None
 
 # SRU / Dublin Core 名前空間
 NS = {
@@ -104,7 +143,7 @@ def _parse_sru_response(
             language=SourceLanguage.NL,
             location=str(location)[:200],
             source_type="delpher",
-            raw_text=str(description)[:5000] if description else None,
+            raw_text=None,
             keywords_matched=matched,
         )
         documents.append(doc)
@@ -166,7 +205,25 @@ class DelpherSource(ArchiveSource):
         )
         response.raise_for_status()
 
-        return _parse_sru_response(response.text, keywords)
+        result = _parse_sru_response(response.text, keywords)
+        if result.error or not result.documents:
+            return result
+
+        # 全文テキストエンリッチメント（resolver URL + :ocr）
+        fulltext_targets: list[tuple[int, str]] = []
+        for idx, doc in enumerate(result.documents):
+            if doc.source_url and len(fulltext_targets) < _MAX_FULLTEXT_FETCHES:
+                fulltext_targets.append((idx, doc.source_url))
+
+        for idx, url in fulltext_targets:
+            self._rate_limit()
+            text = _fetch_ocr_text(self._session, url)
+            if text:
+                result.documents[idx].raw_text = text
+
+        # 全文取得成功したドキュメントのみ保持
+        filtered = [doc for doc in result.documents if doc.raw_text]
+        return ArchiveSearchResult(documents=filtered, total_hits=result.total_hits)
 
 
 # レジストリに自動登録

--- a/mystery_agents/tools/europeana.py
+++ b/mystery_agents/tools/europeana.py
@@ -2,18 +2,121 @@
 
 Europeana の集約コレクション（6,000+ の欧州文化遺産機関）を検索する。
 wskey クエリパラメータ認証を使用。
+Fulltext API v3 による全文テキスト取得にも対応。
 """
 
+import logging
 import os
 from typing import Any
 
+import requests
 
 from ..schemas.document import ArchiveDocument
 from .archive_source_base import ArchiveSearchResult, ArchiveSource
 from .search_utils import build_search_query
 from .source_registry import register_source
 
+logger = logging.getLogger(__name__)
+
 BASE_URL = "https://api.europeana.eu/record/v2/search.json"
+_FULLTEXT_URL = "https://api.europeana.eu/fulltext/v3/{dataset_id}/{local_id}"
+
+# 全文取得の上限設定
+_MAX_FULLTEXT_FETCHES = 5
+_FULLTEXT_TIMEOUT = 15
+_MAX_TEXT_LENGTH = 5000
+
+
+def _extract_record_ids(europeana_id: str) -> tuple[str | None, str | None]:
+    """Europeana item ID からデータセット ID とローカル ID を抽出する。
+
+    ID 形式: /{datasetId}/{localId}
+    例: /2020601/https___1702_uva_nl_object_dcp_id_...
+
+    Args:
+        europeana_id: Europeana アイテム ID
+
+    Returns:
+        (dataset_id, local_id) のタプル。パース失敗時は (None, None)。
+    """
+    if not europeana_id or not europeana_id.startswith("/"):
+        return None, None
+    parts = europeana_id.lstrip("/").split("/", 1)
+    if len(parts) != 2:
+        return None, None
+    return parts[0], parts[1]
+
+
+def _parse_annotation_text(data: dict) -> str | None:
+    """IIIF Annotation JSON からテキストを抽出する。
+
+    Europeana Fulltext API v3 は IIIF Annotation 形式で返す。
+    AnnotationPage 直接のアイテムとネストされた AnnotationPage の
+    両方に対応する。
+
+    Args:
+        data: IIIF Annotation JSON レスポンス
+
+    Returns:
+        抽出テキスト（最大5000文字）。テキストがない場合は None。
+    """
+    texts: list[str] = []
+    for item in data.get("items", []):
+        body = item.get("body", {})
+        if isinstance(body, dict):
+            value = body.get("value", "")
+            if value:
+                texts.append(value)
+        # ネストされた AnnotationPage
+        for nested in item.get("items", []):
+            body = nested.get("body", {})
+            if isinstance(body, dict):
+                value = body.get("value", "")
+                if value:
+                    texts.append(value)
+    if not texts:
+        return None
+    return "\n".join(texts)[:_MAX_TEXT_LENGTH]
+
+
+def _fetch_fulltext(
+    session: requests.Session,
+    dataset_id: str,
+    local_id: str,
+    api_key: str,
+) -> str | None:
+    """Europeana Fulltext API v3 から全文テキストを取得する。
+
+    Args:
+        session: HTTP セッション
+        dataset_id: Europeana データセット ID
+        local_id: Europeana ローカル ID
+        api_key: Europeana API キー
+
+    Returns:
+        全文テキスト（最大5000文字）。取得失敗時は None。
+    """
+    try:
+        url = _FULLTEXT_URL.format(dataset_id=dataset_id, local_id=local_id)
+        params: dict[str, str] = {}
+        if api_key:
+            params["wskey"] = api_key
+        resp = session.get(
+            url,
+            timeout=_FULLTEXT_TIMEOUT,
+            params=params,
+            headers={
+                "Accept": "application/ld+json",
+                "User-Agent": "GhostInTheArchive/1.0",
+            },
+        )
+        if resp.status_code != 200:
+            logger.debug("Europeana fulltext %d for %s/%s", resp.status_code, dataset_id, local_id)
+            return None
+        return _parse_annotation_text(resp.json())
+    except (requests.RequestException, ValueError, KeyError) as e:
+        logger.debug("Europeana fulltext 取得失敗 (%s/%s): %s", dataset_id, local_id, e)
+        return None
 
 # 言語コード → Europeana COUNTRY フィルタ値マッピング
 # LANGUAGE フィルタではなく COUNTRY フィルタを使用する理由:
@@ -91,6 +194,8 @@ class EuropeanaSource(ArchiveSource):
         data = response.json()
 
         documents = []
+        # 全文取得対象の (index, europeana_id) ペア
+        fulltext_targets: list[tuple[int, str]] = []
         items = data.get("items", [])
 
         for item in items:
@@ -150,12 +255,29 @@ class EuropeanaSource(ArchiveSource):
                 language=lang,
                 location=str(location)[:200],
                 source_type=self.source_type,
-                raw_text=str(description)[:5000] if description else None,
+                raw_text=None,
                 thumbnail_url=thumbnail,
                 image_url=full_image,
                 keywords_matched=matched,
             )
             documents.append(doc)
+
+            # 全文取得候補に追加（上位5件まで）
+            europeana_id = item.get("id", "")
+            if europeana_id and len(fulltext_targets) < _MAX_FULLTEXT_FETCHES:
+                fulltext_targets.append((len(documents) - 1, europeana_id))
+
+        # 全文テキストエンリッチメント
+        for idx, eid in fulltext_targets:
+            self._rate_limit()
+            ds_id, loc_id = _extract_record_ids(eid)
+            if ds_id and loc_id:
+                text = _fetch_fulltext(self._session, ds_id, loc_id, api_key)
+                if text:
+                    documents[idx].raw_text = text
+
+        # 全文取得成功したドキュメントのみ保持
+        documents = [doc for doc in documents if doc.raw_text]
 
         total_hits = data.get("totalResults", len(documents))
         return ArchiveSearchResult(documents=documents, total_hits=total_hits)

--- a/mystery_agents/tools/internet_archive.py
+++ b/mystery_agents/tools/internet_archive.py
@@ -2,16 +2,56 @@
 
 Internet Archive の膨大なコレクション（書籍、雑誌、ウェブページ、
 その他のデジタル化資料）を検索する。
+djvu.txt エンドポイントによる OCR 全文テキスト取得にも対応。
 """
 
+import logging
 
+import requests
 
 from ..schemas.document import ArchiveDocument
 from .archive_source_base import ArchiveSearchResult, ArchiveSource
 from .search_utils import build_search_query
 from .source_registry import register_source
 
+logger = logging.getLogger(__name__)
+
 BASE_URL = "https://archive.org/advancedsearch.php"
+_DJVU_TEXT_URL = "https://archive.org/download/{identifier}/{identifier}_djvu.txt"
+
+# 全文取得の上限設定
+_MAX_FULLTEXT_FETCHES = 5
+_FULLTEXT_TIMEOUT = 15
+_MAX_TEXT_LENGTH = 5000
+
+
+def _fetch_djvu_text(
+    session: requests.Session, identifier: str
+) -> str | None:
+    """Internet Archive の djvu.txt から OCR テキストを取得する。
+
+    Args:
+        session: HTTP セッション
+        identifier: Internet Archive アイテム識別子
+
+    Returns:
+        OCR テキスト（最大5000文字）。取得失敗時は None。
+    """
+    try:
+        url = _DJVU_TEXT_URL.format(identifier=identifier)
+        resp = session.get(
+            url,
+            timeout=_FULLTEXT_TIMEOUT,
+            headers={"User-Agent": "GhostInTheArchive/1.0"},
+        )
+        if resp.status_code != 200:
+            logger.debug("IA djvu.txt %d for %s", resp.status_code, identifier)
+            return None
+        text = resp.text.strip()
+        return text[:_MAX_TEXT_LENGTH] if text else None
+    except (requests.RequestException, ValueError) as e:
+        logger.debug("IA djvu.txt 取得失敗 (%s): %s", identifier, e)
+        return None
 
 _LANG_CODE_MAP = {
     "en": ["eng", "english"],
@@ -90,6 +130,8 @@ class InternetArchiveSource(ArchiveSource):
 
         resp = data.get("response", {})
         documents = []
+        # 全文取得対象の (index, identifier) ペア
+        fulltext_targets: list[tuple[int, str]] = []
 
         for item in resp.get("docs", []):
             title = item.get("title", "Unknown Title")
@@ -130,11 +172,25 @@ class InternetArchiveSource(ArchiveSource):
                 language=lang,
                 location="Unknown",
                 source_type=self.source_type,
-                raw_text=str(description)[:5000] if description else None,
+                raw_text=None,
                 thumbnail_url=thumbnail_url,
                 keywords_matched=matched,
             )
             documents.append(doc)
+
+            # 全文取得候補に追加（上位5件まで）
+            if identifier and len(fulltext_targets) < _MAX_FULLTEXT_FETCHES:
+                fulltext_targets.append((len(documents) - 1, identifier))
+
+        # 全文テキストエンリッチメント
+        for idx, ident in fulltext_targets:
+            self._rate_limit()
+            text = _fetch_djvu_text(self._session, ident)
+            if text:
+                documents[idx].raw_text = text
+
+        # 全文取得成功したドキュメントのみ保持
+        documents = [doc for doc in documents if doc.raw_text]
 
         total_hits = resp.get("numFound", 0)
         return ArchiveSearchResult(documents=documents, total_hits=total_hits)

--- a/mystery_agents/tools/source_registry.py
+++ b/mystery_agents/tools/source_registry.py
@@ -23,7 +23,7 @@ _registry: dict[str, ArchiveSource] = {}
 _all_loaded = False
 
 # 登録対象の API ツールモジュール（パッケージ内の相対パス）
-# Delpher は公開言語削減（PR #328）、DPLA は API 停止に伴い除外
+# DPLA は API 停止に伴い除外
 # LOC Digital / DDB / Wellcome はメタデータのみ API のため削除（#409 PR1）
 _SOURCE_MODULES = [
     "mystery_agents.tools.nypl_digital",
@@ -32,6 +32,7 @@ _SOURCE_MODULES = [
     "mystery_agents.tools.chronicling_america",
     "mystery_agents.tools.trove",
     "mystery_agents.tools.ndl_search",
+    "mystery_agents.tools.delpher",
 ]
 
 

--- a/tests/unit/test_api_librarians.py
+++ b/tests/unit/test_api_librarians.py
@@ -46,7 +46,7 @@ class TestAPILibrarianFactory:
         """US 以外の Librarian は search_newspapers を持たない。"""
         from mystery_agents.tools.librarian_tools import search_newspapers
 
-        for api_key in ["europeana", "internet_archive", "ndl", "trove"]:
+        for api_key in ["europeana", "internet_archive", "ndl", "trove", "delpher"]:
             agent = create_api_librarian(api_key)
             assert search_newspapers not in agent.tools
 

--- a/tests/unit/test_chronicling_america.py
+++ b/tests/unit/test_chronicling_america.py
@@ -1,0 +1,170 @@
+"""Unit tests for mystery_agents/tools/chronicling_america.py fulltext retrieval."""
+
+import responses
+
+from mystery_agents.tools.chronicling_america import (
+    _fetch_item_fulltext,
+    _fetch_page_fulltext,
+)
+from shared.http_retry import create_retry_session
+
+
+class TestFetchPageFulltext:
+    """_fetch_page_fulltext のテスト。"""
+
+    @responses.activate
+    def test_returns_fulltext(self):
+        """full_text フィールドがある場合にテキストを返す。"""
+        page_url = "https://www.loc.gov/resource/sn83030214/1893-01-15/ed-1/?sp=1"
+        responses.add(
+            responses.GET,
+            "https://www.loc.gov/resource/sn83030214/1893-01-15/ed-1/?sp=1&fo=json",
+            json={"full_text": "The quick brown fox jumped over the lazy dog."},
+            status=200,
+        )
+
+        session = create_retry_session()
+        result = _fetch_page_fulltext(session, page_url)
+
+        assert result == "The quick brown fox jumped over the lazy dog."
+
+    @responses.activate
+    def test_returns_none_on_404(self):
+        """404 の場合は None を返す。"""
+        page_url = "https://www.loc.gov/resource/missing"
+        responses.add(
+            responses.GET,
+            "https://www.loc.gov/resource/missing?fo=json",
+            status=404,
+        )
+
+        session = create_retry_session()
+        result = _fetch_page_fulltext(session, page_url)
+
+        assert result is None
+
+    @responses.activate
+    def test_returns_none_on_empty_fulltext(self):
+        """full_text が空の場合は None を返す。"""
+        page_url = "https://www.loc.gov/resource/test"
+        responses.add(
+            responses.GET,
+            "https://www.loc.gov/resource/test?fo=json",
+            json={"full_text": ""},
+            status=200,
+        )
+
+        session = create_retry_session()
+        result = _fetch_page_fulltext(session, page_url)
+
+        assert result is None
+
+    @responses.activate
+    def test_truncates_long_text(self):
+        """5000文字を超えるテキストは切り詰める。"""
+        page_url = "https://www.loc.gov/resource/test"
+        long_text = "A" * 6000
+        responses.add(
+            responses.GET,
+            "https://www.loc.gov/resource/test?fo=json",
+            json={"full_text": long_text},
+            status=200,
+        )
+
+        session = create_retry_session()
+        result = _fetch_page_fulltext(session, page_url)
+
+        assert len(result) == 5000
+
+
+class TestFetchItemFulltext:
+    """_fetch_item_fulltext のテスト。"""
+
+    @responses.activate
+    def test_direct_fulltext(self):
+        """アイテム JSON に直接 full_text がある場合。"""
+        item_url = "https://www.loc.gov/item/sn83030214/"
+        responses.add(
+            responses.GET,
+            "https://www.loc.gov/item/sn83030214/?fo=json",
+            json={"full_text": "Direct OCR text from item."},
+            status=200,
+        )
+
+        session = create_retry_session()
+        result = _fetch_item_fulltext(session, item_url)
+
+        assert result == "Direct OCR text from item."
+
+    @responses.activate
+    def test_fallback_to_resource_page(self):
+        """full_text がなく resources からページを辿る場合。"""
+        item_url = "https://www.loc.gov/item/sn83030214/"
+        responses.add(
+            responses.GET,
+            "https://www.loc.gov/item/sn83030214/?fo=json",
+            json={
+                "resources": [
+                    {"url": "https://www.loc.gov/resource/sn83030214/page1"}
+                ]
+            },
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            "https://www.loc.gov/resource/sn83030214/page1?fo=json",
+            json={"full_text": "Page OCR text from resource."},
+            status=200,
+        )
+
+        session = create_retry_session()
+        result = _fetch_item_fulltext(session, item_url)
+
+        assert result == "Page OCR text from resource."
+
+    @responses.activate
+    def test_returns_none_on_404(self):
+        """アイテム URL が 404 の場合は None を返す。"""
+        item_url = "https://www.loc.gov/item/missing/"
+        responses.add(
+            responses.GET,
+            "https://www.loc.gov/item/missing/?fo=json",
+            status=404,
+        )
+
+        session = create_retry_session()
+        result = _fetch_item_fulltext(session, item_url)
+
+        assert result is None
+
+    @responses.activate
+    def test_returns_none_when_no_fulltext_or_resources(self):
+        """full_text も resources もない場合は None を返す。"""
+        item_url = "https://www.loc.gov/item/empty/"
+        responses.add(
+            responses.GET,
+            "https://www.loc.gov/item/empty/?fo=json",
+            json={"title": "Some item without text"},
+            status=200,
+        )
+
+        session = create_retry_session()
+        result = _fetch_item_fulltext(session, item_url)
+
+        assert result is None
+
+    @responses.activate
+    def test_handles_url_with_query_params(self):
+        """既にクエリパラメータを含む URL を正しく処理する。"""
+        item_url = "https://www.loc.gov/resource/sn83030214/1893-01-15/ed-1/?sp=1"
+        responses.add(
+            responses.GET,
+            "https://www.loc.gov/resource/sn83030214/1893-01-15/ed-1/?sp=1&fo=json",
+            json={"full_text": "Text with query params."},
+            status=200,
+        )
+
+        session = create_retry_session()
+        result = _fetch_item_fulltext(session, item_url)
+
+        assert result == "Text with query params."

--- a/tests/unit/test_delpher.py
+++ b/tests/unit/test_delpher.py
@@ -6,8 +6,10 @@ from mystery_agents.schemas.document import SourceLanguage
 from mystery_agents.tools.delpher import (
     BASE_URL,
     DelpherSource,
+    _fetch_ocr_text,
     _parse_sru_response,
 )
+from shared.http_retry import create_retry_session
 
 # モック SRU XML レスポンス
 MOCK_SRU_RESPONSE = """\
@@ -76,6 +78,19 @@ class TestDelpherSource:
             content_type="application/xml",
             status=200,
         )
+        # OCR 全文取得モック
+        responses.add(
+            responses.GET,
+            "http://resolver.kb.nl/resolve?urn=ddd:010097857:mpeg21:a0001:ocr",
+            body="OCR text van het spookhuis.",
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            "http://resolver.kb.nl/resolve?urn=ddd:010054321:mpeg21:a0002:ocr",
+            body="OCR text van de Vliegende Hollander.",
+            status=200,
+        )
 
         source = DelpherSource()
         result = source.search(keywords=["spookhuis", "Amsterdam"])
@@ -92,6 +107,7 @@ class TestDelpherSource:
         assert doc.date == "1842-01-01"
         assert doc.location == "De Tijd"
         assert doc.summary == "Een mysterieus verhaal over het spookhuis"
+        assert doc.raw_text == "OCR text van het spookhuis."
 
         # 2件目: publisher がない場合 source フィールドを location に使用
         doc2 = result.documents[1]
@@ -253,3 +269,105 @@ class TestDelpherDateFilter:
 
         request = responses.calls[0].request
         assert "dc.date" not in request.url
+
+
+class TestFetchOcrText:
+    """_fetch_ocr_text のテスト。"""
+
+    @responses.activate
+    def test_returns_text(self):
+        """OCR テキストが取得できる場合にテキストを返す。"""
+        resolver_url = "http://resolver.kb.nl/resolve?urn=ddd:010097857:mpeg21:a0001"
+        responses.add(
+            responses.GET,
+            f"{resolver_url}:ocr",
+            body="Dit is de OCR tekst.",
+            status=200,
+        )
+
+        session = create_retry_session()
+        result = _fetch_ocr_text(session, resolver_url)
+
+        assert result == "Dit is de OCR tekst."
+
+    @responses.activate
+    def test_returns_none_on_404(self):
+        """404 の場合は None を返す。"""
+        resolver_url = "http://resolver.kb.nl/resolve?urn=ddd:missing"
+        responses.add(
+            responses.GET,
+            f"{resolver_url}:ocr",
+            status=404,
+        )
+
+        session = create_retry_session()
+        result = _fetch_ocr_text(session, resolver_url)
+
+        assert result is None
+
+    @responses.activate
+    def test_truncates_long_text(self):
+        """5000文字を超えるテキストは切り詰める。"""
+        resolver_url = "http://resolver.kb.nl/resolve?urn=ddd:long"
+        responses.add(
+            responses.GET,
+            f"{resolver_url}:ocr",
+            body="X" * 6000,
+            status=200,
+        )
+
+        session = create_retry_session()
+        result = _fetch_ocr_text(session, resolver_url)
+
+        assert len(result) == 5000
+
+    @responses.activate
+    def test_returns_none_on_empty_text(self):
+        """空のレスポンスは None を返す。"""
+        resolver_url = "http://resolver.kb.nl/resolve?urn=ddd:empty"
+        responses.add(
+            responses.GET,
+            f"{resolver_url}:ocr",
+            body="   ",
+            status=200,
+        )
+
+        session = create_retry_session()
+        result = _fetch_ocr_text(session, resolver_url)
+
+        assert result is None
+
+
+class TestDelpherFulltextFilter:
+    """Delpher 全文フィルタリングテスト。"""
+
+    @responses.activate
+    def test_filters_docs_without_ocr(self):
+        """OCR 取得に失敗したドキュメントは除外される。"""
+        responses.add(
+            responses.GET,
+            BASE_URL,
+            body=MOCK_SRU_RESPONSE,
+            content_type="application/xml",
+            status=200,
+        )
+        # 1件目: OCR あり
+        responses.add(
+            responses.GET,
+            "http://resolver.kb.nl/resolve?urn=ddd:010097857:mpeg21:a0001:ocr",
+            body="OCR tekst beschikbaar.",
+            status=200,
+        )
+        # 2件目: OCR 404
+        responses.add(
+            responses.GET,
+            "http://resolver.kb.nl/resolve?urn=ddd:010054321:mpeg21:a0002:ocr",
+            status=404,
+        )
+
+        source = DelpherSource()
+        result = source.search(keywords=["spookhuis"])
+
+        assert len(result.documents) == 1
+        assert result.documents[0].title == "Het spookhuis te Amsterdam"
+        assert result.documents[0].raw_text == "OCR tekst beschikbaar."

--- a/tests/unit/test_europeana.py
+++ b/tests/unit/test_europeana.py
@@ -7,10 +7,15 @@ import responses
 from mystery_agents.tools.europeana import (
     BASE_URL,
     EuropeanaSource,
+    _FULLTEXT_URL,
     _detect_language,
     _extract_location,
+    _extract_record_ids,
+    _fetch_fulltext,
+    _parse_annotation_text,
 )
 from mystery_agents.tools.archive_source_base import ArchiveSource
+from shared.http_retry import create_retry_session
 
 
 class TestSearchEuropeana:
@@ -42,6 +47,7 @@ class TestSearchEuropeana:
                     "title": ["Medieval Manuscript from Paris"],
                     "year": ["1450"],
                     "guid": "https://www.europeana.eu/item/123/abc",
+                    "id": "/123/abc",
                     "dcDescription": ["A rare medieval manuscript found in Paris archives"],
                     "language": ["fr"],
                     "country": ["France"],
@@ -49,6 +55,13 @@ class TestSearchEuropeana:
             ],
         }
         responses.add(responses.GET, BASE_URL, json=mock_response, status=200)
+        # 全文取得モック
+        responses.add(
+            responses.GET,
+            _FULLTEXT_URL.format(dataset_id="123", local_id="abc"),
+            json={"items": [{"body": {"value": "Full OCR text of the manuscript."}}]},
+            status=200,
+        )
 
         source = EuropeanaSource()
         with patch.dict("os.environ", {"EUROPEANA_API_KEY": "test_key"}):
@@ -61,6 +74,7 @@ class TestSearchEuropeana:
         assert doc.language == "fr"
         assert doc.source_type == "europeana"
         assert "europeana.eu" in doc.source_url
+        assert doc.raw_text == "Full OCR text of the manuscript."
 
     @responses.activate
     def test_country_filter(self):
@@ -179,6 +193,7 @@ class TestSearchEuropeana:
             "items": [
                 {
                     "title": ["Test Document"],
+                    "id": "/456/test_doc",
                     "edmIsShownAt": ["https://example.europeana.eu/item/456"],
                     "language": ["en"],
                     "country": ["United Kingdom"],
@@ -186,6 +201,13 @@ class TestSearchEuropeana:
             ],
         }
         responses.add(responses.GET, BASE_URL, json=mock_response, status=200)
+        # 全文取得モック
+        responses.add(
+            responses.GET,
+            _FULLTEXT_URL.format(dataset_id="456", local_id="test_doc"),
+            json={"items": [{"body": {"value": "Fulltext via edmIsShownAt."}}]},
+            status=200,
+        )
 
         source = EuropeanaSource()
         with patch.dict("os.environ", {"EUROPEANA_API_KEY": "test_key"}):
@@ -278,3 +300,194 @@ class TestParseYear:
 
     def test_parse_full_date(self):
         assert ArchiveSource.parse_year("1850-03-15") == "1850-01-01"
+
+
+class TestExtractRecordIds:
+    """_extract_record_ids のテスト。"""
+
+    def test_valid_id(self):
+        """正常な Europeana ID を datasetId / localId に分解する。"""
+        ds, loc = _extract_record_ids("/2020601/abc_def")
+        assert ds == "2020601"
+        assert loc == "abc_def"
+
+    def test_empty_string(self):
+        """空文字列は (None, None) を返す。"""
+        assert _extract_record_ids("") == (None, None)
+
+    def test_no_leading_slash(self):
+        """先頭 / がない場合は (None, None) を返す。"""
+        assert _extract_record_ids("2020601/abc") == (None, None)
+
+    def test_single_segment(self):
+        """スラッシュが1つだけで localId がない場合は (None, None) を返す。"""
+        assert _extract_record_ids("/2020601") == (None, None)
+
+    def test_complex_local_id(self):
+        """localId にスラッシュを含む場合でも正しく分解する。"""
+        ds, loc = _extract_record_ids("/123/https___example.com_path")
+        assert ds == "123"
+        assert loc == "https___example.com_path"
+
+
+class TestParseAnnotationText:
+    """_parse_annotation_text のテスト。"""
+
+    def test_flat_items(self):
+        """フラットな items からテキストを抽出する。"""
+        data = {"items": [{"body": {"value": "First page text."}}]}
+        assert _parse_annotation_text(data) == "First page text."
+
+    def test_nested_items(self):
+        """ネストされた AnnotationPage からテキストを抽出する。"""
+        data = {
+            "items": [
+                {"items": [{"body": {"value": "Nested page text."}}]}
+            ]
+        }
+        assert _parse_annotation_text(data) == "Nested page text."
+
+    def test_multiple_items_joined(self):
+        """複数のテキストが改行で結合される。"""
+        data = {
+            "items": [
+                {"body": {"value": "Line one."}},
+                {"body": {"value": "Line two."}},
+            ]
+        }
+        result = _parse_annotation_text(data)
+        assert "Line one." in result
+        assert "Line two." in result
+        assert "\n" in result
+
+    def test_empty_items(self):
+        """items が空の場合は None を返す。"""
+        assert _parse_annotation_text({"items": []}) is None
+
+    def test_no_items_key(self):
+        """items キーがない場合は None を返す。"""
+        assert _parse_annotation_text({}) is None
+
+    def test_truncates_long_text(self):
+        """5000文字を超えるテキストは切り詰める。"""
+        data = {"items": [{"body": {"value": "A" * 6000}}]}
+        result = _parse_annotation_text(data)
+        assert len(result) == 5000
+
+
+class TestFetchFulltext:
+    """_fetch_fulltext のテスト。"""
+
+    @responses.activate
+    def test_returns_text(self):
+        """正常なレスポンスでテキストを返す。"""
+        responses.add(
+            responses.GET,
+            _FULLTEXT_URL.format(dataset_id="123", local_id="abc"),
+            json={"items": [{"body": {"value": "Annotation text."}}]},
+            status=200,
+        )
+
+        session = create_retry_session()
+        result = _fetch_fulltext(session, "123", "abc", "test_key")
+
+        assert result == "Annotation text."
+
+    @responses.activate
+    def test_returns_none_on_404(self):
+        """404 の場合は None を返す。"""
+        responses.add(
+            responses.GET,
+            _FULLTEXT_URL.format(dataset_id="123", local_id="missing"),
+            status=404,
+        )
+
+        session = create_retry_session()
+        result = _fetch_fulltext(session, "123", "missing", "test_key")
+
+        assert result is None
+
+    @responses.activate
+    def test_returns_none_on_empty_annotation(self):
+        """空の Annotation は None を返す。"""
+        responses.add(
+            responses.GET,
+            _FULLTEXT_URL.format(dataset_id="123", local_id="empty"),
+            json={"items": []},
+            status=200,
+        )
+
+        session = create_retry_session()
+        result = _fetch_fulltext(session, "123", "empty", "test_key")
+
+        assert result is None
+
+
+class TestEuropeanaFulltextFilter:
+    """Europeana 全文フィルタリングテスト。"""
+
+    @responses.activate
+    def test_filters_docs_without_fulltext(self):
+        """全文取得に失敗したドキュメントは除外される。"""
+        mock_response = {
+            "success": True,
+            "totalResults": 2,
+            "items": [
+                {
+                    "title": ["Has Fulltext"],
+                    "guid": "https://www.europeana.eu/item/has/text",
+                    "id": "/has/text",
+                    "language": ["en"],
+                },
+                {
+                    "title": ["No Fulltext"],
+                    "guid": "https://www.europeana.eu/item/no/text",
+                    "id": "/no/text",
+                    "language": ["en"],
+                },
+            ],
+        }
+        responses.add(responses.GET, BASE_URL, json=mock_response, status=200)
+        # 1件目: 全文あり
+        responses.add(
+            responses.GET,
+            _FULLTEXT_URL.format(dataset_id="has", local_id="text"),
+            json={"items": [{"body": {"value": "Fulltext here."}}]},
+            status=200,
+        )
+        # 2件目: 404
+        responses.add(
+            responses.GET,
+            _FULLTEXT_URL.format(dataset_id="no", local_id="text"),
+            status=404,
+        )
+
+        source = EuropeanaSource()
+        with patch.dict("os.environ", {"EUROPEANA_API_KEY": "test_key"}):
+            result = source.search(keywords=["test"])
+
+        assert len(result.documents) == 1
+        assert result.documents[0].title == "Has Fulltext"
+        assert result.documents[0].raw_text == "Fulltext here."
+
+    @responses.activate
+    def test_no_id_field_means_no_fulltext(self):
+        """id フィールドがないアイテムは全文取得対象外 → 除外される。"""
+        mock_response = {
+            "success": True,
+            "totalResults": 1,
+            "items": [
+                {
+                    "title": ["No ID"],
+                    "guid": "https://www.europeana.eu/item/test",
+                    "language": ["en"],
+                }
+            ],
+        }
+        responses.add(responses.GET, BASE_URL, json=mock_response, status=200)
+
+        source = EuropeanaSource()
+        with patch.dict("os.environ", {"EUROPEANA_API_KEY": "test_key"}):
+            result = source.search(keywords=["test"])
+
+        assert len(result.documents) == 0

--- a/tests/unit/test_internet_archive.py
+++ b/tests/unit/test_internet_archive.py
@@ -1,0 +1,151 @@
+"""Unit tests for mystery_agents/tools/internet_archive.py fulltext retrieval."""
+
+from unittest.mock import patch
+
+import responses
+
+from mystery_agents.tools.internet_archive import (
+    BASE_URL,
+    InternetArchiveSource,
+    _DJVU_TEXT_URL,
+    _fetch_djvu_text,
+)
+from shared.http_retry import create_retry_session
+
+
+class TestFetchDjvuText:
+    """_fetch_djvu_text のテスト。"""
+
+    @responses.activate
+    def test_returns_text(self):
+        """djvu.txt が取得できる場合にテキストを返す。"""
+        identifier = "test_book_1893"
+        url = _DJVU_TEXT_URL.format(identifier=identifier)
+        responses.add(responses.GET, url, body="Full text of the book.", status=200)
+
+        session = create_retry_session()
+        result = _fetch_djvu_text(session, identifier)
+
+        assert result == "Full text of the book."
+
+    @responses.activate
+    def test_returns_none_on_404(self):
+        """djvu.txt が存在しない場合（404）は None を返す。"""
+        identifier = "no_text_item"
+        url = _DJVU_TEXT_URL.format(identifier=identifier)
+        responses.add(responses.GET, url, status=404)
+
+        session = create_retry_session()
+        result = _fetch_djvu_text(session, identifier)
+
+        assert result is None
+
+    @responses.activate
+    def test_truncates_long_text(self):
+        """5000文字を超えるテキストは切り詰める。"""
+        identifier = "long_book"
+        url = _DJVU_TEXT_URL.format(identifier=identifier)
+        responses.add(responses.GET, url, body="B" * 6000, status=200)
+
+        session = create_retry_session()
+        result = _fetch_djvu_text(session, identifier)
+
+        assert len(result) == 5000
+
+    @responses.activate
+    def test_returns_none_on_empty_text(self):
+        """空のレスポンスは None を返す。"""
+        identifier = "empty_book"
+        url = _DJVU_TEXT_URL.format(identifier=identifier)
+        responses.add(responses.GET, url, body="   ", status=200)
+
+        session = create_retry_session()
+        result = _fetch_djvu_text(session, identifier)
+
+        assert result is None
+
+
+class TestInternetArchiveFulltextFilter:
+    """Internet Archive 検索の全文フィルタリングテスト。"""
+
+    @responses.activate
+    def test_filters_docs_without_fulltext(self):
+        """djvu.txt 取得に失敗したドキュメントは除外される。"""
+        # 検索 API モック（2件返す）
+        responses.add(
+            responses.GET,
+            BASE_URL,
+            json={
+                "response": {
+                    "numFound": 2,
+                    "docs": [
+                        {
+                            "identifier": "has_text",
+                            "title": "Book With Text",
+                            "description": "desc",
+                            "date": "1893",
+                        },
+                        {
+                            "identifier": "no_text",
+                            "title": "Book Without Text",
+                            "description": "desc",
+                            "date": "1893",
+                        },
+                    ],
+                }
+            },
+            status=200,
+        )
+        # djvu.txt: 1件目は成功、2件目は 404
+        responses.add(
+            responses.GET,
+            _DJVU_TEXT_URL.format(identifier="has_text"),
+            body="OCR text content",
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            _DJVU_TEXT_URL.format(identifier="no_text"),
+            status=404,
+        )
+
+        source = InternetArchiveSource()
+        result = source.search(keywords=["test"], date_start="1800", date_end="1899")
+
+        assert len(result.documents) == 1
+        assert result.documents[0].title == "Book With Text"
+        assert result.documents[0].raw_text == "OCR text content"
+
+    @responses.activate
+    def test_keeps_all_docs_with_fulltext(self):
+        """全ドキュメントの djvu.txt 取得に成功した場合、全件保持される。"""
+        responses.add(
+            responses.GET,
+            BASE_URL,
+            json={
+                "response": {
+                    "numFound": 1,
+                    "docs": [
+                        {
+                            "identifier": "good_book",
+                            "title": "Good Book",
+                            "description": "desc",
+                            "date": "1850",
+                        },
+                    ],
+                }
+            },
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            _DJVU_TEXT_URL.format(identifier="good_book"),
+            body="Full text here",
+            status=200,
+        )
+
+        source = InternetArchiveSource()
+        result = source.search(keywords=["test"], date_start="1800", date_end="1899")
+
+        assert len(result.documents) == 1
+        assert result.documents[0].raw_text == "Full text here"

--- a/tests/unit/test_source_registry.py
+++ b/tests/unit/test_source_registry.py
@@ -164,11 +164,11 @@ class TestEnsureAllLoaded:
         """実際のモジュールがロードされ、ソースが登録される。"""
         all_sources = get_all_sources()
 
-        # 全 API ツールが登録されていること（DDB, LOC Digital, Wellcome, Delpher は除外済み）
+        # 全 API ツールが登録されていること（DDB, LOC Digital, Wellcome は除外済み）
         expected_keys = {
             "nypl", "internet_archive",
             "europeana", "chronicling_america", "trove",
-            "ndl",
+            "ndl", "delpher",
         }
         assert expected_keys.issubset(set(all_sources.keys()))
 


### PR DESCRIPTION
## Summary

4つの API ソース（Chronicling America, Internet Archive, Europeana, Delpher）に全文テキスト取得機能を追加。Scholar/Polymath がメタデータだけでなく一次資料の本文を分析できるようにする。

- **Chronicling America**: LOC JSON API 2段階取得（item URL → resources → page OCR `full_text`）
- **Internet Archive**: `{identifier}_djvu.txt` ダウンロード（404 時はドキュメント除外）
- **Europeana**: Fulltext API v3 + IIIF Annotation パース（失敗時はドキュメント除外）
- **Delpher**: resolver URL + `:ocr` サフィックス（失敗時はドキュメント除外）
- Delpher をソースレジストリに再追加（PR #328 で公開言語削減に伴い除外、OCR 全文取得対応で復活）
- API グループ数: 5 → 6 に更新（Delpher 追加分）

### 全文取得パターン

| ソース | 方式 | 失敗時の挙動 |
|--------|------|-------------|
| Chronicling America | best-effort | ドキュメント保持（raw_text=None） |
| Internet Archive | djvu.txt | ドキュメント除外 |
| Europeana | Fulltext API v3 | ドキュメント除外 |
| Delpher | resolver+:ocr | ドキュメント除外 |

共通定数: `_MAX_FULLTEXT_FETCHES=5`, `_FULLTEXT_TIMEOUT=15`, `_MAX_TEXT_LENGTH=5000`

### 変更ファイル

**ソースコード（8件）**: chronicling_america.py, internet_archive.py, europeana.py, delpher.py, source_registry.py, api_librarians.py, agent.py, CLAUDE.md

**テスト（6件）**: test_chronicling_america.py(新規), test_internet_archive.py(新規), test_europeana.py(拡張), test_delpher.py(拡張), test_source_registry.py, test_api_librarians.py

## Test plan

- [x] `pytest tests/unit/ -v` — 全 1321 テストパス
- [ ] 各 fulltext ヘルパー関数の HTTP モックテスト確認
- [ ] Europeana/IA/Delpher の失敗 doc フィルタ動作確認
- [ ] `test_source_registry.py` — Delpher 含む 7 ソース登録確認
- [ ] `test_api_librarians.py` — Delpher 含む 6 API config 確認

Closes #409 (PR 2/3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)