### PR TITLE
fix: approved_archive_images 未初期化による Storyteller クラッシュを修正

### DIFF
--- a/mystery_agents/agent.py
+++ b/mystery_agents/agent.py
@@ -42,7 +42,12 @@ from .agents.publisher import create_publisher
 from .agents.storyteller import create_storyteller
 from .agents.translator import create_all_translators
 from shared.model_config import DEFAULT_STORYTELLER
-from shared.state_keys import DEBATE_WHITEBOARD, SELECTED_LANGUAGES, STRUCTURED_REPORT
+from shared.state_keys import (
+    APPROVED_ARCHIVE_IMAGES,
+    DEBATE_WHITEBOARD,
+    SELECTED_LANGUAGES,
+    STRUCTURED_REPORT,
+)
 
 if TYPE_CHECKING:
     from google.adk.agents.callback_context import CallbackContext
@@ -101,6 +106,8 @@ def _initialize_pipeline_state(
     callback_context.state[SELECTED_LANGUAGES] = []
     callback_context.state[DEBATE_WHITEBOARD] = ""
     callback_context.state[STRUCTURED_REPORT] = {}
+    # Polymath が save_structured_report を呼ばなかった場合のフォールバック
+    callback_context.state[APPROVED_ARCHIVE_IMAGES] = []
     # scholar_analysis_* は DynamicPolymathBlock が動的に参照するため初期化不要
     # active_analyses_summary は DynamicScholarBlock が設定するため初期化不要
     return None  # 実行続行


### PR DESCRIPTION
## Summary
- Polymath が `save_structured_report` を呼ばずにテキスト出力のみで完了した場合、`approved_archive_images` キーがセッション状態に存在せず Storyteller の instruction テンプレート解決時に `Context variable not found` エラーが発生していた
- `_initialize_pipeline_state` で `approved_archive_images` を空リストとして初期化し、フォールバックを確保

## Test plan
- [x] `pytest tests/unit/ -v -k "scholar_tools or pipeline"` — 全172テスト通過
- [x] `save_structured_report` が呼ばれた場合は上書きされるため既存動作に影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)