### PR TITLE
fix: About 調査プロセスのステップ1 を hybrid（LLM + PROGRAM）に分類修正

### DIFF
--- a/web-public/src/app/[lang]/about/page.tsx
+++ b/web-public/src/app/[lang]/about/page.tsx
@@ -14,9 +14,9 @@ import { buildOgpMetadata, buildAlternates } from "@/lib/seo"
 const METHODOLOGY_STEPS: {
   key: "search" | "fulltext" | "excerpt" | "analysis" | "debate" | "certification";
   icon: LucideIcon;
-  type: "program" | "llm";
+  type: "program" | "llm" | "hybrid";
 }[] = [
-  { key: "search", icon: Database, type: "program" },
+  { key: "search", icon: Database, type: "hybrid" },
   { key: "fulltext", icon: FileText, type: "program" },
   { key: "excerpt", icon: Scissors, type: "program" },
   { key: "analysis", icon: GraduationCap, type: "llm" },
@@ -153,6 +153,9 @@ export default async function AboutPage({
 
               {/* 凡例バッジ */}
               <div className="flex items-center gap-4 mb-6">
+                <span className="font-mono text-[10px] uppercase tracking-wider text-amber-400 bg-amber-400/10 px-2 py-0.5 rounded">
+                  {dict.about.methodology.hybridLabel}
+                </span>
                 <span className="font-mono text-[10px] uppercase tracking-wider text-emerald-400 bg-emerald-400/10 px-2 py-0.5 rounded">
                   {dict.about.methodology.programLabel}
                 </span>
@@ -164,16 +167,17 @@ export default async function AboutPage({
               {/* ステップカード */}
               <div className="space-y-4">
                 {METHODOLOGY_STEPS.map((step, index) => {
-                  const isProgram = step.type === "program"
-                  const color = isProgram ? "text-emerald-400" : "text-purple-400"
-                  const badgeColor = isProgram
-                    ? "text-emerald-400 bg-emerald-400/10"
+                  const color = step.type === "hybrid" ? "text-amber-400"
+                    : step.type === "program" ? "text-emerald-400" : "text-purple-400"
+                  const badgeColor = step.type === "hybrid" ? "text-amber-400 bg-amber-400/10"
+                    : step.type === "program" ? "text-emerald-400 bg-emerald-400/10"
                     : "text-purple-400 bg-purple-400/10"
-                  const borderColor = isProgram ? "border-emerald-900/30" : "border-purple-900/30"
+                  const borderColor = step.type === "hybrid" ? "border-amber-900/30"
+                    : step.type === "program" ? "border-emerald-900/30" : "border-purple-900/30"
                   const Icon = step.icon
                   const stepDict = dict.about.methodology.steps[step.key]
-                  const label = isProgram
-                    ? dict.about.methodology.programLabel
+                  const label = step.type === "hybrid" ? dict.about.methodology.hybridLabel
+                    : step.type === "program" ? dict.about.methodology.programLabel
                     : dict.about.methodology.llmLabel
 
                   return (

--- a/web-public/src/lib/i18n/dictionaries/de.ts
+++ b/web-public/src/lib/i18n/dictionaries/de.ts
@@ -77,13 +77,14 @@ const dict: Dictionary = {
     methodology: {
       heading: "Wie wir ermitteln",
       intro:
-        "Jede Ermittlung folgt einem sechsstufigen Prozess. Die Schritte 1–3 sind deterministische Programmoperationen — keine KI-Interpretation ist beteiligt. Die Schritte 4–6 verwenden große Sprachmodelle (LLMs) für Analyse, Synthese und Textgenerierung.",
+        "Jede Ermittlung folgt einem sechsstufigen Prozess. Schritt 1 verwendet einen KI-Agenten zur Generierung von Suchbegriffen, die dann programmatisch an die Archiv-APIs gesendet werden. Die Schritte 2–3 sind deterministische Programmoperationen — keine KI-Interpretation ist beteiligt. Die Schritte 4–6 verwenden große Sprachmodelle (LLMs) für Analyse, Synthese und Textgenerierung.",
       programLabel: "PROGRAMM",
       llmLabel: "LLM",
+      hybridLabel: "LLM + PROGRAMM",
       steps: {
         search: {
           title: "API-Suche",
-          description: "Programmatische Anfragen werden an die APIs öffentlicher digitaler Archive gesendet — Trove, NDL Search, NYPL Digital Collections, Chronicling America, Internet Archive und Delpher. Das System ruft Metadaten und Katalogeinträge ab, die zum Ermittlungsthema passen.",
+          description: "Ein KI-Agent analysiert das Ermittlungsthema und generiert Suchbegriffe — sowohl systematische Begriffe für die Reproduzierbarkeit als auch explorative Begriffe für breitere Entdeckungen. Diese Suchbegriffe werden dann programmatisch an die APIs öffentlicher digitaler Archive gesendet — Trove, NDL Search, NYPL Digital Collections, Chronicling America, Internet Archive und Delpher — um Metadaten und Katalogeinträge abzurufen.",
         },
         fulltext: {
           title: "Volltextabruf",

--- a/web-public/src/lib/i18n/dictionaries/en.ts
+++ b/web-public/src/lib/i18n/dictionaries/en.ts
@@ -76,13 +76,14 @@ const dict: Dictionary = {
     methodology: {
       heading: "How We Investigate",
       intro:
-        "Each investigation follows a six-step pipeline. Steps 1–3 are deterministic program operations — no AI interpretation is involved. Steps 4–6 use large language models (LLMs) for analysis, synthesis, and narrative generation.",
+        "Each investigation follows a six-step pipeline. Step 1 uses an AI agent to generate search keywords, which are then sent to archive APIs programmatically. Steps 2–3 are deterministic program operations — no AI interpretation is involved. Steps 4–6 use large language models (LLMs) for analysis, synthesis, and narrative generation.",
       programLabel: "PROGRAM",
       llmLabel: "LLM",
+      hybridLabel: "LLM + PROGRAM",
       steps: {
         search: {
           title: "API Search",
-          description: "Programmatic queries are sent to public digital archive APIs — Trove, NDL Search, NYPL Digital Collections, Chronicling America, Internet Archive, and Delpher. The system retrieves metadata and catalog records matching the investigation theme.",
+          description: "An AI agent analyzes the investigation theme and generates search keywords — both systematic terms for reproducibility and exploratory terms for broader discovery. These keywords are then sent programmatically to public digital archive APIs — Trove, NDL Search, NYPL Digital Collections, Chronicling America, Internet Archive, and Delpher — to retrieve metadata and catalog records.",
         },
         fulltext: {
           title: "Full-text Retrieval",

--- a/web-public/src/lib/i18n/dictionaries/es.ts
+++ b/web-public/src/lib/i18n/dictionaries/es.ts
@@ -77,13 +77,14 @@ const dict: Dictionary = {
     methodology: {
       heading: "Cómo investigamos",
       intro:
-        "Cada investigación sigue un proceso de seis pasos. Los pasos 1–3 son operaciones programáticas deterministas — no interviene ninguna interpretación de IA. Los pasos 4–6 utilizan modelos de lenguaje grandes (LLMs) para el análisis, la síntesis y la generación narrativa.",
+        "Cada investigación sigue un proceso de seis pasos. El paso 1 utiliza un agente de IA para generar palabras clave de búsqueda, que luego se envían a las API de los archivos de forma programática. Los pasos 2–3 son operaciones programáticas deterministas — no interviene ninguna interpretación de IA. Los pasos 4–6 utilizan modelos de lenguaje grandes (LLMs) para el análisis, la síntesis y la generación narrativa.",
       programLabel: "PROGRAMA",
       llmLabel: "LLM",
+      hybridLabel: "LLM + PROGRAMA",
       steps: {
         search: {
           title: "Búsqueda API",
-          description: "Se envían consultas programáticas a las API de archivos digitales públicos — Trove, NDL Search, NYPL Digital Collections, Chronicling America, Internet Archive y Delpher. El sistema recupera metadatos y registros de catálogo que coinciden con el tema de investigación.",
+          description: "Un agente de IA analiza el tema de investigación y genera palabras clave de búsqueda — tanto términos sistemáticos para la reproducibilidad como términos exploratorios para un descubrimiento más amplio. Estas palabras clave se envían de forma programática a las API de archivos digitales públicos — Trove, NDL Search, NYPL Digital Collections, Chronicling America, Internet Archive y Delpher — para recuperar metadatos y registros de catálogo.",
         },
         fulltext: {
           title: "Recuperación de texto completo",

--- a/web-public/src/lib/i18n/dictionaries/ja.ts
+++ b/web-public/src/lib/i18n/dictionaries/ja.ts
@@ -76,13 +76,14 @@ const dict: Dictionary = {
     methodology: {
       heading: "調査プロセス",
       intro:
-        "各調査は6段階のパイプラインに従います。ステップ1〜3は決定論的なプログラム処理であり、AIの解釈は一切介在しません。ステップ4〜6は大規模言語モデル（LLM）を用いた分析・統合・記事生成を行います。",
+        "各調査は6段階のパイプラインに従います。ステップ1ではAIエージェントが調査テーマに基づいて検索キーワードを生成し、そのキーワードでアーカイブ API にプログラムでクエリを送信します。ステップ2〜3は決定論的なプログラム処理であり、AIの解釈は介在しません。ステップ4〜6は大規模言語モデル（LLM）を用いた分析・統合・記事生成を行います。",
       programLabel: "プログラム",
       llmLabel: "LLM",
+      hybridLabel: "LLM + プログラム",
       steps: {
         search: {
           title: "API 検索",
-          description: "公開デジタルアーカイブの API — Trove、NDL Search、NYPL Digital Collections、Chronicling America、Internet Archive、Delpher — にプログラムでクエリを送信します。調査テーマに合致するメタデータとカタログレコードを取得します。",
+          description: "AIエージェントが調査テーマを分析し、検索キーワードを生成します。再現性を保証する体系的キーワードと、発見の幅を広げる探索的キーワードの2種類です。生成されたキーワードは公開デジタルアーカイブの API — Trove、NDL Search、NYPL Digital Collections、Chronicling America、Internet Archive、Delpher — にプログラムで送信され、メタデータとカタログレコードを取得します。",
         },
         fulltext: {
           title: "全文取得",

--- a/web-public/src/lib/i18n/dictionaries/types.ts
+++ b/web-public/src/lib/i18n/dictionaries/types.ts
@@ -64,6 +64,7 @@ export interface Dictionary {
       intro: string;
       programLabel: string;
       llmLabel: string;
+      hybridLabel: string;
       steps: {
         search: { title: string; description: string };
         fulltext: { title: string; description: string };


### PR DESCRIPTION
## Summary

- About ページ「How We Investigate」セクションのステップ1「API Search」の分類を `PROGRAM` → `hybrid`（LLM + PROGRAM）に修正
- Librarian は `LlmAgent`（gemini-2.5-flash）がキーワード生成を行い、その後プログラムで API にクエリ送信するハイブリッド処理であり、純粋な PROGRAM 分類は不正確だった
- ステップ2-3 は実装確認済みで PROGRAM のまま正確

## Changes

- `page.tsx`: type union に `"hybrid"` 追加、ステップ1 の type を `hybrid` に変更、amber-400 色の凡例バッジ・ステップカード色分岐を追加
- `types.ts`: `hybridLabel: string` を追加
- 4辞書（en/ja/es/de）: `hybridLabel` 追加、`intro` と `search.description` を修正（AI エージェントによるキーワード生成を明記）

## Test plan

- [x] `npx tsc --noEmit` — TypeScript 型エラーなし
- [ ] `npm run build` — SSG ビルド成功（Firebase env 必要）
- [ ] 4言語の About ページでステップ1 に amber 色の「LLM + PROGRAM」バッジが表示されることを目視確認
- [ ] ステップ2-3 は従来通り emerald の PROGRAM バッジであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)