### PR TITLE
feat: Librarian 全文取得メトリクス導入 + NO_FULLTEXT_AVAILABLE 早期終了

### DIFF
--- a/mystery_agents/agents/aggregator.py
+++ b/mystery_agents/agents/aggregator.py
@@ -19,6 +19,7 @@ from google.genai import types
 from shared.language_names import get_language_name
 from shared.state_keys import (
     ACTIVE_LANGUAGES,
+    FULLTEXT_METRICS,
     RAW_SEARCH_RESULTS,
     SELECTED_LANGUAGES,
     collected_documents_key,
@@ -62,25 +63,40 @@ class AggregatorAgent(BaseAgent):
             reverse=True,
         )
 
+        # 全文メトリクス算出
+        fulltext_metrics = _compute_fulltext_metrics(docs_by_lang, active_languages)
+
+        global_fulltext = fulltext_metrics["fulltext_documents"]
+
         # state_delta を構築
         state_delta: dict[str, object] = {}
 
         for lang in active_languages:
             docs = docs_by_lang[lang]
-            text = _format_documents(lang, docs)
+            lang_stats = fulltext_metrics["by_language"].get(lang, {})
+            text = _format_documents(
+                lang,
+                docs,
+                lang_fulltext=lang_stats.get("fulltext", 0),
+                lang_metadata_only=lang_stats.get("metadata_only", 0),
+                global_fulltext=global_fulltext,
+            )
             state_delta[collected_documents_key(lang)] = text
 
         state_delta[ACTIVE_LANGUAGES] = active_languages
+        state_delta[FULLTEXT_METRICS] = fulltext_metrics
 
         # selected_languages を active_languages で更新（Scholar/debate layer 互換）
         if active_languages:
             state_delta[SELECTED_LANGUAGES] = active_languages
 
         total_docs = sum(len(d) for d in docs_by_lang.values())
+        ft = fulltext_metrics["fulltext_documents"]
         summary = (
             f"Aggregated {total_docs} documents across "
             f"{len(active_languages)} languages: "
             f"{', '.join(f'{lang}({len(docs_by_lang[lang])})' for lang in active_languages)}"
+            f" Full text: {ft}/{total_docs}"
         )
         logger.info(
             "Aggregator: %s",
@@ -88,6 +104,7 @@ class AggregatorAgent(BaseAgent):
             extra={
                 "active_languages": active_languages,
                 "total_documents": total_docs,
+                "fulltext_documents": ft,
                 "docs_per_language": {
                     lang: len(docs_by_lang[lang]) for lang in active_languages
                 },
@@ -105,22 +122,71 @@ class AggregatorAgent(BaseAgent):
         )
 
 
-def _format_documents(lang: str, docs: list[dict]) -> str:
+def _deduplicate_docs(docs: list[dict]) -> list[dict]:
+    """URL ベースでドキュメントを重複除去する。"""
+    seen_urls: set[str] = set()
+    unique: list[dict] = []
+    for doc in docs:
+        url = doc.get("source_url", "")
+        if url and url not in seen_urls:
+            seen_urls.add(url)
+            unique.append(doc)
+        elif not url:
+            unique.append(doc)
+    return unique
+
+
+def _compute_fulltext_metrics(
+    docs_by_lang: dict[str, list[dict]],
+    active_languages: list[str],
+) -> dict:
+    """全文テキスト取得メトリクスを算出する。
+
+    Returns:
+        {
+            "total_documents": int,
+            "fulltext_documents": int,
+            "metadata_only_documents": int,
+            "by_language": {
+                lang: {"total": int, "fulltext": int, "metadata_only": int},
+                ...
+            }
+        }
+    """
+    by_language: dict[str, dict[str, int]] = {}
+    total = 0
+    total_ft = 0
+
+    for lang in active_languages:
+        docs = _deduplicate_docs(docs_by_lang[lang])
+        ft = sum(1 for d in docs if d.get("raw_text"))
+        mo = len(docs) - ft
+        by_language[lang] = {"total": len(docs), "fulltext": ft, "metadata_only": mo}
+        total += len(docs)
+        total_ft += ft
+
+    return {
+        "total_documents": total,
+        "fulltext_documents": total_ft,
+        "metadata_only_documents": total - total_ft,
+        "by_language": by_language,
+    }
+
+
+def _format_documents(
+    lang: str,
+    docs: list[dict],
+    *,
+    lang_fulltext: int = 0,
+    lang_metadata_only: int = 0,
+    global_fulltext: int = 0,
+) -> str:
     """ドキュメントリストを Scholar が読める形式にフォーマットする。
 
     重複 URL を除去し、各ドキュメントのメタデータとテキスト抜粋を
     構造化テキストとして整形する。
     """
-    # URL 重複除去
-    seen_urls: set[str] = set()
-    unique_docs: list[dict] = []
-    for doc in docs:
-        url = doc.get("source_url", "")
-        if url and url not in seen_urls:
-            seen_urls.add(url)
-            unique_docs.append(doc)
-        elif not url:
-            unique_docs.append(doc)
+    unique_docs = _deduplicate_docs(docs)
 
     lang_name = get_language_name(lang)
 
@@ -128,8 +194,16 @@ def _format_documents(lang: str, docs: list[dict]) -> str:
         return f"NO_DOCUMENTS_FOUND: No {lang_name}-language documents collected."
 
     lines = [
-        f"# Collected Documents ({lang_name}) — {len(unique_docs)} documents\n"
+        f"# Collected Documents ({lang_name}) — {len(unique_docs)} documents"
+        f" ({lang_fulltext} with full text, {lang_metadata_only} metadata-only)\n"
     ]
+
+    # 全言語合計の全文ドキュメントが 1-2 件の場合、限定的証拠の注記
+    if 0 < global_fulltext <= 2:
+        lines.append(
+            f"> **Note**: Only {global_fulltext} document(s) with full text available "
+            f"across all languages. Analysis may be limited.\n"
+        )
 
     for i, doc in enumerate(unique_docs, 1):
         lines.append(f"## [{i}] {doc.get('title', 'Untitled')}")
@@ -152,6 +226,8 @@ def _format_documents(lang: str, docs: list[dict]) -> str:
             if len(str(doc["raw_text"])) > 3000:
                 excerpt += "..."
             lines.append(f"- **Excerpt**: {excerpt}")
+        else:
+            lines.append("- **Excerpt**: [metadata only — full text not available]")
         lines.append("")  # ドキュメント間の空行
 
     return "\n".join(lines)

--- a/mystery_agents/agents/pipeline_gate.py
+++ b/mystery_agents/agents/pipeline_gate.py
@@ -14,6 +14,7 @@ from google.genai import types
 from shared.constants import DEFAULT_SELECTED_LANGUAGES, is_meaningful
 from shared.state_keys import (
     CREATIVE_CONTENT,
+    FULLTEXT_METRICS,
     INVESTIGATION_QUERY,
     MYSTERY_REPORT,
     PIPELINE_RUN_ID,
@@ -60,24 +61,43 @@ def make_scholar_gate():
         if not isinstance(selected, list):
             selected = list(DEFAULT_SELECTED_LANGUAGES)
 
+        has_docs = False
         for lang in selected:
             docs = callback_context.state.get(collected_documents_key(lang), "")
             if _is_meaningful(docs):
-                logger.info(
-                    "Pipeline gate [scholar]: 通過（%s に有意なデータあり）", lang,
-                    extra={"gate_name": "scholar", "decision": "pass"},
-                )
-                return None  # 有意なデータあり → 実行
+                has_docs = True
+                break
 
-        message = (
-            "INSUFFICIENT_DATA: All Librarians returned no documents. "
-            "Pipeline terminated to conserve resources."
+        if not has_docs:
+            message = (
+                "INSUFFICIENT_DATA: All Librarians returned no documents. "
+                "Pipeline terminated to conserve resources."
+            )
+            _log_and_record_failure(callback_context, "librarian", message)
+            return types.Content(
+                parts=[types.Part(text=message)],
+                role="model",
+            )
+
+        # Check 2: 全文ドキュメントが 0 件なら早期終了
+        metrics = callback_context.state.get(FULLTEXT_METRICS)
+        if isinstance(metrics, dict) and metrics.get("fulltext_documents", -1) == 0:
+            message = (
+                "NO_FULLTEXT_AVAILABLE: Documents found but none contain full text. "
+                "Scholar analysis requires full text excerpts. "
+                "Pipeline terminated to conserve resources."
+            )
+            _log_and_record_failure(callback_context, "aggregator", message)
+            return types.Content(
+                parts=[types.Part(text=message)],
+                role="model",
+            )
+
+        logger.info(
+            "Pipeline gate [scholar]: 通過",
+            extra={"gate_name": "scholar", "decision": "pass"},
         )
-        _log_and_record_failure(callback_context, "librarian", message)
-        return types.Content(
-            parts=[types.Part(text=message)],
-            role="model",
-        )
+        return None
 
     return gate
 

--- a/shared/constants.py
+++ b/shared/constants.py
@@ -43,6 +43,7 @@ SCHEMA_VERSION = 2
 # セッション状態の値がこれらで始まる場合、有意なデータなしと判定する。
 FAILURE_MARKERS: frozenset[str] = frozenset({
     "NO_DOCUMENTS_FOUND",
+    "NO_FULLTEXT_AVAILABLE",
     "INSUFFICIENT_DATA",
     "NO_CONTENT",
     "Not available",

--- a/shared/state_keys.py
+++ b/shared/state_keys.py
@@ -33,6 +33,7 @@ INVESTIGATION_QUERY = "investigation_query"
 PIPELINE_RUN_ID = "pipeline_run_id"
 STORYTELLER_LLM_METADATA = "storyteller_llm_metadata"
 WORD_COUNT_TIER = "_word_count_tier"
+FULLTEXT_METRICS = "fulltext_metrics"
 SEARCH_LOG = "search_log"
 AGENT_TOKEN_LOG = "_agent_token_log"
 

--- a/shared/state_registry.py
+++ b/shared/state_registry.py
@@ -212,6 +212,12 @@ STATE_KEYS: list[StateKey] = [
         read_by=("script_planner", "scriptwriter", "alchemist"),
     ),
     StateKey(
+        name="fulltext_metrics",
+        description="Aggregator が算出する全文テキスト取得指標（全言語合計 + 言語別）",
+        written_by=("aggregator",),
+        read_by=("pipeline_gate",),
+    ),
+    StateKey(
         name="search_log",
         description="Librarian 検索活動ログ（API 別統計・キーワード分類を蓄積、Publisher が Firestore 永続化）",
         written_by=("librarian_tools",),

--- a/tests/unit/test_aggregator.py
+++ b/tests/unit/test_aggregator.py
@@ -4,7 +4,11 @@ raw_search_results からの言語別集約ロジックを検証する。
 """
 
 
-from mystery_agents.agents.aggregator import _format_documents, create_aggregator
+from mystery_agents.agents.aggregator import (
+    _compute_fulltext_metrics,
+    _format_documents,
+    create_aggregator,
+)
 
 
 class TestFormatDocuments:
@@ -132,6 +136,102 @@ class TestFormatDocuments:
         ]
         result = _format_documents("it", docs)
         assert "Italian" in result
+
+
+class TestFulltextMetrics:
+    """全文テキスト取得メトリクス関連のテスト。"""
+
+    def test_header_includes_fulltext_metrics(self):
+        """ヘッダーに全文/メタデータ専用の内訳が含まれる。"""
+        docs = [
+            {
+                "title": "Doc with text",
+                "source_url": "https://example.com/1",
+                "language": "en",
+                "source_type": "loc",
+                "raw_text": "Full text content here",
+            },
+            {
+                "title": "Doc without text",
+                "source_url": "https://example.com/2",
+                "language": "en",
+                "source_type": "loc",
+            },
+        ]
+        result = _format_documents(
+            "en", docs, lang_fulltext=1, lang_metadata_only=1, global_fulltext=5,
+        )
+        assert "(1 with full text, 1 metadata-only)" in result
+
+    def test_metadata_only_label(self):
+        """raw_text なしドキュメントにメタデータ専用ラベルが付く。"""
+        docs = [
+            {
+                "title": "Metadata Only Doc",
+                "source_url": "https://example.com/meta",
+                "language": "en",
+                "source_type": "loc",
+            },
+        ]
+        result = _format_documents("en", docs)
+        assert "[metadata only — full text not available]" in result
+
+    def test_limited_evidence_note(self):
+        """全言語合計の全文ドキュメントが 1-2 件の場合、限定的証拠の注記が出る。"""
+        docs = [
+            {
+                "title": "Sole Doc",
+                "source_url": "https://example.com/sole",
+                "language": "en",
+                "source_type": "loc",
+                "raw_text": "Some text",
+            },
+        ]
+        result = _format_documents(
+            "en", docs, lang_fulltext=1, lang_metadata_only=0, global_fulltext=1,
+        )
+        assert "Only 1 document(s) with full text available" in result
+
+    def test_no_limited_note_when_enough_fulltext(self):
+        """全文ドキュメントが 3+ 件の場合、限定的証拠の注記は出ない。"""
+        docs = [
+            {
+                "title": "Doc",
+                "source_url": "https://example.com/doc",
+                "language": "en",
+                "source_type": "loc",
+                "raw_text": "Text",
+            },
+        ]
+        result = _format_documents(
+            "en", docs, lang_fulltext=1, lang_metadata_only=0, global_fulltext=5,
+        )
+        assert "Only" not in result
+        assert "limited" not in result.lower()
+
+
+class TestComputeFulltextMetrics:
+    """_compute_fulltext_metrics のテスト。"""
+
+    def test_mixed_docs(self):
+        """全文あり/なしが混在するケースでメトリクスが正しく算出される。"""
+        docs_by_lang = {
+            "en": [
+                {"source_url": "https://a.com/1", "raw_text": "text"},
+                {"source_url": "https://a.com/2"},
+                {"source_url": "https://a.com/3", "raw_text": "more text"},
+            ],
+            "de": [
+                {"source_url": "https://b.com/1"},
+                {"source_url": "https://b.com/2"},
+            ],
+        }
+        metrics = _compute_fulltext_metrics(docs_by_lang, ["en", "de"])
+        assert metrics["total_documents"] == 5
+        assert metrics["fulltext_documents"] == 2
+        assert metrics["metadata_only_documents"] == 3
+        assert metrics["by_language"]["en"]["fulltext"] == 2
+        assert metrics["by_language"]["de"]["metadata_only"] == 2
 
 
 class TestCreateAggregator:

--- a/tests/unit/test_pipeline_gate.py
+++ b/tests/unit/test_pipeline_gate.py
@@ -116,6 +116,71 @@ class TestScholarGate:
         assert result is None
 
 
+class TestScholarGateFulltext:
+    """ScholarGate の全文チェック関連テスト。"""
+
+    def test_no_fulltext_terminates(self, caplog):
+        """全文ドキュメントが 0 件で NO_FULLTEXT_AVAILABLE を返す。"""
+        ctx = MockCallbackContext(state={
+            "selected_languages": ["en"],
+            "collected_documents_en": "# Collected Documents (English) — 3 documents...",
+            "fulltext_metrics": {
+                "total_documents": 3,
+                "fulltext_documents": 0,
+                "metadata_only_documents": 3,
+                "by_language": {"en": {"total": 3, "fulltext": 0, "metadata_only": 3}},
+            },
+        })
+        gate = make_scholar_gate()
+        result = gate(ctx)
+        assert result is not None
+        assert "NO_FULLTEXT_AVAILABLE" in caplog.text
+
+    def test_some_fulltext_passes(self):
+        """全文ドキュメントが 1 件以上あれば通過する。"""
+        ctx = MockCallbackContext(state={
+            "selected_languages": ["en"],
+            "collected_documents_en": "# Collected Documents (English) — 5 documents...",
+            "fulltext_metrics": {
+                "total_documents": 5,
+                "fulltext_documents": 2,
+                "metadata_only_documents": 3,
+                "by_language": {"en": {"total": 5, "fulltext": 2, "metadata_only": 3}},
+            },
+        })
+        gate = make_scholar_gate()
+        result = gate(ctx)
+        assert result is None
+
+    def test_missing_metrics_passes(self):
+        """fulltext_metrics が未設定でも通過する（後方互換）。"""
+        ctx = MockCallbackContext(state={
+            "selected_languages": ["en"],
+            "collected_documents_en": "Found 5 documents about Bell Witch...",
+        })
+        gate = make_scholar_gate()
+        result = gate(ctx)
+        assert result is None
+
+    def test_no_documents_takes_precedence(self, caplog):
+        """ドキュメントなし + 全文なしの場合、INSUFFICIENT_DATA が先に発動する。"""
+        ctx = MockCallbackContext(state={
+            "selected_languages": ["en"],
+            "collected_documents_en": "NO_DOCUMENTS_FOUND: No English-language documents.",
+            "fulltext_metrics": {
+                "total_documents": 0,
+                "fulltext_documents": 0,
+                "metadata_only_documents": 0,
+                "by_language": {},
+            },
+        })
+        gate = make_scholar_gate()
+        result = gate(ctx)
+        assert result is not None
+        assert "INSUFFICIENT_DATA" in caplog.text
+        assert "NO_FULLTEXT_AVAILABLE" not in caplog.text
+
+
 class TestStorytellerGate:
     """make_storyteller_gate のテスト。"""
 


### PR DESCRIPTION
## Summary

- Aggregator で全文テキスト取得メトリクス（`fulltext_metrics`）を算出し、ステートに保存
- ScholarGate に全文チェックを追加：ドキュメントは見つかったが全文テキストが 0 件の場合、`NO_FULLTEXT_AVAILABLE` で早期終了し LLM API コストを節約
- Aggregator 出力ヘッダーに全文/メタデータ専用の内訳を表示、全文が 1-2 件の場合は限定的証拠の注記を追加

## 変更内容

| ファイル | 変更 |
|---------|------|
| `shared/constants.py` | `NO_FULLTEXT_AVAILABLE` を `FAILURE_MARKERS` に追加 |
| `shared/state_keys.py` | `FULLTEXT_METRICS` 定数追加 |
| `shared/state_registry.py` | `fulltext_metrics` エントリ登録 |
| `mystery_agents/agents/aggregator.py` | メトリクス算出、ヘッダー強化、メタデータラベル、重複除去ヘルパー抽出 |
| `mystery_agents/agents/pipeline_gate.py` | ScholarGate に全文チェック追加（`fulltext_metrics` 未設定時はスキップ — 後方互換） |
| `tests/unit/test_aggregator.py` | 全文メトリクス関連テスト 5 件追加 |
| `tests/unit/test_pipeline_gate.py` | 全文ゲート関連テスト 4 件追加 |

## Test plan

- [x] `pytest tests/unit/test_constants.py tests/unit/test_aggregator.py tests/unit/test_pipeline_gate.py -v` — 全47件パス
- [x] `pytest tests/unit/ -v` — 全1388件パス（回帰なし）

Closes #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)