### PR TITLE
fix: Delpher SRU リクエストに x-collection パラメータを追加

### DIFF
--- a/mystery_agents/tools/delpher.py
+++ b/mystery_agents/tools/delpher.py
@@ -19,6 +19,7 @@ from .source_registry import register_source
 logger = logging.getLogger(__name__)
 
 BASE_URL = "https://jsru.kb.nl/sru/sru"
+COLLECTION = "DDD_artikel"
 
 # 全文取得の上限設定
 _MAX_FULLTEXT_FETCHES = 5
@@ -188,6 +189,7 @@ class DelpherSource(ArchiveSource):
         params = {
             "operation": "searchRetrieve",
             "version": "1.2",
+            "x-collection": COLLECTION,
             "query": query,
             "maximumRecords": min(max_results, 100),
             "recordSchema": "dc",

--- a/tests/unit/test_delpher.py
+++ b/tests/unit/test_delpher.py
@@ -5,10 +5,12 @@ import responses
 from mystery_agents.schemas.document import SourceLanguage
 from mystery_agents.tools.delpher import (
     BASE_URL,
+    COLLECTION,
     DelpherSource,
     _fetch_ocr_text,
     _parse_sru_response,
 )
+from mystery_agents.tools.search_utils import build_search_query
 from shared.http_retry import create_retry_session
 
 # モック SRU XML レスポンス
@@ -165,6 +167,7 @@ class TestDelpherSource:
         request = responses.calls[0].request
         assert "operation=searchRetrieve" in request.url
         assert "version=1.2" in request.url
+        assert "x-collection=DDD_artikel" in request.url
         assert "recordSchema=dc" in request.url
         assert "spook" in request.url
 
@@ -212,6 +215,14 @@ class TestDelpherSource:
         source = DelpherSource()
         result = source.search(keywords=[])
         assert result.error == "No keywords provided"
+
+    def test_multi_word_keywords_quoted_in_cql(self):
+        """複数語キーワードが CQL クエリ内で正しくクォートされる。"""
+        query = build_search_query(["Oera Linda Boek", "1867"])
+        assert '"Oera Linda Boek"' in query
+        assert "1867" in query
+        # 単語キーワードはクォートされない
+        assert query == '"Oera Linda Boek" OR 1867'
 
     def test_date_parsing(self):
         """SRU の日付フォーマット（YYYY/MM/DD HH:MM:SS）が正しくパースされる。"""


### PR DESCRIPTION
## Summary

- Delpher（KB/オランダ国立図書館）API が常に 0 件を返す問題を修正
- SRU リクエストに `x-collection=DDD_artikel` パラメータを追加し、新聞記事コレクションを明示的に指定
- 手動テストで `"oera linda"` が 0 件 → 1,148 件にヒットすることを確認済み

## 変更内容

- `mystery_agents/tools/delpher.py`: `COLLECTION = "DDD_artikel"` 定数を追加、`params` に `x-collection` を追加
- `tests/unit/test_delpher.py`: `x-collection` アサーション追加 + 複数語キーワード CQL クォーティングテスト追加

## Test plan

- [x] `pytest tests/unit/test_delpher.py -v` — 全 19 テスト PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)