### PR TITLE
feat: Curator テーマ提案に API カバレッジ適合性評価を導入

### DIFF
--- a/curator_agents/agents/curator.py
+++ b/curator_agents/agents/curator.py
@@ -8,12 +8,16 @@ overlap with existing mysteries.
 from google.adk.agents import LlmAgent
 from google.genai import types
 
+from shared.api_coverage import build_coverage_prompt_table
 from shared.model_config import create_pro_model
 
 from curator_agents.schemas import build_category_prompt_section
 
 # カテゴリ定義を ClassificationCode enum から動的生成
 _CATEGORY_SECTION = build_category_prompt_section()
+
+# API カバレッジテーブルを api_coverage.py から動的生成
+_API_COVERAGE_TABLE = build_coverage_prompt_table()
 
 # === 日本語訳 ===
 # あなたは「Ghost in the Archive」プロジェクトのテーマ提案エージェントです。
@@ -37,20 +41,20 @@ _CATEGORY_SECTION = build_category_prompt_section()
 # Librarian エージェントが実際に検索できる API は以下の通りです。
 # テーマ提案時は、これらの API で一次資料がヒットするテーマのみ提案してください。
 #
-# | API | 言語 | カバレッジ | 全文取得が得意な年代 |
-# |-----|------|-----------|---------------------|
-# | Chronicling America (LOC Newspapers) | en | 米国の歴史的新聞（1770-1963） | 1770〜1963年 OCR |
-# | NYPL Digital Collections | en | ニューヨーク公共図書館120万点（手稿・地図・写真・稀覯本） | 年代により異なる |
-# | Internet Archive | en, de, es, fr, nl, pt, ja | グローバル7,000万点超（書籍・雑誌・音声・映像・ウェブ） | 全年代、書籍・雑誌 OCR |
-# | Europeana | de, es, fr, nl, pt | 欧州50カ国・6,000機関から6,000万点超 | 新聞のみ全文取得可 |
-# | KB/Delpher (オランダ国立図書館) | nl | オランダ（新聞1618年〜、書籍、雑誌） | 1600年代〜1990年代 OCR |
-# | Trove (オーストラリア国立図書館) | en | オーストラリア（新聞1803年〜、書籍、画像） | 1800年代〜1950年代 新聞 OCR |
-# | NDL Search (国立国会図書館) | ja | 日本（書籍・雑誌・手稿、江戸〜昭和期） | 明治〜昭和期 デジタル化資料 |
+# （api_coverage.py から動的生成されたテーブル: API名、言語、地域、カバレッジ、全文信頼度、全文年代）
 #
 # ## 全文取得ガイダンス
 # **全文 OCR が利用可能な年代・地域のテーマを優先すること。**
 # メタデータのみのヒットでは Ghost 品質のアノマリーを発見しにくい。
-# 上記テーブルの「全文取得が得意な年代」列を参考に、全文テキストが取得できるテーマを選ぶこと。
+# 上記テーブルの「Full-text Reliability」列を参考に、全文テキストが取得できるテーマを選ぶこと。
+# Full-text Reliability が HIGH の API でヒットするテーマを特に優先すること。
+#
+# ## API カバレッジスコアリング
+# 各テーマには `probe_keywords` フィールドを必ず出力すること。
+# probe_keywords は、そのテーマで API を検索する際に最も効果的な 3-5 個のキーワード。
+# 人名・地名・年代等の固有名詞を優先すること。
+# システムがこの probe_keywords を使って全 API を自動検索し、
+# 実際のヒット件数に基づいて coverage_score を算出する。
 #
 # ## 利用不可のアーカイブ（テーマ禁止）
 # 以下のアーカイブ API は未実装です。これらでしか資料が見つからないテーマは提案しないでください：
@@ -63,20 +67,13 @@ _CATEGORY_SECTION = build_category_prompt_section()
 # - インド・南アジアのアーカイブ — 未実装。インド固有のテーマは不可
 #
 # ## 地理的多様性（API カバレッジベース）
-# 以下の言語圏から幅広くテーマを選択すること。各言語圏の後のカッコ内は利用可能な API：
-# - **英語圏**（米国・オーストラリア）— NYPL, Chronicling America, Trove
-# - **ドイツ語圏**（ドイツ・オーストリア・スイス）— Europeana（新聞のみ）, Internet Archive
-# - **スペイン語圏**（スペイン・中南米）— Europeana, Internet Archive
-# - **フランス語圏**（フランス・ベルギー・旧植民地）— Europeana, Internet Archive
-# - **オランダ語圏**（オランダ・フランドル・旧植民地）— Delpher, Europeana
-# - **ポルトガル語圏**（ポルトガル・ブラジル）— Europeana, Internet Archive
-# - **日本語圏**（日本）— NDL Search, Internet Archive
+# 上記テーブルの Regions 列を参照し、幅広い地域からテーマを選択すること。
 # 全5件を単一の言語圏に集中させない。少なくとも3つの異なる言語圏をカバーすること。
 #
 # ## テーマの条件
 # - 世界中のあらゆる時代が対象（ただし上記 API で一次資料が見つかることが必須条件）
-# - 上記7件の API のいずれかで具体的に資料がヒットしそうなテーマのみ提案すること
-# - 全文 OCR が利用可能な年代・地域のテーマを優先すること
+# - 上記 API のいずれかで具体的に資料がヒットしそうなテーマのみ提案すること
+# - Full-text Reliability が HIGH の API でヒットするテーマを優先すること
 # - 複数の学術領域から分析可能な、記録の隙間に潜む謎
 # - 具体的な年代、地名、キーワードを含む調査クエリとして使えるもの
 #
@@ -107,7 +104,8 @@ _CATEGORY_SECTION = build_category_prompt_section()
 #   {
 #     "theme": "調査クエリとしてそのまま使える英語のテーマ文",
 #     "description": "このテーマが面白い理由の簡潔な英語説明（2-3文）。どの API で資料がヒットしそうかにも言及すること",
-#     "category": "分類コード（HIS/FLK/ANT/OCC/URB/CRM/REL/LOC）"
+#     "category": "分類コード（HIS/FLK/ANT/OCC/URB/CRM/REL/LOC）",
+#     "probe_keywords": ["keyword1", "keyword2", "keyword3"]
 #   }
 # ]
 # ```
@@ -115,7 +113,7 @@ _CATEGORY_SECTION = build_category_prompt_section()
 # 5件のテーマを提案してください。
 # === End 日本語訳 ===
 
-# カテゴリ定義部分のみ動的挿入し、ADK セッション状態プレースホルダーはそのまま保持
+# カテゴリ定義と API テーブルを動的挿入し、ADK セッション状態プレースホルダーはそのまま保持
 CURATOR_INSTRUCTION = """
 You are the Theme Suggestion Agent for the "Ghost in the Archive" project.
 Suggest 5 interesting research themes when the administrator is choosing the next investigation topic.
@@ -136,23 +134,23 @@ Current category distribution:
 Prioritize underrepresented categories.
 
 ## Available Archive APIs (7 total)
-The Librarian agent can ONLY search the following 7 APIs. Suggest themes for which primary sources \
+The Librarian agent can ONLY search the following APIs. Suggest themes for which primary sources \
 are likely to be found in at least one of these APIs:
 
-| API | Languages | Coverage | Full-text era |
-|-----|-----------|----------|---------------|
-| Chronicling America (LOC Newspapers) | en | US newspapers (1770-1963) | 1770–1963 OCR |
-| NYPL Digital Collections | en | 1.2M items (manuscripts, maps, photos, rare books) | varies |
-| Internet Archive | en, de, es, fr, nl, pt, ja | 70M+ items globally (books, periodicals, audio, video, web) | all eras, books/periodicals OCR |
-| Europeana | de, es, fr, nl, pt | 60M+ items from 50+ European countries | newspapers only full-text |
-| KB/Delpher (Dutch National Library) | nl | Netherlands (newspapers from 1618, books, periodicals) | 1600s–1990s OCR |
-| Trove (National Library of Australia) | en | Australia (newspapers from 1803, books, images) | 1800s–1950s newspaper OCR |
-| NDL Search (National Diet Library, Japan) | ja | Japan (books, periodicals, manuscripts; Edo-Showa eras) | Meiji–Showa digitized |
+""" + _API_COVERAGE_TABLE + """
 
 ## Full-text Retrieval Guidance
 **Prefer themes from eras and regions where full-text OCR is available.** \
 Themes requiring only metadata hits are less likely to yield Ghost-quality anomalies. \
-Refer to the "Full-text era" column above when selecting themes.
+Refer to the "Full-text Reliability" and "Full-text Era" columns above when selecting themes. \
+Prioritize themes likely to hit APIs with HIGH full-text reliability.
+
+## API Coverage Scoring
+For each theme, you MUST output a `probe_keywords` field containing 3-5 keywords \
+that would be most effective for searching the APIs above. \
+Prefer proper nouns (person names, place names, dates) over generic terms. \
+The system will use these probe_keywords to automatically search all APIs and \
+calculate a coverage_score based on actual hit counts.
 
 ## Archives NOT Available (Do NOT Suggest Themes Requiring These)
 The following archives are NOT implemented. Do NOT suggest themes that can only be researched through these:
@@ -165,20 +163,14 @@ The following archives are NOT implemented. Do NOT suggest themes that can only 
 - Indian / South Asian archives — NOT implemented. India-specific themes are NOT allowed
 
 ## Geographic Diversity (API Coverage-Based)
-Select themes from a broad range of language spheres. APIs available for each sphere are shown in parentheses:
-- **English sphere** (US, Australia) — NYPL, Chronicling America, Trove
-- **German sphere** (Germany, Austria, Switzerland) — Europeana (newspapers only), Internet Archive
-- **Spanish sphere** (Spain, Latin America) — Europeana, Internet Archive
-- **French sphere** (France, Belgium, former colonies) — Europeana, Internet Archive
-- **Dutch sphere** (Netherlands, Flanders, former colonies) — Delpher, Europeana
-- **Portuguese sphere** (Portugal, Brazil) — Europeana, Internet Archive
-- **Japanese sphere** (Japan) — NDL Search, Internet Archive
+Refer to the Regions column in the API table above. \
+Select themes from a broad range of regions covered by the available APIs. \
 Do NOT concentrate all 5 themes on a single language sphere. Cover at least 3 distinct language spheres.
 
 ## Theme Requirements
-- Any era worldwide is fair game (the constraint: primary sources must be findable via the 7 APIs above)
-- ONLY suggest themes for which at least one of the 7 APIs above is likely to return relevant primary sources
-- Prefer themes from eras where full-text OCR is available (see Full-text era column)
+- Any era worldwide is fair game (the constraint: primary sources must be findable via the APIs above)
+- ONLY suggest themes for which at least one of the APIs above is likely to return relevant primary sources
+- Prefer themes that hit APIs with HIGH full-text reliability
 - Amenable to interdisciplinary analysis (history, folklore, anthropology, linguistics, archival science)
 - Include specific dates, place names, and keywords usable as research queries
 
@@ -209,7 +201,8 @@ Output the following JSON array. Do NOT output any text other than the JSON.
   {{
     "theme": "A theme statement in English, usable directly as a research query",
     "description": "A concise explanation (2-3 sentences) of why this theme is interesting. Mention which APIs are likely to yield relevant primary sources.",
-    "category": "Classification code (HIS/FLK/ANT/OCC/URB/CRM/REL/LOC)"
+    "category": "Classification code (HIS/FLK/ANT/OCC/URB/CRM/REL/LOC)",
+    "probe_keywords": ["keyword1", "keyword2", "keyword3"]
   }}
 ]
 ```

--- a/curator_agents/core.py
+++ b/curator_agents/core.py
@@ -10,6 +10,7 @@ import json
 import logging
 
 from .agents.curator import curator_agent
+from .probe import probe_all_themes
 from .queries import (
     get_existing_titles,
     get_category_distribution,
@@ -95,5 +96,8 @@ async def suggest_themes(
         raise ValueError(
             f"All suggestions failed schema validation. Raw: {result_text[:500]}"
         )
+
+    # API プローブ: 実際のヒット件数に基づいて coverage_score を算出・上書き
+    suggestions = await asyncio.to_thread(probe_all_themes, suggestions)
 
     return suggestions

--- a/curator_agents/probe.py
+++ b/curator_agents/probe.py
@@ -1,0 +1,81 @@
+"""テーマ候補に対する軽量 API プローブ。
+
+Curator が生成した probe_keywords を使い、全ソースを並列検索して
+実際のヒット件数に基づいた coverage_score を算出・上書きする。
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from mystery_agents.tools.source_registry import get_all_sources
+from shared.api_coverage import API_COVERAGE_REGISTRY, calculate_coverage_score
+
+logger = logging.getLogger(__name__)
+
+
+def _build_source_to_group_map() -> dict[str, str]:
+    """source_registry キー → API グループキーのマッピングを構築する。"""
+    mapping: dict[str, str] = {}
+    for api_key, cov in API_COVERAGE_REGISTRY.items():
+        for sk in cov.source_keys:
+            mapping[sk] = api_key
+    return mapping
+
+
+def probe_theme(keywords: list[str]) -> dict[str, int]:
+    """1テーマについて全ソースを並列プローブし、API グループごとのヒット件数を返す。
+
+    Args:
+        keywords: 検索キーワードリスト（probe_keywords）
+
+    Returns:
+        {api_group_key: total_hits} 形式の dict
+    """
+    all_sources = get_all_sources()
+    source_to_group = _build_source_to_group_map()
+
+    group_hits: dict[str, int] = defaultdict(int)
+
+    with ThreadPoolExecutor(max_workers=7) as executor:
+        futures = {
+            executor.submit(source.search, keywords, max_results=1): key
+            for key, source in all_sources.items()
+        }
+        for future in as_completed(futures):
+            source_key = futures[future]
+            try:
+                result = future.result()
+                api_group = source_to_group.get(source_key, source_key)
+                group_hits[api_group] += result.total_hits
+            except Exception:
+                logger.debug(
+                    "プローブ失敗 (source=%s): %s",
+                    source_key,
+                    future.exception(),
+                )
+
+    return dict(group_hits)
+
+
+def probe_all_themes(themes: list[dict]) -> list[dict]:
+    """全テーマをプローブし、coverage_score と primary_apis を付与する。
+
+    Args:
+        themes: Curator が生成したテーマ dict のリスト
+
+    Returns:
+        coverage_score, primary_apis, probe_hits が付与されたテーマリスト
+    """
+    for theme in themes:
+        # probe_keywords が未出力の場合はテーマ文をフォールバック分割
+        probe_kws = theme.get("probe_keywords") or theme["theme"].split()[:5]
+        hits = probe_theme(probe_kws)
+        score, apis = calculate_coverage_score(hits)
+        theme["coverage_score"] = score
+        theme["primary_apis"] = apis
+        theme["probe_hits"] = hits
+
+    return themes

--- a/curator_agents/schemas.py
+++ b/curator_agents/schemas.py
@@ -9,12 +9,13 @@ from __future__ import annotations
 import logging
 from typing import Literal
 
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, ValidationError, field_validator
 
 from mystery_agents.schemas.mystery_id import (
     CLASSIFICATION_DESCRIPTIONS_EN,
     ClassificationCode,
 )
+from shared.api_coverage import VALID_API_KEYS
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +24,7 @@ ALL_CATEGORIES: list[str] = [code.value for code in ClassificationCode]
 
 # Literal 型（Pydantic 検証用）
 CategoryCode = Literal["HIS", "FLK", "ANT", "OCC", "URB", "CRM", "REL", "LOC"]
+CoverageScore = Literal["HIGH", "MEDIUM", "LOW"]
 
 
 class ThemeSuggestion(BaseModel):
@@ -31,6 +33,19 @@ class ThemeSuggestion(BaseModel):
     theme: str
     description: str
     category: CategoryCode
+    # プローブ後に上書きされるため optional
+    coverage_score: CoverageScore | None = None
+    primary_apis: list[str] = []
+    # LLM が出力、プローブで使用（未出力時はテーマ文をフォールバック分割）
+    probe_keywords: list[str] = []
+    # プローブ結果（API グループ → ヒット件数）
+    probe_hits: dict[str, int] = {}
+
+    @field_validator("primary_apis")
+    @classmethod
+    def filter_invalid_api_keys(cls, v: list[str]) -> list[str]:
+        """VALID_API_KEYS に含まれないキーを除外する（拒否はしない）。"""
+        return [k for k in v if k in VALID_API_KEYS]
 
 
 def validate_suggestions(raw: list) -> list[dict]:

--- a/services/curator.py
+++ b/services/curator.py
@@ -97,13 +97,16 @@ async def translate_suggestions(suggestions: list[dict]) -> list[dict]:
         )
         return suggestions
 
-    # Merge English and Japanese
+    # Merge English and Japanese（カバレッジフィールドを保持）
     ja_suggestions = translation.get("suggestions", [])
     bilingual = []
     for i, en_suggestion in enumerate(suggestions):
         entry = {
             "theme": en_suggestion.get("theme", ""),
             "description": en_suggestion.get("description", ""),
+            "coverage_score": en_suggestion.get("coverage_score"),
+            "primary_apis": en_suggestion.get("primary_apis", []),
+            "probe_hits": en_suggestion.get("probe_hits", {}),
         }
         if i < len(ja_suggestions):
             entry["theme_ja"] = ja_suggestions[i].get("theme", "")

--- a/shared/api_coverage.py
+++ b/shared/api_coverage.py
@@ -1,0 +1,165 @@
+"""API カバレッジメタデータ — Curator プロンプト + プローブスコア算出の両方で使用。
+
+各 API グループの言語・地域・全文信頼度を宣言し、
+Curator プロンプトへの動的テーブル挿入とプローブスコア算出ロジックを提供する。
+
+api_key は Librarian エージェントの API グループキー（api_librarians.py の API_CONFIGS と一致）、
+source_keys は source_registry のキー（nypl, chronicling_america 等）へのマッピング。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ApiCoverage:
+    """1 API グループのカバレッジメタデータ。"""
+
+    api_key: str
+    display_name: str
+    source_keys: tuple[str, ...]
+    languages: tuple[str, ...]
+    regions: tuple[str, ...]
+    time_period: str
+    fulltext_reliability: str  # "HIGH" / "MEDIUM" / "LOW"
+    fulltext_era: str
+
+
+API_COVERAGE_REGISTRY: dict[str, ApiCoverage] = {
+    "us_archives": ApiCoverage(
+        api_key="us_archives",
+        display_name="US Digital Archives (NYPL + Chronicling America)",
+        source_keys=("nypl", "chronicling_america"),
+        languages=("en",),
+        regions=("United States",),
+        time_period="1690-1963",
+        fulltext_reliability="HIGH",
+        fulltext_era="1770-1963 OCR",
+    ),
+    "europeana": ApiCoverage(
+        api_key="europeana",
+        display_name="Europeana",
+        source_keys=("europeana",),
+        languages=("de", "es", "fr", "nl", "pt"),
+        regions=("Europe (50+ countries)",),
+        time_period="Antiquity-present",
+        fulltext_reliability="LOW",
+        fulltext_era="Newspapers only full-text",
+    ),
+    "internet_archive": ApiCoverage(
+        api_key="internet_archive",
+        display_name="Internet Archive",
+        source_keys=("internet_archive",),
+        languages=("en", "de", "es", "fr", "nl", "pt", "ja"),
+        regions=("Global",),
+        time_period="All eras",
+        fulltext_reliability="HIGH",
+        fulltext_era="All eras, books/periodicals OCR",
+    ),
+    "ndl": ApiCoverage(
+        api_key="ndl",
+        display_name="NDL Search (National Diet Library, Japan)",
+        source_keys=("ndl",),
+        languages=("ja",),
+        regions=("Japan",),
+        time_period="Edo-Showa",
+        fulltext_reliability="MEDIUM",
+        fulltext_era="Meiji-Showa digitized",
+    ),
+    "delpher": ApiCoverage(
+        api_key="delpher",
+        display_name="KB/Delpher (Dutch National Library)",
+        source_keys=("delpher",),
+        languages=("nl",),
+        regions=("Netherlands", "Dutch colonies"),
+        time_period="1618-present",
+        fulltext_reliability="HIGH",
+        fulltext_era="1600s-1990s OCR",
+    ),
+    "trove": ApiCoverage(
+        api_key="trove",
+        display_name="Trove (National Library of Australia)",
+        source_keys=("trove",),
+        languages=("en",),
+        regions=("Australia", "Oceania"),
+        time_period="1803-present",
+        fulltext_reliability="HIGH",
+        fulltext_era="1800s-1950s newspaper OCR",
+    ),
+    "ndl_search": ApiCoverage(
+        api_key="ndl_search",
+        display_name="NDL Search (duplicate check)",
+        source_keys=("ndl",),
+        languages=("ja",),
+        regions=("Japan",),
+        time_period="Edo-Showa",
+        fulltext_reliability="MEDIUM",
+        fulltext_era="Meiji-Showa digitized",
+    ),
+}
+
+# ndl_search は source_registry のキー "ndl" と api_librarians の "ndl" が一致するため、
+# 重複エントリは削除し ndl のみ残す
+del API_COVERAGE_REGISTRY["ndl_search"]
+
+VALID_API_KEYS: frozenset[str] = frozenset(API_COVERAGE_REGISTRY)
+
+
+def build_coverage_prompt_table() -> str:
+    """Curator プロンプト用の API カバレッジテーブルを動的生成する。
+
+    Returns:
+        マークダウンテーブル形式の文字列
+    """
+    header = (
+        "| API | Languages | Regions | Coverage | "
+        "Full-text Reliability | Full-text Era |"
+    )
+    separator = (
+        "|-----|-----------|---------|----------|"
+        "----------------------|---------------|"
+    )
+    rows = [header, separator]
+    for cov in API_COVERAGE_REGISTRY.values():
+        langs = ", ".join(cov.languages)
+        regions = ", ".join(cov.regions)
+        rows.append(
+            f"| {cov.display_name} | {langs} | {regions} | "
+            f"{cov.time_period} | {cov.fulltext_reliability} | {cov.fulltext_era} |"
+        )
+    return "\n".join(rows)
+
+
+def calculate_coverage_score(
+    probe_results: dict[str, int],
+) -> tuple[str, list[str]]:
+    """プローブ結果からスコアと有効 API リストを算出する。
+
+    Args:
+        probe_results: {api_key: total_hits} 形式のプローブ結果
+
+    Returns:
+        (score, primary_apis) タプル。
+        score は "HIGH" / "MEDIUM" / "LOW"。
+        primary_apis はヒットがあった API キーのリスト。
+    """
+    # ヒットがあった API を抽出
+    hit_apis = [k for k, v in probe_results.items() if v > 0]
+    hit_count = len(hit_apis)
+
+    # 全文信頼度 HIGH の API がヒットに含まれるか
+    has_high_reliability = any(
+        API_COVERAGE_REGISTRY[k].fulltext_reliability == "HIGH"
+        for k in hit_apis
+        if k in API_COVERAGE_REGISTRY
+    )
+
+    if hit_count >= 3 and has_high_reliability:
+        score = "HIGH"
+    elif hit_count >= 2:
+        score = "MEDIUM"
+    else:
+        score = "LOW"
+
+    return score, hit_apis

--- a/tests/unit/test_api_coverage.py
+++ b/tests/unit/test_api_coverage.py
@@ -1,0 +1,125 @@
+"""Unit tests for shared/api_coverage.py.
+
+API カバレッジメタデータ、プロンプトテーブル生成、スコア算出ロジックをテストする。
+"""
+
+from shared.api_coverage import (
+    API_COVERAGE_REGISTRY,
+    VALID_API_KEYS,
+    ApiCoverage,
+    build_coverage_prompt_table,
+    calculate_coverage_score,
+)
+
+
+class TestApiCoverageRegistry:
+    """API_COVERAGE_REGISTRY の定義検証。"""
+
+    def test_contains_all_expected_apis(self):
+        """全 6 API グループが定義されていること。"""
+        expected = {"us_archives", "europeana", "internet_archive", "ndl", "delpher", "trove"}
+        assert set(API_COVERAGE_REGISTRY.keys()) == expected
+
+    def test_valid_api_keys_matches_registry(self):
+        assert VALID_API_KEYS == frozenset(API_COVERAGE_REGISTRY.keys())
+
+    def test_all_entries_are_api_coverage(self):
+        for key, cov in API_COVERAGE_REGISTRY.items():
+            assert isinstance(cov, ApiCoverage)
+            assert cov.api_key == key
+
+    def test_all_entries_have_source_keys(self):
+        """各 API グループに source_keys が1つ以上あること。"""
+        for key, cov in API_COVERAGE_REGISTRY.items():
+            assert len(cov.source_keys) >= 1, f"{key} に source_keys がない"
+
+    def test_fulltext_reliability_valid_values(self):
+        """fulltext_reliability が HIGH/MEDIUM/LOW のいずれかであること。"""
+        for key, cov in API_COVERAGE_REGISTRY.items():
+            assert cov.fulltext_reliability in ("HIGH", "MEDIUM", "LOW"), \
+                f"{key} の fulltext_reliability が不正: {cov.fulltext_reliability}"
+
+    def test_us_archives_has_two_source_keys(self):
+        """us_archives は nypl と chronicling_america の2つを持つこと。"""
+        cov = API_COVERAGE_REGISTRY["us_archives"]
+        assert set(cov.source_keys) == {"nypl", "chronicling_america"}
+
+
+class TestBuildCoveragePromptTable:
+    """build_coverage_prompt_table() のテスト。"""
+
+    def test_contains_all_api_names(self):
+        table = build_coverage_prompt_table()
+        for cov in API_COVERAGE_REGISTRY.values():
+            assert cov.display_name in table
+
+    def test_contains_regions(self):
+        table = build_coverage_prompt_table()
+        assert "United States" in table
+        assert "Japan" in table
+        assert "Australia" in table
+
+    def test_contains_fulltext_reliability(self):
+        table = build_coverage_prompt_table()
+        assert "HIGH" in table
+        assert "MEDIUM" in table
+        assert "LOW" in table
+
+    def test_is_markdown_table(self):
+        """マークダウンテーブル形式であること（ヘッダ + セパレータ + データ行）。"""
+        table = build_coverage_prompt_table()
+        lines = table.strip().split("\n")
+        assert lines[0].startswith("|")
+        assert "---" in lines[1]
+        # データ行 = 全 API 数
+        assert len(lines) == 2 + len(API_COVERAGE_REGISTRY)
+
+
+class TestCalculateCoverageScore:
+    """calculate_coverage_score() のスコア算出ロジックテスト。"""
+
+    def test_high_score_three_apis_with_high_reliability(self):
+        """3+ API ヒット、うち 1+ が HIGH → HIGH。"""
+        probe = {"us_archives": 5, "internet_archive": 3, "trove": 2}
+        score, apis = calculate_coverage_score(probe)
+        assert score == "HIGH"
+        assert set(apis) == {"us_archives", "internet_archive", "trove"}
+
+    def test_medium_score_two_apis(self):
+        """2 API ヒット → MEDIUM。"""
+        probe = {"europeana": 3, "ndl": 1}
+        score, apis = calculate_coverage_score(probe)
+        assert score == "MEDIUM"
+        assert set(apis) == {"europeana", "ndl"}
+
+    def test_high_score_three_apis_with_delpher(self):
+        """3 API ヒットで delpher(HIGH) 含む → HIGH。"""
+        probe = {"europeana": 3, "ndl": 2, "delpher": 1}
+        score, apis = calculate_coverage_score(probe)
+        assert score == "HIGH"
+
+    def test_low_score_single_api(self):
+        """1 API のみヒット → LOW。"""
+        probe = {"ndl": 5}
+        score, apis = calculate_coverage_score(probe)
+        assert score == "LOW"
+
+    def test_low_score_no_hits(self):
+        """全 API ヒットなし → LOW。"""
+        probe = {"us_archives": 0, "europeana": 0}
+        score, apis = calculate_coverage_score(probe)
+        assert score == "LOW"
+        assert apis == []
+
+    def test_low_score_empty_probe(self):
+        """空の probe_results → LOW。"""
+        score, apis = calculate_coverage_score({})
+        assert score == "LOW"
+        assert apis == []
+
+    def test_unknown_api_key_ignored_for_reliability_check(self):
+        """未知の API キーは信頼度チェックで無視される。"""
+        probe = {"unknown_api_1": 5, "unknown_api_2": 3, "unknown_api_3": 2}
+        score, apis = calculate_coverage_score(probe)
+        # 3 API ヒットだが全て未知 → HIGH reliability なし → MEDIUM
+        assert score == "MEDIUM"

--- a/tests/unit/test_curator_core.py
+++ b/tests/unit/test_curator_core.py
@@ -6,13 +6,23 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 
+def _identity_probe(themes):
+    """プローブをモックするヘルパー: テーマにダミーのカバレッジフィールドを付与。"""
+    for t in themes:
+        t["coverage_score"] = "HIGH"
+        t["primary_apis"] = ["us_archives"]
+        t["probe_hits"] = {"us_archives": 5}
+    return themes
+
+
 @pytest.fixture
 def mock_firestore_queries():
-    """Firestore クエリ3つをモック。"""
+    """Firestore クエリ3つ + プローブをモック。"""
     with patch("curator_agents.core.get_existing_titles", return_value=["Theme A"]), \
          patch("curator_agents.core.get_recent_failures", return_value=[]), \
          patch("curator_agents.core.get_category_distribution", return_value={"HIS": 2}), \
-         patch("curator_agents.core.format_category_distribution", return_value="HIS: 2"):
+         patch("curator_agents.core.format_category_distribution", return_value="HIS: 2"), \
+         patch("curator_agents.core.probe_all_themes", side_effect=_identity_probe):
         yield
 
 
@@ -141,3 +151,19 @@ class TestSuggestThemes:
 
             with pytest.raises(ValueError, match="failure marker"):
                 await suggest_themes()
+
+    @pytest.mark.asyncio
+    async def test_includes_coverage_score_after_probe(self, mock_firestore_queries, valid_agent_output):
+        """Should include coverage_score from probe in results."""
+        with patch(
+            "curator_agents.core.run_single_agent",
+            new_callable=AsyncMock,
+            return_value=valid_agent_output,
+        ):
+            from curator_agents.core import suggest_themes
+
+            result = await suggest_themes()
+
+        assert result[0]["coverage_score"] == "HIGH"
+        assert result[0]["primary_apis"] == ["us_archives"]
+        assert result[0]["probe_hits"] == {"us_archives": 5}

--- a/tests/unit/test_curator_probe.py
+++ b/tests/unit/test_curator_probe.py
@@ -1,0 +1,123 @@
+"""Unit tests for curator_agents/probe.py.
+
+API プローブの並列実行、ヒット集約、エラー時のグレースフルデグラデーションをテストする。
+"""
+
+from unittest.mock import MagicMock, patch
+
+from curator_agents.probe import probe_all_themes, probe_theme
+
+
+def _make_mock_source(source_key: str, total_hits: int = 0, raise_error: bool = False):
+    """テスト用のモックソースを生成する。"""
+    source = MagicMock()
+    source.source_key = source_key
+    if raise_error:
+        source.search.side_effect = Exception("API error")
+    else:
+        result = MagicMock()
+        result.total_hits = total_hits
+        source.search.return_value = result
+    return source
+
+
+class TestProbeTheme:
+    """probe_theme() のテスト。"""
+
+    def test_aggregates_hits_by_api_group(self):
+        """source_key レベルの結果を API グループレベルに集約すること。"""
+        mock_sources = {
+            "nypl": _make_mock_source("nypl", total_hits=5),
+            "chronicling_america": _make_mock_source("chronicling_america", total_hits=3),
+            "europeana": _make_mock_source("europeana", total_hits=2),
+            "internet_archive": _make_mock_source("internet_archive", total_hits=0),
+        }
+        with patch("curator_agents.probe.get_all_sources", return_value=mock_sources):
+            result = probe_theme(["Boston", "1850"])
+
+        # nypl + chronicling_america → us_archives に集約
+        assert result.get("us_archives", 0) == 8
+        assert result.get("europeana", 0) == 2
+        # internet_archive はヒット0だが結果には含まれる
+        assert result.get("internet_archive", 0) == 0
+
+    def test_calls_search_with_max_results_1(self):
+        """search を max_results=1 で呼ぶこと。"""
+        mock_source = _make_mock_source("nypl", total_hits=10)
+        mock_sources = {"nypl": mock_source}
+        with patch("curator_agents.probe.get_all_sources", return_value=mock_sources):
+            probe_theme(["test"])
+
+        mock_source.search.assert_called_once_with(["test"], max_results=1)
+
+    def test_graceful_on_api_error(self):
+        """API エラー時は該当ソースをスキップし、他のソースの結果を返すこと。"""
+        mock_sources = {
+            "nypl": _make_mock_source("nypl", raise_error=True),
+            "europeana": _make_mock_source("europeana", total_hits=5),
+        }
+        with patch("curator_agents.probe.get_all_sources", return_value=mock_sources):
+            result = probe_theme(["test"])
+
+        # nypl はエラーで結果なし、europeana は正常
+        assert "us_archives" not in result or result.get("us_archives", 0) == 0
+        assert result.get("europeana", 0) == 5
+
+    def test_empty_sources_returns_empty(self):
+        """ソースが空の場合は空 dict を返すこと。"""
+        with patch("curator_agents.probe.get_all_sources", return_value={}):
+            result = probe_theme(["test"])
+        assert result == {}
+
+
+class TestProbeAllThemes:
+    """probe_all_themes() のテスト。"""
+
+    def test_adds_coverage_fields_to_themes(self):
+        """各テーマに coverage_score, primary_apis, probe_hits が付与されること。"""
+        themes = [
+            {"theme": "Boston Harbor Ghosts", "description": "Test", "category": "OCC",
+             "probe_keywords": ["Boston", "harbor", "ghost"]},
+        ]
+        mock_sources = {
+            "nypl": _make_mock_source("nypl", total_hits=5),
+            "chronicling_america": _make_mock_source("chronicling_america", total_hits=3),
+            "internet_archive": _make_mock_source("internet_archive", total_hits=2),
+            "trove": _make_mock_source("trove", total_hits=1),
+        }
+        with patch("curator_agents.probe.get_all_sources", return_value=mock_sources):
+            result = probe_all_themes(themes)
+
+        assert len(result) == 1
+        assert result[0]["coverage_score"] in ("HIGH", "MEDIUM", "LOW")
+        assert isinstance(result[0]["primary_apis"], list)
+        assert isinstance(result[0]["probe_hits"], dict)
+
+    def test_fallback_keywords_when_probe_keywords_missing(self):
+        """probe_keywords が空の場合、テーマ文を分割してフォールバックすること。"""
+        themes = [
+            {"theme": "Boston Harbor Ghosts 1850", "description": "Test", "category": "OCC"},
+        ]
+        mock_sources = {
+            "nypl": _make_mock_source("nypl", total_hits=1),
+        }
+        with patch("curator_agents.probe.get_all_sources", return_value=mock_sources) as _:
+            probe_all_themes(themes)
+
+        # search が呼ばれたキーワードがテーマの先頭5単語であること
+        mock_sources["nypl"].search.assert_called_once()
+        call_args = mock_sources["nypl"].search.call_args
+        assert call_args[0][0] == ["Boston", "Harbor", "Ghosts", "1850"]
+
+    def test_preserves_existing_theme_fields(self):
+        """既存のテーマフィールド（theme, description, category）が保持されること。"""
+        themes = [
+            {"theme": "Test Theme", "description": "Desc", "category": "HIS",
+             "probe_keywords": ["test"]},
+        ]
+        with patch("curator_agents.probe.get_all_sources", return_value={}):
+            result = probe_all_themes(themes)
+
+        assert result[0]["theme"] == "Test Theme"
+        assert result[0]["description"] == "Desc"
+        assert result[0]["category"] == "HIS"

--- a/tests/unit/test_curator_schemas.py
+++ b/tests/unit/test_curator_schemas.py
@@ -45,6 +45,53 @@ class TestThemeSuggestion:
         with pytest.raises(Exception):
             ThemeSuggestion.model_validate(data)
 
+    def test_coverage_score_accepts_valid_values(self):
+        """coverage_score が HIGH/MEDIUM/LOW/None を受け入れること。"""
+        for score in ("HIGH", "MEDIUM", "LOW"):
+            data = {
+                "theme": "T", "description": "D", "category": "HIS",
+                "coverage_score": score,
+            }
+            s = ThemeSuggestion.model_validate(data)
+            assert s.coverage_score == score
+
+    def test_coverage_score_defaults_to_none(self):
+        """coverage_score 未指定時は None がデフォルトであること。"""
+        data = {"theme": "T", "description": "D", "category": "HIS"}
+        s = ThemeSuggestion.model_validate(data)
+        assert s.coverage_score is None
+
+    def test_probe_keywords_defaults_to_empty_list(self):
+        """probe_keywords 未指定時は空リストがデフォルトであること。"""
+        data = {"theme": "T", "description": "D", "category": "HIS"}
+        s = ThemeSuggestion.model_validate(data)
+        assert s.probe_keywords == []
+
+    def test_probe_hits_defaults_to_empty_dict(self):
+        """probe_hits 未指定時は空 dict がデフォルトであること。"""
+        data = {"theme": "T", "description": "D", "category": "HIS"}
+        s = ThemeSuggestion.model_validate(data)
+        assert s.probe_hits == {}
+
+    def test_primary_apis_filters_invalid_keys(self):
+        """primary_apis の不正な API キーが除外されること。"""
+        data = {
+            "theme": "T", "description": "D", "category": "HIS",
+            "primary_apis": ["us_archives", "invalid_api", "trove"],
+        }
+        s = ThemeSuggestion.model_validate(data)
+        assert s.primary_apis == ["us_archives", "trove"]
+
+    def test_primary_apis_accepts_all_valid_keys(self):
+        """全有効 API キーが受け入れられること。"""
+        from shared.api_coverage import VALID_API_KEYS
+        data = {
+            "theme": "T", "description": "D", "category": "HIS",
+            "primary_apis": list(VALID_API_KEYS),
+        }
+        s = ThemeSuggestion.model_validate(data)
+        assert set(s.primary_apis) == VALID_API_KEYS
+
 
 class TestValidateSuggestions:
     """validate_suggestions() のテスト。"""
@@ -93,6 +140,24 @@ class TestValidateSuggestions:
         with caplog.at_level(logging.WARNING, logger="curator_agents.schemas"):
             validate_suggestions([{"bad": "data"}])
         assert "テーマ提案 #0 を除外" in caplog.text
+
+    def test_preserves_coverage_fields(self):
+        """validate_suggestions がカバレッジフィールドを保持すること。"""
+        raw = [
+            {
+                "theme": "Theme A", "description": "Desc A", "category": "HIS",
+                "coverage_score": "HIGH",
+                "primary_apis": ["us_archives", "trove"],
+                "probe_keywords": ["Boston", "1850"],
+                "probe_hits": {"us_archives": 5, "trove": 2},
+            },
+        ]
+        result = validate_suggestions(raw)
+        assert len(result) == 1
+        assert result[0]["coverage_score"] == "HIGH"
+        assert result[0]["primary_apis"] == ["us_archives", "trove"]
+        assert result[0]["probe_keywords"] == ["Boston", "1850"]
+        assert result[0]["probe_hits"] == {"us_archives": 5, "trove": 2}
 
 
 class TestBuildCategoryPromptSection:

--- a/tests/unit/test_curator_server.py
+++ b/tests/unit/test_curator_server.py
@@ -289,10 +289,14 @@ class TestTranslateSuggestionsMerge:
     @pytest.mark.asyncio
     async def test_merges_translator_output_with_correct_keys(self):
         """Translator が返す {suggestions: [{theme, description}]} 形式を正しくマージする。"""
-        # Curator の出力には category が含まれる（実フロー準拠）
+        # Curator の出力には category + カバレッジフィールドが含まれる（実フロー準拠）
         en_suggestions = [
-            {"theme": "Ghost Ships", "description": "Maritime mysteries", "category": "OCC"},
-            {"theme": "Voodoo Queen", "description": "New Orleans legends", "category": "FLK"},
+            {"theme": "Ghost Ships", "description": "Maritime mysteries", "category": "OCC",
+             "coverage_score": "HIGH", "primary_apis": ["us_archives", "trove"],
+             "probe_hits": {"us_archives": 5, "trove": 2}},
+            {"theme": "Voodoo Queen", "description": "New Orleans legends", "category": "FLK",
+             "coverage_score": "MEDIUM", "primary_apis": ["us_archives"],
+             "probe_hits": {"us_archives": 3}},
         ]
         # Translator エージェントの出力形式: サフィックスなしの素のフィールド名
         translator_output = json.dumps({
@@ -325,6 +329,11 @@ class TestTranslateSuggestionsMerge:
         assert result[0]["description_ja"] == "海の怪異"
         assert result[1]["theme_ja"] == "ヴードゥーの女王"
         assert result[1]["description_ja"] == "ニューオーリンズの伝説"
+        # カバレッジフィールドが保持されていること
+        assert result[0]["coverage_score"] == "HIGH"
+        assert result[0]["primary_apis"] == ["us_archives", "trove"]
+        assert result[0]["probe_hits"] == {"us_archives": 5, "trove": 2}
+        assert result[1]["coverage_score"] == "MEDIUM"
 
     @pytest.mark.asyncio
     async def test_returns_english_only_when_json_parse_fails(self, caplog):

--- a/web-admin/src/components/investigation-form.tsx
+++ b/web-admin/src/components/investigation-form.tsx
@@ -14,11 +14,31 @@ const STORYTELLER_OPTIONS = [
   { value: "mistral", label: "Mistral Large" },
 ] as const
 
+// API キー → 表示名マッピング
+const API_DISPLAY_NAMES: Record<string, string> = {
+  us_archives: "US Archives",
+  europeana: "Europeana",
+  internet_archive: "Internet Archive",
+  ndl: "NDL",
+  delpher: "Delpher",
+  trove: "Trove",
+}
+
+// カバレッジスコアの色分け
+const COVERAGE_BADGE_STYLES: Record<string, string> = {
+  HIGH: "bg-emerald-900/40 text-emerald-400 border-emerald-700/50",
+  MEDIUM: "bg-amber-900/40 text-amber-400 border-amber-700/50",
+  LOW: "bg-red-900/40 text-red-400 border-red-700/50",
+}
+
 interface ThemeSuggestion {
   theme: string
   description: string
   theme_ja?: string
   description_ja?: string
+  coverage_score?: "HIGH" | "MEDIUM" | "LOW"
+  primary_apis?: string[]
+  probe_hits?: Record<string, number>
 }
 
 interface InvestigationFormProps {
@@ -107,11 +127,31 @@ export function InvestigationForm({
               onClick={() => onSelectSuggestion(s.theme)}
               className="text-left p-3 border border-border/50 rounded-sm hover:border-gold/30 hover:bg-gold/5 transition-colors"
             >
-              <p className="text-sm font-medium text-parchment mb-1">{s.theme}</p>
+              <div className="flex items-center gap-2 mb-1">
+                <p className="text-sm font-medium text-parchment flex-1">{s.theme}</p>
+                {s.coverage_score && (
+                  <span className={`text-[10px] font-mono px-1.5 py-0.5 rounded border ${COVERAGE_BADGE_STYLES[s.coverage_score]}`}>
+                    {s.coverage_score}
+                  </span>
+                )}
+              </div>
               {s.theme_ja && (
                 <p className="text-xs text-muted-foreground mb-1">{s.theme_ja}</p>
               )}
-              <p className="text-xs text-muted-foreground">{s.description_ja || s.description}</p>
+              <p className="text-xs text-muted-foreground mb-1.5">{s.description_ja || s.description}</p>
+              {s.primary_apis && s.primary_apis.length > 0 && (
+                <div className="flex flex-wrap gap-1">
+                  {s.primary_apis.map((api) => (
+                    <span
+                      key={api}
+                      className="text-[10px] font-mono px-1.5 py-0.5 bg-border/30 text-muted-foreground rounded"
+                    >
+                      {API_DISPLAY_NAMES[api] || api}
+                      {s.probe_hits?.[api] != null && ` (${s.probe_hits[api]})`}
+                    </span>
+                  ))}
+                </div>
+              )}
             </button>
           ))}
         </div>

--- a/web-admin/src/hooks/use-investigation.ts
+++ b/web-admin/src/hooks/use-investigation.ts
@@ -8,6 +8,9 @@ interface ThemeSuggestion {
   description: string
   theme_ja?: string
   description_ja?: string
+  coverage_score?: "HIGH" | "MEDIUM" | "LOW"
+  primary_apis?: string[]
+  probe_hits?: Record<string, number>
 }
 
 interface UseInvestigationOptions {


### PR DESCRIPTION
## Summary

- テーマ提案時に全7 API へ軽量プローブ検索（`max_results=1`）を並列実行し、実際のヒット件数に基づいた `coverage_score`（HIGH/MEDIUM/LOW）を算出
- 管理画面にカバレッジバッジ（色分け: 緑/黄/赤）と API タグ（ヒット件数付き）を表示
- Curator プロンプトの API テーブルを `shared/api_coverage.py` から動的生成に置換（地域・全文信頼度列を追加）
- LLM に `probe_keywords` 出力を必須指示し、プローブで検証用キーワードとして使用

### スコア算出ロジック
| スコア | 条件 |
|--------|------|
| HIGH | ヒット API 数 ≥ 3、かつうち 1+ が全文信頼度 HIGH |
| MEDIUM | ヒット API 数 = 2、または全文信頼度 HIGH の API がない |
| LOW | ヒット API 数 ≤ 1 |

### 変更ファイル
| ファイル | 操作 |
|---------|------|
| `shared/api_coverage.py` | 新規 |
| `curator_agents/probe.py` | 新規 |
| `curator_agents/schemas.py` | 編集 |
| `curator_agents/agents/curator.py` | 編集 |
| `curator_agents/core.py` | 編集 |
| `services/curator.py` | 編集 |
| `web-admin/src/hooks/use-investigation.ts` | 編集 |
| `web-admin/src/components/investigation-form.tsx` | 編集 |
| `tests/unit/test_api_coverage.py` | 新規 |
| `tests/unit/test_curator_probe.py` | 新規 |
| `tests/unit/test_curator_schemas.py` | 編集 |
| `tests/unit/test_curator_core.py` | 編集 |
| `tests/unit/test_curator_server.py` | 編集 |

## Test plan
- [x] `pytest tests/unit/test_api_coverage.py tests/unit/test_curator_probe.py tests/unit/test_curator_schemas.py tests/unit/test_curator_core.py tests/unit/test_curator_server.py -v` — 全75テスト合格
- [ ] `python -m curator_agents` で CLI 実行し、出力 JSON に `coverage_score` + `primary_apis` + `probe_hits` が含まれることを確認
- [ ] Admin UI で「テーマ提案」ボタンを押し、カバレッジバッジ・API タグ・ヒット件数が表示されることを確認

Closes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)