### PR TITLE
feat: Librarian 全文テキストのキーワード指向抽出（#412）

### DIFF
--- a/mystery_agents/tools/chronicling_america.py
+++ b/mystery_agents/tools/chronicling_america.py
@@ -11,6 +11,7 @@ import requests
 
 from ..schemas.document import ArchiveDocument, SourceLanguage
 from .archive_source_base import ArchiveSearchResult, ArchiveSource
+from .fulltext_extraction import build_extraction_keywords, extract_keyword_passages
 from .search_utils import build_search_query
 from .source_registry import register_source
 
@@ -34,7 +35,7 @@ BASE_URL = "https://www.loc.gov/search/"
 # 全文取得の上限設定
 _MAX_FULLTEXT_FETCHES = 5
 _FULLTEXT_TIMEOUT = 15
-_MAX_TEXT_LENGTH = 5000
+_MAX_RAW_FETCH = 200_000
 
 
 def _fetch_page_fulltext(
@@ -47,7 +48,7 @@ def _fetch_page_fulltext(
         page_url: LOC ページ URL
 
     Returns:
-        OCR テキスト（最大5000文字）。取得失敗時は None。
+        OCR テキスト（安全上限で切り詰め）。取得失敗時は None。
     """
     try:
         sep = "&" if "?" in page_url else "?"
@@ -61,7 +62,7 @@ def _fetch_page_fulltext(
             return None
         data = resp.json()
         text = data.get("full_text", "")
-        return text.strip()[:_MAX_TEXT_LENGTH] if text else None
+        return text.strip()[:_MAX_RAW_FETCH] if text else None
     except (requests.RequestException, ValueError, KeyError) as e:
         logger.debug("LOC page fulltext 取得失敗: %s", e)
         return None
@@ -80,7 +81,7 @@ def _fetch_item_fulltext(
         item_url: LOC アイテム URL
 
     Returns:
-        OCR テキスト（最大5000文字）。取得失敗時は None。
+        OCR テキスト（安全上限で切り詰め）。取得失敗時は None。
     """
     try:
         sep = "&" if "?" in item_url else "?"
@@ -97,7 +98,7 @@ def _fetch_item_fulltext(
         # 直接 full_text がある場合
         full_text = data.get("full_text", "")
         if full_text:
-            return full_text.strip()[:_MAX_TEXT_LENGTH]
+            return full_text.strip()[:_MAX_RAW_FETCH]
 
         # resources → 最初のページから full_text を取得
         resources = data.get("resources", [])
@@ -222,12 +223,15 @@ class ChroniclingAmericaSource(ArchiveSource):
             if url and len(fulltext_targets) < _MAX_FULLTEXT_FETCHES:
                 fulltext_targets.append((len(documents) - 1, url))
 
-        # 全文テキストエンリッチメント（ベストエフォート）
+        # 全文テキストエンリッチメント（キーワード指向抽出）
         for idx, item_url in fulltext_targets:
             self._rate_limit()
             text = _fetch_item_fulltext(self._session, item_url)
             if text:
-                documents[idx].raw_text = text
+                extraction_kws = build_extraction_keywords(
+                    keywords, title=documents[idx].title
+                )
+                documents[idx].raw_text = extract_keyword_passages(text, extraction_kws)
 
         pagination = data.get("pagination", {})
         total_hits = pagination.get("total", pagination.get("of", 0))

--- a/mystery_agents/tools/delpher.py
+++ b/mystery_agents/tools/delpher.py
@@ -12,6 +12,7 @@ import requests
 
 from ..schemas.document import ArchiveDocument, SourceLanguage
 from .archive_source_base import ArchiveSearchResult, ArchiveSource
+from .fulltext_extraction import build_extraction_keywords, extract_keyword_passages
 from .search_utils import build_search_query
 from .source_registry import register_source
 
@@ -22,7 +23,7 @@ BASE_URL = "https://jsru.kb.nl/sru/sru"
 # 全文取得の上限設定
 _MAX_FULLTEXT_FETCHES = 5
 _FULLTEXT_TIMEOUT = 15
-_MAX_TEXT_LENGTH = 5000
+_MAX_RAW_FETCH = 200_000
 
 
 def _fetch_ocr_text(
@@ -37,7 +38,7 @@ def _fetch_ocr_text(
         resolver_url: Delpher resolver URL（例: http://resolver.kb.nl/resolve?urn=...）
 
     Returns:
-        OCR テキスト（最大5000文字）。取得失敗時は None。
+        OCR テキスト（安全上限で切り詰め）。取得失敗時は None。
     """
     try:
         ocr_url = f"{resolver_url.rstrip('/')}:ocr"
@@ -50,7 +51,7 @@ def _fetch_ocr_text(
             logger.debug("Delpher OCR %d for %s", resp.status_code, resolver_url)
             return None
         text = resp.text.strip()
-        return text[:_MAX_TEXT_LENGTH] if text else None
+        return text[:_MAX_RAW_FETCH] if text else None
     except (requests.RequestException, ValueError) as e:
         logger.debug("Delpher OCR 取得失敗 (%s): %s", resolver_url, e)
         return None
@@ -219,7 +220,12 @@ class DelpherSource(ArchiveSource):
             self._rate_limit()
             text = _fetch_ocr_text(self._session, url)
             if text:
-                result.documents[idx].raw_text = text
+                extraction_kws = build_extraction_keywords(
+                    keywords, title=result.documents[idx].title
+                )
+                result.documents[idx].raw_text = extract_keyword_passages(
+                    text, extraction_kws
+                )
 
         # 全文取得成功したドキュメントのみ保持
         filtered = [doc for doc in result.documents if doc.raw_text]

--- a/mystery_agents/tools/fulltext_extraction.py
+++ b/mystery_agents/tools/fulltext_extraction.py
@@ -1,0 +1,141 @@
+"""全文テキストのキーワード指向抽出モジュール。
+
+先頭切り詰めに代わり、全文中からテーマキーワードにヒットする箇所を検索し、
+前後コンテキストを抽出して結合する。Scholar が受け取るテキストの分析品質を向上させる。
+"""
+
+
+def extract_keyword_passages(
+    full_text: str,
+    keywords: list[str],
+    *,
+    context_chars: int = 500,
+    max_output_chars: int = 5000,
+    separator: str = "\n[...]\n",
+) -> str:
+    """全文からキーワード周辺のパッセージを抽出して結合する。
+
+    Args:
+        full_text: 全文テキスト
+        keywords: 抽出対象のキーワードリスト
+        context_chars: 各ヒットの前後に含めるコンテキスト文字数
+        max_output_chars: 出力の最大文字数
+        separator: 非連続パッセージ間の区切り文字列
+
+    Returns:
+        キーワード周辺のパッセージを結合した文字列。
+        短いテキストはそのまま返す。キーワードがヒットしない場合は先頭にフォールバック。
+    """
+    if not full_text:
+        return ""
+
+    # 短いテキストはそのまま返す
+    if len(full_text) <= max_output_chars:
+        return full_text
+
+    # キーワードが空 → 先頭フォールバック
+    if not keywords:
+        return full_text[:max_output_chars]
+
+    # 全文を小文字化してキーワードの出現位置を収集
+    text_lower = full_text.lower()
+    hit_positions: list[int] = []
+    for kw in keywords:
+        kw_lower = kw.lower()
+        if not kw_lower:
+            continue
+        start = 0
+        while True:
+            pos = text_lower.find(kw_lower, start)
+            if pos == -1:
+                break
+            hit_positions.append(pos)
+            start = pos + 1
+
+    # ヒットなし → 先頭フォールバック
+    if not hit_positions:
+        return full_text[:max_output_chars]
+
+    # 各ヒット位置を ±context_chars に拡張して範囲を生成
+    text_len = len(full_text)
+    ranges: list[tuple[int, int]] = []
+    for pos in hit_positions:
+        r_start = max(0, pos - context_chars)
+        r_end = min(text_len, pos + context_chars)
+        ranges.append((r_start, r_end))
+
+    # ソート → 重複・隣接をマージ
+    ranges.sort()
+    merged: list[tuple[int, int]] = [ranges[0]]
+    for r_start, r_end in ranges[1:]:
+        prev_start, prev_end = merged[-1]
+        if r_start <= prev_end:
+            merged[-1] = (prev_start, max(prev_end, r_end))
+        else:
+            merged.append((r_start, r_end))
+
+    # 元テキスト（大文字保持）からパッセージを切り出し
+    passages: list[str] = []
+    total_len = 0
+    for i, (r_start, r_end) in enumerate(merged):
+        passage = full_text[r_start:r_end]
+        # セパレータ分も含めた累積長を計算
+        added_len = len(passage) + (len(separator) if i > 0 else 0)
+        if total_len + added_len > max_output_chars:
+            # 残り文字数分だけ切り出して終了
+            remaining = max_output_chars - total_len - (len(separator) if i > 0 else 0)
+            if remaining > 0:
+                passages.append(passage[:remaining])
+            break
+        passages.append(passage)
+        total_len += added_len
+
+    return separator.join(passages)
+
+
+def build_extraction_keywords(
+    search_keywords: list[str],
+    *,
+    title: str = "",
+    subjects: list[str] | None = None,
+    min_word_length: int = 4,
+) -> list[str]:
+    """検索キーワード + ドキュメントメタデータから抽出用キーワードを構築する。
+
+    Args:
+        search_keywords: ベースとなる検索キーワード
+        title: ドキュメントのタイトル（スペース分割で単語を追加）
+        subjects: サブジェクトタグのリスト
+        min_word_length: タイトルから追加する単語の最小文字数
+
+    Returns:
+        重複除去済みのキーワードリスト（大文字小文字を無視して重複排除）
+    """
+    seen_lower: set[str] = set()
+    result: list[str] = []
+
+    def _add(keyword: str) -> None:
+        kw_stripped = keyword.strip()
+        if not kw_stripped:
+            return
+        lower = kw_stripped.lower()
+        if lower not in seen_lower:
+            seen_lower.add(lower)
+            result.append(kw_stripped)
+
+    # 検索キーワードをベースに追加
+    for kw in search_keywords:
+        _add(kw)
+
+    # タイトルをスペース分割 → 十分な長さの単語を追加
+    if title:
+        for word in title.split():
+            if len(word) >= min_word_length:
+                _add(word)
+
+    # subjects リストをそのまま追加
+    if subjects:
+        for subj in subjects:
+            _add(subj)
+
+    return result

--- a/mystery_agents/tools/internet_archive.py
+++ b/mystery_agents/tools/internet_archive.py
@@ -11,6 +11,7 @@ import requests
 
 from ..schemas.document import ArchiveDocument
 from .archive_source_base import ArchiveSearchResult, ArchiveSource
+from .fulltext_extraction import build_extraction_keywords, extract_keyword_passages
 from .search_utils import build_search_query
 from .source_registry import register_source
 
@@ -22,7 +23,7 @@ _DJVU_TEXT_URL = "https://archive.org/download/{identifier}/{identifier}_djvu.tx
 # 全文取得の上限設定
 _MAX_FULLTEXT_FETCHES = 5
 _FULLTEXT_TIMEOUT = 15
-_MAX_TEXT_LENGTH = 5000
+_MAX_RAW_FETCH = 200_000
 
 
 def _fetch_djvu_text(
@@ -35,7 +36,7 @@ def _fetch_djvu_text(
         identifier: Internet Archive アイテム識別子
 
     Returns:
-        OCR テキスト（最大5000文字）。取得失敗時は None。
+        OCR テキスト（安全上限で切り詰め）。取得失敗時は None。
     """
     try:
         url = _DJVU_TEXT_URL.format(identifier=identifier)
@@ -48,7 +49,7 @@ def _fetch_djvu_text(
             logger.debug("IA djvu.txt %d for %s", resp.status_code, identifier)
             return None
         text = resp.text.strip()
-        return text[:_MAX_TEXT_LENGTH] if text else None
+        return text[:_MAX_RAW_FETCH] if text else None
     except (requests.RequestException, ValueError) as e:
         logger.debug("IA djvu.txt 取得失敗 (%s): %s", identifier, e)
         return None
@@ -130,8 +131,8 @@ class InternetArchiveSource(ArchiveSource):
 
         resp = data.get("response", {})
         documents = []
-        # 全文取得対象の (index, identifier) ペア
-        fulltext_targets: list[tuple[int, str]] = []
+        # 全文取得対象の (index, identifier, subjects) タプル
+        fulltext_targets: list[tuple[int, str, list[str]]] = []
 
         for item in resp.get("docs", []):
             title = item.get("title", "Unknown Title")
@@ -180,14 +181,20 @@ class InternetArchiveSource(ArchiveSource):
 
             # 全文取得候補に追加（上位5件まで）
             if identifier and len(fulltext_targets) < _MAX_FULLTEXT_FETCHES:
-                fulltext_targets.append((len(documents) - 1, identifier))
+                subjects_raw = item.get("subject", [])
+                if isinstance(subjects_raw, str):
+                    subjects_raw = [subjects_raw]
+                fulltext_targets.append((len(documents) - 1, identifier, subjects_raw))
 
-        # 全文テキストエンリッチメント
-        for idx, ident in fulltext_targets:
+        # 全文テキストエンリッチメント（キーワード指向抽出）
+        for idx, ident, subjects in fulltext_targets:
             self._rate_limit()
             text = _fetch_djvu_text(self._session, ident)
             if text:
-                documents[idx].raw_text = text
+                extraction_kws = build_extraction_keywords(
+                    keywords, title=documents[idx].title, subjects=subjects
+                )
+                documents[idx].raw_text = extract_keyword_passages(text, extraction_kws)
 
         # 全文取得成功したドキュメントのみ保持
         documents = [doc for doc in documents if doc.raw_text]

--- a/mystery_agents/tools/ndl_search.py
+++ b/mystery_agents/tools/ndl_search.py
@@ -15,6 +15,7 @@ import requests
 
 from ..schemas.document import ArchiveDocument, SourceLanguage
 from .archive_source_base import ArchiveSearchResult, ArchiveSource
+from .fulltext_extraction import build_extraction_keywords, extract_keyword_passages
 from .source_registry import register_source
 
 logger = logging.getLogger(__name__)
@@ -28,7 +29,7 @@ _NDL_LAB_URL = "https://lab.ndl.go.jp/dl/api/book/layouttext/{pid}"
 # 全文取得の上限設定
 _MAX_FULLTEXT_FETCHES = 5
 _FULLTEXT_TIMEOUT = 15
-_MAX_TEXT_LENGTH = 5000
+_MAX_RAW_FETCH = 200_000
 
 # RSS 2.0 + Dublin Core 等の XML 名前空間
 _NS = {
@@ -64,7 +65,7 @@ def _fetch_fulltext(session: requests.Session, pid: str) -> str | None:
         pid: NDL デジタルコレクションの PID
 
     Returns:
-        OCR テキスト（最大5000文字）。取得失敗時は None。
+        OCR テキスト（安全上限で切り詰め）。取得失敗時は None。
     """
     try:
         resp = session.get(
@@ -87,7 +88,7 @@ def _fetch_fulltext(session: requests.Session, pid: str) -> str | None:
 
         if not lines:
             return None
-        return "\n".join(lines)[:_MAX_TEXT_LENGTH]
+        return "\n".join(lines)[:_MAX_RAW_FETCH]
 
     except (requests.RequestException, ValueError, KeyError) as e:
         logger.debug("NDL Lab 全文取得失敗 (PID %s): %s", pid, e)
@@ -204,12 +205,15 @@ class NDLSearchSource(ArchiveSource):
             if pid and len(fulltext_targets) < _MAX_FULLTEXT_FETCHES:
                 fulltext_targets.append((len(documents) - 1, pid))
 
-        # 全文テキストエンリッチメント（ベストエフォート）
+        # 全文テキストエンリッチメント（キーワード指向抽出）
         for idx, pid in fulltext_targets:
             self._rate_limit()
             text = _fetch_fulltext(self._session, pid)
             if text:
-                documents[idx].raw_text = text
+                extraction_kws = build_extraction_keywords(
+                    keywords, title=documents[idx].title
+                )
+                documents[idx].raw_text = extract_keyword_passages(text, extraction_kws)
 
         return ArchiveSearchResult(documents=documents, total_hits=total_hits)
 

--- a/mystery_agents/tools/nypl_digital.py
+++ b/mystery_agents/tools/nypl_digital.py
@@ -13,6 +13,7 @@ import requests
 
 from ..schemas.document import ArchiveDocument, SourceLanguage
 from .archive_source_base import ArchiveSearchResult, ArchiveSource
+from .fulltext_extraction import build_extraction_keywords, extract_keyword_passages
 from .search_utils import build_search_query
 from .source_registry import register_source
 
@@ -24,7 +25,7 @@ _PLAIN_TEXT_URL = "https://api.repo.nypl.org/api/v2/items/plain_text/{uuid}"
 # 全文取得の上限設定
 _MAX_FULLTEXT_FETCHES = 5
 _FULLTEXT_TIMEOUT = 15
-_MAX_TEXT_LENGTH = 5000
+_MAX_RAW_FETCH = 200_000
 
 
 def _fetch_plain_text(
@@ -37,7 +38,7 @@ def _fetch_plain_text(
         uuid: NYPL アイテムの UUID
 
     Returns:
-        OCR テキスト（最大5000文字）。取得失敗時は None。
+        OCR テキスト（安全上限で切り詰め）。取得失敗時は None。
     """
     try:
         headers = {"User-Agent": "GhostInTheArchive/1.0"}
@@ -61,7 +62,7 @@ def _fetch_plain_text(
         )
         if not text or not isinstance(text, str):
             return None
-        return text.strip()[:_MAX_TEXT_LENGTH]
+        return text.strip()[:_MAX_RAW_FETCH]
 
     except (requests.RequestException, ValueError, KeyError) as e:
         logger.debug("NYPL plain_text 取得失敗 (UUID %s): %s", uuid, e)
@@ -170,12 +171,15 @@ class NYPLSource(ArchiveSource):
             if uuid and len(fulltext_targets) < _MAX_FULLTEXT_FETCHES:
                 fulltext_targets.append((len(documents) - 1, uuid))
 
-        # 全文テキストエンリッチメント（ベストエフォート）
+        # 全文テキストエンリッチメント（キーワード指向抽出）
         for idx, uuid in fulltext_targets:
             self._rate_limit()
             text = _fetch_plain_text(self._session, uuid, token=token)
             if text:
-                documents[idx].raw_text = text
+                extraction_kws = build_extraction_keywords(
+                    keywords, title=documents[idx].title
+                )
+                documents[idx].raw_text = extract_keyword_passages(text, extraction_kws)
 
         total_hits = int(nypl_response.get("numResults", 0))
         return ArchiveSearchResult(documents=documents, total_hits=total_hits)

--- a/mystery_agents/tools/trove.py
+++ b/mystery_agents/tools/trove.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from ..schemas.document import ArchiveDocument, SourceLanguage
 from .archive_source_base import ArchiveSearchResult, ArchiveSource
+from .fulltext_extraction import build_extraction_keywords, extract_keyword_passages
 from .search_utils import build_search_query
 from .source_registry import register_source
 
@@ -110,6 +111,14 @@ class TroveSource(ArchiveSource):
             combined = f"{title} {summary_text}".lower()
             matched = [kw for kw in keywords if kw.lower() in combined]
 
+            # キーワード指向抽出（Trove はインラインで全文を取得）
+            raw_text = None
+            if article_text:
+                extraction_kws = build_extraction_keywords(
+                    keywords, title=str(title)
+                )
+                raw_text = extract_keyword_passages(article_text, extraction_kws)
+
             doc = ArchiveDocument(
                 title=str(title)[:500],
                 date=self.parse_year(str(date_str), min_century=18),
@@ -118,7 +127,7 @@ class TroveSource(ArchiveSource):
                 language=SourceLanguage.EN,
                 location=str(location)[:200],
                 source_type=self.source_type,
-                raw_text=article_text[:5000] if article_text else None,
+                raw_text=raw_text,
                 keywords_matched=matched,
             )
             documents.append(doc)

--- a/tests/unit/test_chronicling_america.py
+++ b/tests/unit/test_chronicling_america.py
@@ -60,8 +60,8 @@ class TestFetchPageFulltext:
         assert result is None
 
     @responses.activate
-    def test_truncates_long_text(self):
-        """5000文字を超えるテキストは切り詰める。"""
+    def test_returns_full_text_under_raw_limit(self):
+        """安全上限以下のテキストはそのまま返す（キーワード抽出は呼び出し側で行う）。"""
         page_url = "https://www.loc.gov/resource/test"
         long_text = "A" * 6000
         responses.add(
@@ -74,7 +74,7 @@ class TestFetchPageFulltext:
         session = create_retry_session()
         result = _fetch_page_fulltext(session, page_url)
 
-        assert len(result) == 5000
+        assert len(result) == 6000
 
 
 class TestFetchItemFulltext:

--- a/tests/unit/test_delpher.py
+++ b/tests/unit/test_delpher.py
@@ -306,8 +306,8 @@ class TestFetchOcrText:
         assert result is None
 
     @responses.activate
-    def test_truncates_long_text(self):
-        """5000文字を超えるテキストは切り詰める。"""
+    def test_returns_full_text_under_raw_limit(self):
+        """安全上限以下のテキストはそのまま返す（キーワード抽出は呼び出し側で行う）。"""
         resolver_url = "http://resolver.kb.nl/resolve?urn=ddd:long"
         responses.add(
             responses.GET,
@@ -319,7 +319,7 @@ class TestFetchOcrText:
         session = create_retry_session()
         result = _fetch_ocr_text(session, resolver_url)
 
-        assert len(result) == 5000
+        assert len(result) == 6000
 
     @responses.activate
     def test_returns_none_on_empty_text(self):

--- a/tests/unit/test_fulltext_extraction.py
+++ b/tests/unit/test_fulltext_extraction.py
@@ -1,0 +1,173 @@
+"""Unit tests for mystery_agents/tools/fulltext_extraction.py."""
+
+from mystery_agents.tools.fulltext_extraction import (
+    build_extraction_keywords,
+    extract_keyword_passages,
+)
+
+
+class TestExtractKeywordPassages:
+    """extract_keyword_passages のテスト。"""
+
+    def test_short_text_returned_as_is(self):
+        """max_output_chars 以下のテキストはそのまま返す。"""
+        text = "Short text about ghosts."
+        result = extract_keyword_passages(text, ["ghosts"], max_output_chars=5000)
+        assert result == text
+
+    def test_single_keyword_single_hit(self):
+        """単一キーワード・単一ヒットでコンテキストが正しく抽出される。"""
+        # "ghost" を10000文字目付近に配置
+        text = "A" * 10000 + "The ghost appeared." + "B" * 10000
+        result = extract_keyword_passages(
+            text, ["ghost"], context_chars=50, max_output_chars=5000
+        )
+        assert "ghost" in result
+        assert len(result) <= 5000
+        # 先頭の "AAA..." ではなくキーワード周辺が抽出される
+        assert result != text[:5000]
+
+    def test_multiple_keywords_multiple_hits(self):
+        """複数キーワード・複数ヒットで全ヒットが網羅される。"""
+        text = "A" * 5000 + "ghost" + "A" * 5000 + "haunted" + "A" * 5000
+        result = extract_keyword_passages(
+            text, ["ghost", "haunted"], context_chars=100, max_output_chars=5000
+        )
+        assert "ghost" in result
+        assert "haunted" in result
+
+    def test_overlapping_ranges_merged(self):
+        """近接キーワードが1つのパッセージに統合される。"""
+        text = "A" * 5000 + "ghost haunted" + "A" * 5000
+        result = extract_keyword_passages(
+            text, ["ghost", "haunted"], context_chars=100, max_output_chars=5000
+        )
+        assert "ghost haunted" in result
+        # セパレータが含まれない（マージされている）
+        assert "[...]" not in result
+
+    def test_no_hits_falls_back_to_head(self):
+        """キーワードがヒットしない場合は先頭にフォールバック。"""
+        text = "A" * 10000
+        result = extract_keyword_passages(
+            text, ["ghost"], max_output_chars=5000
+        )
+        assert result == "A" * 5000
+
+    def test_empty_keywords_falls_back_to_head(self):
+        """キーワードが空の場合は先頭にフォールバック。"""
+        text = "A" * 10000
+        result = extract_keyword_passages(text, [], max_output_chars=5000)
+        assert result == "A" * 5000
+
+    def test_max_output_chars_limit(self):
+        """出力が max_output_chars を超えない。"""
+        text = "ghost " * 10000  # キーワードが大量にヒットする
+        result = extract_keyword_passages(
+            text, ["ghost"], context_chars=500, max_output_chars=3000
+        )
+        assert len(result) <= 3000
+
+    def test_case_insensitive_matching(self):
+        """大文字小文字を無視してマッチする。"""
+        text = "A" * 5000 + "The GHOST appeared here." + "B" * 5000
+        result = extract_keyword_passages(
+            text, ["ghost"], context_chars=50, max_output_chars=5000
+        )
+        # 元の大文字が保持される
+        assert "GHOST" in result
+
+    def test_japanese_text(self):
+        """日本語テキストで CJK キーワードが正常動作する。"""
+        text = "あ" * 5000 + "怪談の記録がここに残されている" + "い" * 5000
+        result = extract_keyword_passages(
+            text, ["怪談"], context_chars=100, max_output_chars=5000
+        )
+        assert "怪談" in result
+
+    def test_separator_between_non_contiguous_passages(self):
+        """非連続パッセージ間に [...] 区切りが入る。"""
+        text = "A" * 5000 + "ghost" + "B" * 5000 + "haunted" + "C" * 5000
+        result = extract_keyword_passages(
+            text, ["ghost", "haunted"], context_chars=100, max_output_chars=15000
+        )
+        assert "[...]" in result
+
+    def test_empty_text_returns_empty(self):
+        """空テキストは空文字列を返す。"""
+        assert extract_keyword_passages("", ["ghost"]) == ""
+
+    def test_preserves_original_casing(self):
+        """抽出されたパッセージは元テキストの大文字小文字を保持する。"""
+        text = "X" * 6000 + "The Ghost of Salem was REAL." + "Y" * 6000
+        result = extract_keyword_passages(
+            text, ["ghost"], context_chars=50, max_output_chars=5000
+        )
+        assert "Ghost" in result
+        assert "REAL" in result
+
+
+class TestBuildExtractionKeywords:
+    """build_extraction_keywords のテスト。"""
+
+    def test_search_keywords_only(self):
+        """検索キーワードのみ。"""
+        result = build_extraction_keywords(["ghost", "haunted"])
+        assert result == ["ghost", "haunted"]
+
+    def test_title_words_added(self):
+        """タイトルから十分長い単語が追加される。"""
+        result = build_extraction_keywords(
+            ["ghost"], title="The Haunted House of Salem"
+        )
+        assert "ghost" in result
+        assert "Haunted" in result
+        assert "House" in result
+        assert "Salem" in result
+        # "The" (3文字) と "of" (2文字) は除外
+        assert "The" not in result
+        assert "of" not in result
+
+    def test_subjects_added(self):
+        """subjects リストが追加される。"""
+        result = build_extraction_keywords(
+            ["ghost"], subjects=["Folklore", "Massachusetts"]
+        )
+        assert "ghost" in result
+        assert "Folklore" in result
+        assert "Massachusetts" in result
+
+    def test_deduplication_case_insensitive(self):
+        """大文字小文字を無視して重複除去される。"""
+        result = build_extraction_keywords(
+            ["Ghost"], title="ghost story", subjects=["GHOST"]
+        )
+        # "Ghost" のみ（最初に追加されたもの）
+        assert len([kw for kw in result if kw.lower() == "ghost"]) == 1
+
+    def test_short_words_filtered(self):
+        """min_word_length 未満のタイトル単語はフィルタリングされる。"""
+        result = build_extraction_keywords(
+            [], title="A Big Cat", min_word_length=4
+        )
+        # "A" (1文字), "Big" (3文字), "Cat" (3文字) すべて除外
+        assert result == []
+
+    def test_empty_inputs(self):
+        """全入力が空の場合は空リストを返す。"""
+        result = build_extraction_keywords([])
+        assert result == []
+
+    def test_combined(self):
+        """検索キーワード + タイトル + subjects の組み合わせ。"""
+        result = build_extraction_keywords(
+            ["Salem", "witch"],
+            title="The Salem Witch Trials",
+            subjects=["History", "witch"],
+        )
+        assert "Salem" in result
+        assert "witch" in result
+        assert "Witch" not in result  # "witch" と重複
+        assert "Trials" in result
+        assert "History" in result
+        assert "The" not in result

--- a/tests/unit/test_internet_archive.py
+++ b/tests/unit/test_internet_archive.py
@@ -39,8 +39,8 @@ class TestFetchDjvuText:
         assert result is None
 
     @responses.activate
-    def test_truncates_long_text(self):
-        """5000文字を超えるテキストは切り詰める。"""
+    def test_returns_full_text_under_raw_limit(self):
+        """安全上限以下のテキストはそのまま返す（キーワード抽出は呼び出し側で行う）。"""
         identifier = "long_book"
         url = _DJVU_TEXT_URL.format(identifier=identifier)
         responses.add(responses.GET, url, body="B" * 6000, status=200)
@@ -48,7 +48,7 @@ class TestFetchDjvuText:
         session = create_retry_session()
         result = _fetch_djvu_text(session, identifier)
 
-        assert len(result) == 5000
+        assert len(result) == 6000
 
     @responses.activate
     def test_returns_none_on_empty_text(self):

--- a/tests/unit/test_ndl_search.py
+++ b/tests/unit/test_ndl_search.py
@@ -289,8 +289,8 @@ class TestFetchFulltext:
         assert _fetch_fulltext(session, "11111") is None
 
     @responses.activate
-    def test_truncated_at_5000(self):
-        """テキストが5000文字で切り詰められる。"""
+    def test_returns_full_text_under_raw_limit(self):
+        """安全上限以下のテキストはそのまま返す（キーワード抽出は呼び出し側で行う）。"""
         lab_url = _NDL_LAB_URL.format(pid="22222")
         # 6000文字のテキストを含む1行
         long_text = "あ" * 6000
@@ -303,7 +303,7 @@ class TestFetchFulltext:
         text = _fetch_fulltext(session, "22222")
 
         assert text is not None
-        assert len(text) == 5000
+        assert len(text) == 6000
 
 
 class TestNDLFulltextEnrichment:

--- a/tests/unit/test_nypl_digital.py
+++ b/tests/unit/test_nypl_digital.py
@@ -172,8 +172,8 @@ class TestFetchPlainText:
         assert _fetch_plain_text(session, "uuid-timeout") is None
 
     @responses.activate
-    def test_truncated_at_5000(self):
-        """テキストが5000文字で切り詰められる。"""
+    def test_returns_full_text_under_raw_limit(self):
+        """安全上限以下のテキストはそのまま返す（キーワード抽出は呼び出し側で行う）。"""
         url = _PLAIN_TEXT_URL.format(uuid="uuid-long")
         long_text = "A" * 6000
         mock_data = {"nyplAPI": {"response": {"text": long_text}}}
@@ -185,7 +185,7 @@ class TestFetchPlainText:
         text = _fetch_plain_text(session, "uuid-long")
 
         assert text is not None
-        assert len(text) == 5000
+        assert len(text) == 6000
 
 
 class TestNYPLFulltextEnrichment:


### PR DESCRIPTION
## Summary

- 全7つの API ソースで先頭5000文字の機械的切り詰めを**キーワード指向抽出**に置き換え
- 全文中からテーマキーワードにヒットする箇所を検索し、前後500文字のコンテキストを抽出して結合
- Scholar が受け取るテキストの分析品質を大幅に向上

### 変更内容

| ファイル | 変更 |
|---|---|
| `fulltext_extraction.py` | 新規: `extract_keyword_passages()` + `build_extraction_keywords()` |
| `internet_archive.py` | fetch 上限 5K→200K、エンリッチメントでキーワード抽出適用、IA の subject タグ活用 |
| `ndl_search.py` | 同上パターン適用 |
| `nypl_digital.py` | 同上パターン適用 |
| `chronicling_america.py` | 同上パターン適用（`_fetch_page_fulltext` + `_fetch_item_fulltext`） |
| `delpher.py` | 同上パターン適用 |
| `trove.py` | インライン全文に `extract_keyword_passages()` 適用 |

### アルゴリズム

1. テキストが `max_output_chars` 以下 → そのまま返す
2. 全文を小文字化してキーワードの全出現位置を `str.find()` で収集
3. 各ヒットを ±500文字に拡張 → 重複範囲をマージ
4. 元テキスト（大文字保持）からパッセージを切り出し、`[...]` で結合
5. ヒットなし → 先頭フォールバック

## Test plan

- [x] `test_fulltext_extraction.py`: 19件の新規テスト（キーワード抽出・フォールバック・日本語・マージ等）
- [x] 5件の既存テスト更新（truncation → raw limit テスト）
- [x] `pytest tests/unit/ -v` — 全1340件パス
- [x] `ruff check` — lint パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)