### PR TITLE
feat: Aggregator excerpt 制限を 500→3000 文字に拡大

### DIFF
--- a/mystery_agents/agents/aggregator.py
+++ b/mystery_agents/agents/aggregator.py
@@ -147,9 +147,9 @@ def _format_documents(lang: str, docs: list[dict]) -> str:
             kw_str = ", ".join(matched) if isinstance(matched, list) else str(matched)
             lines.append(f"- **Keywords matched**: {kw_str}")
         if doc.get("raw_text"):
-            # テキスト抜粋は500文字に制限
-            excerpt = str(doc["raw_text"])[:500]
-            if len(str(doc["raw_text"])) > 500:
+            # テキスト抜粋は3000文字に制限（全文取得対応で拡大）
+            excerpt = str(doc["raw_text"])[:3000]
+            if len(str(doc["raw_text"])) > 3000:
                 excerpt += "..."
             lines.append(f"- **Excerpt**: {excerpt}")
         lines.append("")  # ドキュメント間の空行

--- a/tests/unit/test_aggregator.py
+++ b/tests/unit/test_aggregator.py
@@ -61,8 +61,8 @@ class TestFormatDocuments:
         assert "1 documents" in result
 
     def test_truncates_long_excerpt(self):
-        """raw_text が長い場合 500 文字 + ... に切り詰める。"""
-        long_text = "x" * 1000
+        """raw_text が長い場合 3000 文字 + ... に切り詰める。"""
+        long_text = "x" * 5000
         docs = [
             {
                 "title": "Long Doc",
@@ -75,7 +75,7 @@ class TestFormatDocuments:
         ]
         result = _format_documents("en", docs)
         assert "..." in result
-        assert "x" * 500 in result
+        assert "x" * 3000 in result
 
     def test_language_name_in_header(self):
         """ヘッダーに言語名が含まれる。"""


### PR DESCRIPTION
## Summary

- Aggregator の excerpt 切り詰め制限を 500→3000 文字に緩和
- PR #414 の全文取得対応により `raw_text` に本文が入るようになったため、Scholar/Polymath がより多くのコンテキストを分析に活用できるようにする

## 変更ファイル

| ファイル | 変更 |
|----------|------|
| `mystery_agents/agents/aggregator.py` | `[:500]` → `[:3000]`, `> 500` → `> 3000` |
| `tests/unit/test_aggregator.py` | テストデータ・assertion を 3000 文字に合わせて更新 |

## Test plan

- [x] `pytest tests/unit/test_aggregator.py -v` — 全 10 テストパス

Closes #409 (PR 3/3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)