### PR TITLE
fix: IA デフォルトサムネイル（notfound.png）の検出・除外を追加

### DIFF
--- a/mystery_agents/tools/librarian_tools.py
+++ b/mystery_agents/tools/librarian_tools.py
@@ -40,6 +40,10 @@ logger = logging.getLogger(__name__)
 # 画像バリデーション: この閾値未満はプレースホルダーとみなす
 MIN_IMAGE_BYTES = 5000
 
+# IA デフォルトサムネイル（notfound.png）の既知サイズ（バイト）
+# サムネイルのないアイテムは /images/notfound.png にリダイレクトされる
+_IA_DEFAULT_ICON_SIZES: frozenset[int] = frozenset({2212})
+
 # 並列実行の最大ワーカー数
 _MAX_WORKERS = 6
 
@@ -47,15 +51,37 @@ _MAX_WORKERS = 6
 _TOTAL_DOCS_CAP = 30
 
 
+def _is_ia_default_icon(resp: requests.Response, url: str) -> bool:
+    """IA デフォルトサムネイル（notfound.png）を検出する。
+
+    archive.org/services/img/ が返す notfound.png を2段階で検出:
+    1. リダイレクト先 URL が /images/notfound.png で終わる
+    2. Content-Length が既知のデフォルトアイコンサイズに一致
+    """
+    # リダイレクト先 URL で検出（最も堅牢）
+    if resp.url.endswith("/images/notfound.png"):
+        return True
+    # Content-Length + URL パターンで検出（リダイレクトなしで配信される場合の備え）
+    if "archive.org/services/img" in url:
+        content_length = resp.headers.get("Content-Length")
+        if content_length is not None and int(content_length) in _IA_DEFAULT_ICON_SIZES:
+            return True
+    return False
+
+
 def _validate_image_url(url: str, timeout: float = 5.0) -> bool:
     """HEAD リクエストで画像 URL の有効性を検証する。
 
     Europeana サムネイル API 等が返す白いプレースホルダー画像（1211バイト等）を
     Content-Length ヘッダで検出し、除外する。
+    Internet Archive のデフォルトサムネイル（notfound.png）も検出・除外する。
     """
     try:
         resp = requests.head(url, timeout=timeout, allow_redirects=True)
         if resp.status_code != 200:
+            return False
+        # IA デフォルトサムネイル検出
+        if _is_ia_default_icon(resp, url):
             return False
         content_length = resp.headers.get("Content-Length")
         if content_length is not None and int(content_length) < MIN_IMAGE_BYTES:

--- a/tests/unit/test_evidence_relevance.py
+++ b/tests/unit/test_evidence_relevance.py
@@ -184,6 +184,48 @@ class TestValidateImageUrl:
         )
         assert _validate_image_url(url) is False
 
+    @responses.activate
+    def test_ia_default_icon_rejected_by_redirect(self):
+        """IA デフォルト建物アイコン（notfound.png リダイレクト）が拒否される。"""
+        from mystery_agents.tools.librarian_tools import _validate_image_url
+
+        url = "https://archive.org/services/img/nonexistent_item"
+        # IA はサムネイルなしアイテムを /images/notfound.png にリダイレクトする
+        responses.add(
+            responses.HEAD, url,
+            status=302,
+            headers={"Location": "https://archive.org/images/notfound.png"},
+        )
+        responses.add(
+            responses.HEAD, "https://archive.org/images/notfound.png",
+            status=200, headers={"Content-Length": "2212"},
+        )
+        assert _validate_image_url(url) is False
+
+    @responses.activate
+    def test_ia_default_icon_rejected_by_size(self):
+        """IA デフォルトアイコンが既知サイズで拒否される（リダイレクトなし想定）。"""
+        from mystery_agents.tools.librarian_tools import _validate_image_url
+
+        url = "https://archive.org/services/img/nonexistent_item"
+        responses.add(
+            responses.HEAD, url,
+            status=200, headers={"Content-Length": "2212"},
+        )
+        assert _validate_image_url(url) is False
+
+    @responses.activate
+    def test_ia_real_thumbnail_accepted(self):
+        """IA 実サムネイル（異なるサイズ）は受け入れられる。"""
+        from mystery_agents.tools.librarian_tools import _validate_image_url
+
+        url = "https://archive.org/services/img/real_book_with_cover"
+        responses.add(
+            responses.HEAD, url,
+            status=200, headers={"Content-Length": "50000"},
+        )
+        assert _validate_image_url(url) is True
+
 
 class TestAccumulateImagesValidation:
     """_accumulate_archive_images の画像バリデーション統合テスト。"""


### PR DESCRIPTION
## Summary

- Internet Archive の `services/img/{identifier}` エンドポイントがサムネイルのないアイテムに対して返す `notfound.png`（建物アイコン）を検出・除外するロジックを `_validate_image_url()` に追加
- リダイレクト先 URL チェック（`/images/notfound.png`）+ Content-Length の既知サイズ（2212B）による二重検出
- テスト3件追加（リダイレクト検出、サイズ検出、実サムネイル受容）

## 背景

記事 `HIS-US-LHR-20260301060823` のアーカイブ画像として IA のデフォルトアイコンが表示されていた。現在の `notfound.png` は 2212B で既存の `MIN_IMAGE_BYTES = 5000` 閾値で弾けるが、IA がアイコンを更新して 5KB を超えた場合に備え、リダイレクト先 URL による堅牢な検出を追加。

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `mystery_agents/tools/librarian_tools.py` | `_is_ia_default_icon()` + `_IA_DEFAULT_ICON_SIZES` 定数追加 |
| `tests/unit/test_evidence_relevance.py` | IA 関連テスト3件追加 |

## Test plan

- [x] `pytest tests/unit/test_evidence_relevance.py -v` — 全22テスト（既存19 + 新規3）パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)