### PR TITLE
fix: フッターから削除済み API（DDB, DPLA, Wellcome）のリンクを除去

### DIFF
--- a/packages/shared/src/components/footer.tsx
+++ b/packages/shared/src/components/footer.tsx
@@ -18,13 +18,10 @@ const TECH_STACK = [
 const PRIMARY_SOURCES = [
   // 米国
   { label: "Library of Congress", href: "https://www.loc.gov/" },
-  { label: "Digital Public Library of America", href: "https://dp.la/" },
   { label: "NYPL Digital Collections", href: "https://digitalcollections.nypl.org/" },
   // 欧州
   { label: "Europeana", href: "https://www.europeana.eu/" },
-  { label: "Deutsche Digitale Bibliothek", href: "https://www.deutsche-digitale-bibliothek.de/" },
   { label: "Delpher (KB)", href: "https://www.delpher.nl/" },
-  { label: "Wellcome Collection", href: "https://wellcomecollection.org/" },
   // アジア太平洋
   { label: "NDL Search", href: "https://ndlsearch.ndl.go.jp/" },
   { label: "Trove", href: "https://trove.nla.gov.au/", pending: true },


### PR DESCRIPTION
## Summary
- PR #413 で API を削除した Deutsche Digitale Bibliothek・Wellcome Collection と、API 停止済みの Digital Public Library of America をフッターの `PRIMARY_SOURCES` リストから除去
- 実際に使用していないアーカイブを「一次資料提供元」として掲載し続ける不正確さを解消
- 後方互換のため `SourceType` 型定義や `archive-name.ts` のマッピングは変更なし

## Test plan
- [x] `tsc --noEmit` が web-public / web-admin ともにエラーなし
- [ ] フッターに DDB, Wellcome, DPLA が表示されないことを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)