### PR TITLE
feat: Librarian 適応的検索（Adaptive Search）— 2ラウンド制導入

### DIFF
--- a/mystery_agents/agent.py
+++ b/mystery_agents/agent.py
@@ -80,6 +80,13 @@ SKIP_AUTHORS = {
     "parallel_api_librarians_batch_1",
     "parallel_api_librarians_batch_2",
     "aggregator",
+    # Librarian SequentialAgent ブロック（Round 1 + Round 2 のラッパー）
+    "librarian_us_archives_block",
+    "librarian_europeana_block",
+    "librarian_internet_archive_block",
+    "librarian_ndl_block",
+    "librarian_delpher_block",
+    "librarian_trove_block",
     # DynamicScholarBlock / DynamicPolymathBlock 内部のオーケストレーターエージェント
     "dynamic_scholar_block",
     "dynamic_analysis",
@@ -132,7 +139,7 @@ def build_pipeline(storyteller: str = DEFAULT_STORYTELLER) -> SequentialAgent:
     agg = create_aggregator()
 
     # ファクトリエージェント（既に毎回新規生成）
-    api_libs = create_all_api_librarians()  # 5 Librarian のフラットリスト
+    api_libs = create_all_api_librarians()  # 6 SequentialAgent（各 R1+R2）
     translators = create_all_translators()
 
     # DynamicScholarBlock: 分析 + 討論を一貫制御

--- a/mystery_agents/agents/api_librarians.py
+++ b/mystery_agents/agents/api_librarians.py
@@ -4,19 +4,24 @@
 各 Librarian はテーマに応じて検索言語を自律的に判断し、
 collected_documents_{api_key} に結果を保存する。
 
+各 API Librarian は SequentialAgent(Round 1 + Round 2) でラップされる:
+- Round 1（temp=0.3）: 堅実な初回検索
+- Round 2（temp=0.7）: Round 1 の結果を踏まえた適応的再検索
+
 後段の AggregatorAgent が全 Librarian 出力を言語別に再集約する。
 
 全 Librarian は gemini-2.5-flash を使用（資料検索は Flash で十分）。
 モデル設定は shared/model_config.py で一元管理（429 リトライ付き）。
 """
 
-from google.adk.agents import LlmAgent
+from google.adk.agents import LlmAgent, SequentialAgent
 from google.genai import types
 
 from shared.model_config import create_flash_model
 from shared.token_tracker import create_token_tracking_callback
 
 from ..tools.librarian_tools import search_archives, search_newspapers
+from .librarian_instructions import ADAPTIVE_INSTRUCTION as _ADAPTIVE_INSTRUCTION
 from .librarian_instructions import BASE_INSTRUCTION as _BASE_INSTRUCTION
 
 # ---------------------------------------------------------------------------
@@ -238,36 +243,62 @@ API_CONFIGS: dict[str, dict] = {
 }
 
 
-def create_api_librarian(api_key: str) -> LlmAgent:
+def create_api_librarian(api_key: str) -> SequentialAgent:
     """指定された API グループの Librarian エージェントを生成する。
+
+    SequentialAgent(Round 1 + Round 2) を返す:
+    - Round 1（temp=0.3）: 堅実な初回検索 → collected_documents_{api_key}
+    - Round 2（temp=0.7）: 適応的再検索 → adaptive_search_{api_key}
 
     Args:
         api_key: API_CONFIGS のキー（例: "us_archives", "europeana"）
 
     Returns:
-        LlmAgent インスタンス
+        SequentialAgent（Round 1 + Round 2 を内包）
     """
     config = API_CONFIGS[api_key]
-    instruction = _BASE_INSTRUCTION.format(**config)
     tools = [search_archives]
     if config.get("has_newspapers"):
         tools.append(search_newspapers)
 
-    return LlmAgent(
+    # Round 1: 堅実な検索（temp=0.3）
+    round1 = LlmAgent(
         name=f"librarian_{api_key}",
         model=create_flash_model(),
         description=(
             f"{config['api_display_name']} specialist librarian. "
             f"Searches {config['api_display_name']} for primary sources."
         ),
-        instruction=instruction,
+        instruction=_BASE_INSTRUCTION.format(**config),
         tools=tools,
         output_key=f"collected_documents_{api_key}",
         generate_content_config=types.GenerateContentConfig(temperature=0.3),
         after_model_callback=create_token_tracking_callback(f"librarian_{api_key}"),
     )
 
+    # Round 2: 探索的再検索（temp=0.7）— 常時実行
+    round2 = LlmAgent(
+        name=f"librarian_{api_key}_adaptive",
+        model=create_flash_model(),
+        description=(
+            f"{config['api_display_name']} adaptive search librarian. "
+            f"Performs complementary follow-up search based on Round 1 results."
+        ),
+        instruction=_ADAPTIVE_INSTRUCTION.format(**config, api_key=api_key),
+        tools=tools,
+        output_key=f"adaptive_search_{api_key}",
+        generate_content_config=types.GenerateContentConfig(temperature=0.7),
+        after_model_callback=create_token_tracking_callback(
+            f"librarian_{api_key}_adaptive"
+        ),
+    )
 
-def create_all_api_librarians() -> list[LlmAgent]:
+    return SequentialAgent(
+        name=f"librarian_{api_key}_block",
+        sub_agents=[round1, round2],
+    )
+
+
+def create_all_api_librarians() -> list[SequentialAgent]:
     """全 API グループの Librarian エージェントをリストで返す。"""
     return [create_api_librarian(key) for key in API_CONFIGS]

--- a/mystery_agents/agents/librarian_instructions.py
+++ b/mystery_agents/agents/librarian_instructions.py
@@ -2,6 +2,9 @@
 
 API グループごとの Librarian の instruction テンプレートを定義する。
 
+- BASE_INSTRUCTION: Round 1（堅実な初回検索）
+- ADAPTIVE_INSTRUCTION: Round 2（適応的再検索）
+
 対応するファクトリ関数は api_librarians.py を参照。
 """
 
@@ -115,4 +118,109 @@ If search returns no documents, output only:
 NO_DOCUMENTS_FOUND: No relevant documents found in {api_display_name}.
 Search theme: [theme]
 ```
+"""
+
+# === 日本語訳 ===
+# 適応的検索（Round 2）指示テンプレート:
+# あなたは「Ghost in the Archive」プロジェクトの {api_display_name} 適応的検索司書です。
+# 初回検索（Round 1）の結果を分析し、異なるアプローチで補完検索を実行します。
+#
+# ## あなたのアーカイブ
+# {api_capabilities}
+#
+# ## Round 1 の検索結果
+# {{collected_documents_{api_key}}}
+#
+# ## あなたの任務
+# Round 1 の結果を分析し、カバーされていない側面を特定して補完検索を実行する。
+#
+# ### Round 1 で資料が見つかった場合
+# - 結果を分析し、まだカバーされていない側面を特定する
+# - 以下の戦略から適切なものを選択:
+#   - より広範な、またはより具体的なキーワードへの切り替え
+#   - 時代用語・古語・方言での検索
+#   - 関連する別の主題領域（例:「幽霊」→「不審死」「行方不明者」）
+#   - 日付範囲の拡大または除去
+#   - 異なる言語でのキーワード（多言語アーカイブの場合）
+#
+# ### Round 1 で資料が見つからなかった場合
+# - 完全に異なるアプローチで再検索:
+#   - 大幅に広範なキーワード
+#   - 別の言語でのキーワード
+#   - 日付範囲の完全除去
+#   - テーマの上位概念・関連概念での検索
+#
+# ## 検索戦略
+# {search_strategy}
+#
+# ## 出力形式
+# Round 1 と同じ形式で新たに見つかった資料を報告する。
+# Round 1 の結果を繰り返さないこと。
+# 新たな資料が見つからなかった場合は簡潔に報告する。
+#
+# ## 重要
+# - Round 1 と同じ検索を繰り返さない — 必ず異なるアプローチを使う
+# - 2段階キーワードモデル（reference_keywords + keywords）を使う
+# - 分析は Scholar の役割 — 収集した資料を詳細に報告するのみ
+# === End 日本語訳 ===
+
+ADAPTIVE_INSTRUCTION = """
+You are a {api_display_name} adaptive search Librarian for the "Ghost in the Archive" project.
+Your job is to perform a complementary follow-up search based on the initial search results.
+You do NOT perform analysis — that is the Scholar Agent's role.
+
+## Your Archive
+{api_capabilities}
+
+## Round 1 Search Results
+Review the initial search results carefully:
+{{collected_documents_{api_key}}}
+
+## Your Mission
+Analyze the Round 1 results and execute a complementary search using a DIFFERENT approach.
+Your goal is to find materials that Round 1 missed.
+
+### If Round 1 Found Documents
+Analyze what was found and identify uncovered aspects. Choose from these strategies:
+- **Broaden or narrow keywords** — if Round 1 was too specific, try broader terms; if too broad, try more specific ones
+- **Period-appropriate terminology** — use archaic terms, dialect words, or historical spellings
+- **Adjacent subject areas** — e.g., "ghost" → "unexplained death", "missing person", "inquest"
+- **Expand or remove date range** — widen the temporal scope to catch related events
+- **Different language keywords** — for multilingual archives, try another relevant language
+- **Folklore angle** — if Round 1 focused on facts, search for legends, superstitions, folk beliefs (or vice versa)
+
+### If Round 1 Found No Documents (NO_DOCUMENTS_FOUND)
+Try a completely different approach:
+- **Much broader keywords** — use general category terms instead of specific ones
+- **Different language** — try keywords in another language relevant to the archive
+- **Remove all date filters** — search without temporal constraints
+- **Higher-level concepts** — search for the broader topic or related phenomena
+
+## Search Strategy
+{search_strategy}
+
+## Two-Phase Keyword Model
+For EVERY tool call, provide both keyword types:
+- **`reference_keywords`**: Proper nouns, dates, places (different from Round 1)
+- **`keywords`**: Creative associations, synonyms, period terms (different from Round 1)
+
+## Output Format
+Report ONLY newly found materials (do not repeat Round 1 results):
+- Title, date, and source URL of each document
+- Summary (context around relevant keywords)
+- Language and source type
+- Material type (Fact/Folklore/Both)
+- Excerpts from the text (if available)
+
+If no additional materials are found, output:
+```
+ADAPTIVE_SEARCH_COMPLETE: No additional materials found in {api_display_name}.
+Round 1 results remain the primary collection for this archive.
+```
+
+## Important
+- **Do NOT repeat the same searches as Round 1** — use a genuinely different approach
+- Generate keywords natively in the appropriate language for your archive
+- Use the Two-Phase Keyword Model (reference_keywords + keywords) for every call
+- Do NOT perform analysis — report collected materials for the Scholar
 """

--- a/shared/state_keys.py
+++ b/shared/state_keys.py
@@ -59,3 +59,8 @@ def translation_result_key(lang: str) -> str:
 def raw_search_results_key(identifier: str) -> str:
     """Librarian 検索結果キー（API/言語別）。"""
     return f"raw_search_results_{identifier}"
+
+
+def adaptive_search_key(api_key: str) -> str:
+    """Librarian Round 2（適応的検索）の出力キー。"""
+    return f"adaptive_search_{api_key}"

--- a/tests/unit/test_api_librarians.py
+++ b/tests/unit/test_api_librarians.py
@@ -1,4 +1,11 @@
-"""API ベース Librarian エージェントファクトリのユニットテスト。"""
+"""API ベース Librarian エージェントファクトリのユニットテスト。
+
+create_api_librarian() は SequentialAgent(Round 1 + Round 2) を返す:
+- Round 1（temp=0.3）: 堅実な初回検索 → collected_documents_{api_key}
+- Round 2（temp=0.7）: 適応的再検索 → adaptive_search_{api_key}
+"""
+
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -9,73 +16,32 @@ from mystery_agents.agents.api_librarians import (
 )
 
 
+def _fake_generate_content_config(**kwargs):
+    """GenerateContentConfig のフェイク。kwargs を属性として保持する。"""
+    m = MagicMock()
+    for k, v in kwargs.items():
+        setattr(m, k, v)
+    return m
+
+
 class TestAPILibrarianFactory:
     """API Librarian ファクトリ関数のテスト。"""
 
     def test_create_all_returns_correct_count(self):
-        """全 API Librarian が生成される。"""
+        """全 API Librarian ブロックが生成される。"""
         librarians = create_all_api_librarians()
         assert len(librarians) == len(API_CONFIGS)
 
-    def test_all_have_unique_names(self):
-        """全 Librarian のエージェント名がユニーク。"""
+    def test_all_blocks_have_unique_names(self):
+        """全ブロックのエージェント名がユニーク。"""
         librarians = create_all_api_librarians()
         names = [agent.name for agent in librarians]
         assert len(names) == len(set(names))
-
-    def test_all_have_unique_output_keys(self):
-        """全 Librarian の output_key がユニーク。"""
-        librarians = create_all_api_librarians()
-        keys = [agent.output_key for agent in librarians]
-        assert len(keys) == len(set(keys))
-
-    def test_output_key_format(self):
-        """output_key が collected_documents_{api_key} 形式。"""
-        for api_key in API_CONFIGS:
-            agent = create_api_librarian(api_key)
-            assert agent.output_key == f"collected_documents_{api_key}"
-
-    def test_us_archives_has_newspaper_tool(self):
-        """USArchivesLibrarian は search_newspapers ツールを持つ。"""
-        from mystery_agents.tools.librarian_tools import search_newspapers
-
-        agent = create_api_librarian("us_archives")
-        assert search_newspapers in agent.tools
-
-    def test_non_us_lacks_newspaper_tool(self):
-        """US 以外の Librarian は search_newspapers を持たない。"""
-        from mystery_agents.tools.librarian_tools import search_newspapers
-
-        for api_key in ["europeana", "internet_archive", "ndl", "trove", "delpher"]:
-            agent = create_api_librarian(api_key)
-            assert search_newspapers not in agent.tools
-
-    def test_all_have_search_archives_tool(self):
-        """全 Librarian が search_archives ツールを持つ。"""
-        from mystery_agents.tools.librarian_tools import search_archives
-
-        librarians = create_all_api_librarians()
-        for agent in librarians:
-            assert search_archives in agent.tools
 
     def test_invalid_api_key_raises(self):
         """存在しない API キーで KeyError が発生する。"""
         with pytest.raises(KeyError):
             create_api_librarian("nonexistent_api")
-
-    @pytest.mark.parametrize("api_key", list(API_CONFIGS.keys()))
-    def test_instruction_contains_api_name(self, api_key):
-        """各 Librarian の instruction に API 名が含まれる。"""
-        agent = create_api_librarian(api_key)
-        display_name = API_CONFIGS[api_key]["api_display_name"]
-        assert display_name in agent.instruction
-
-    def test_agent_name_format(self):
-        """エージェント名が librarian_{api_key} 形式。"""
-        for api_key in API_CONFIGS:
-            agent = create_api_librarian(api_key)
-            # MagicMock 環境では .name がモックされるため repr で検証
-            assert f"librarian_{api_key}" in repr(agent)
 
     def test_instruction_source_keys_exist_in_registry(self):
         """instruction 内の sources= 値がソースレジストリに登録済みであること。"""
@@ -96,3 +62,148 @@ class TestAPILibrarianFactory:
                         f"API '{api_key}' の instruction が参照する "
                         f"sources=\"{src}\" はソースレジストリに未登録"
                     )
+
+
+class TestAdaptiveSearchBlock:
+    """SequentialAgent ブロック（Round 1 + Round 2）の構造テスト。"""
+
+    def test_block_has_two_sub_agents(self):
+        """ブロックは Round 1 + Round 2 の2つの sub_agent を持つ。"""
+        block = create_api_librarian("europeana")
+        assert len(block.sub_agents) == 2
+
+    def test_block_name_format(self):
+        """ブロック名が librarian_{api_key}_block 形式。"""
+        for api_key in API_CONFIGS:
+            block = create_api_librarian(api_key)
+            assert f"librarian_{api_key}_block" in repr(block)
+
+    def test_round1_name_format(self):
+        """Round 1 のエージェント名が librarian_{api_key} 形式。"""
+        for api_key in API_CONFIGS:
+            block = create_api_librarian(api_key)
+            round1 = block.sub_agents[0]
+            assert f"librarian_{api_key}" in repr(round1)
+
+    def test_round2_name_format(self):
+        """Round 2 のエージェント名が librarian_{api_key}_adaptive 形式。"""
+        for api_key in API_CONFIGS:
+            block = create_api_librarian(api_key)
+            round2 = block.sub_agents[1]
+            assert f"librarian_{api_key}_adaptive" in repr(round2)
+
+    def test_round1_output_key(self):
+        """Round 1 の output_key が collected_documents_{api_key} 形式。"""
+        for api_key in API_CONFIGS:
+            block = create_api_librarian(api_key)
+            round1 = block.sub_agents[0]
+            assert round1.output_key == f"collected_documents_{api_key}"
+
+    def test_round2_output_key(self):
+        """Round 2 の output_key が adaptive_search_{api_key} 形式。"""
+        for api_key in API_CONFIGS:
+            block = create_api_librarian(api_key)
+            round2 = block.sub_agents[1]
+            assert round2.output_key == f"adaptive_search_{api_key}"
+
+    @pytest.mark.parametrize("api_key", list(API_CONFIGS.keys()))
+    def test_round1_instruction_contains_api_name(self, api_key):
+        """Round 1 の instruction に API 名が含まれる。"""
+        block = create_api_librarian(api_key)
+        round1 = block.sub_agents[0]
+        display_name = API_CONFIGS[api_key]["api_display_name"]
+        assert display_name in round1.instruction
+
+    @pytest.mark.parametrize("api_key", list(API_CONFIGS.keys()))
+    def test_round2_instruction_contains_api_name(self, api_key):
+        """Round 2 の instruction に API 名が含まれる。"""
+        block = create_api_librarian(api_key)
+        round2 = block.sub_agents[1]
+        display_name = API_CONFIGS[api_key]["api_display_name"]
+        assert display_name in round2.instruction
+
+    @pytest.mark.parametrize("api_key", list(API_CONFIGS.keys()))
+    def test_round2_instruction_has_state_placeholder(self, api_key):
+        """Round 2 の instruction が Round 1 結果の状態変数を参照している。"""
+        block = create_api_librarian(api_key)
+        round2 = block.sub_agents[1]
+        # .format() 後に残る ADK 状態変数プレースホルダー
+        expected = f"{{collected_documents_{api_key}}}"
+        assert expected in round2.instruction
+
+    def test_round1_temperature(self):
+        """Round 1 の temperature が 0.3 である。"""
+        from google.genai import types
+
+        types.GenerateContentConfig.side_effect = _fake_generate_content_config
+        try:
+            block = create_api_librarian("europeana")
+            round1 = block.sub_agents[0]
+            assert round1.generate_content_config.temperature == 0.3
+        finally:
+            types.GenerateContentConfig.side_effect = None
+
+    def test_round2_temperature(self):
+        """Round 2 の temperature が 0.7 である。"""
+        from google.genai import types
+
+        types.GenerateContentConfig.side_effect = _fake_generate_content_config
+        try:
+            block = create_api_librarian("europeana")
+            round2 = block.sub_agents[1]
+            assert round2.generate_content_config.temperature == 0.7
+        finally:
+            types.GenerateContentConfig.side_effect = None
+
+    def test_round1_has_search_archives_tool(self):
+        """Round 1 が search_archives ツールを持つ。"""
+        from mystery_agents.tools.librarian_tools import search_archives
+
+        for api_key in API_CONFIGS:
+            block = create_api_librarian(api_key)
+            round1 = block.sub_agents[0]
+            assert search_archives in round1.tools
+
+    def test_round2_has_search_archives_tool(self):
+        """Round 2 が search_archives ツールを持つ。"""
+        from mystery_agents.tools.librarian_tools import search_archives
+
+        for api_key in API_CONFIGS:
+            block = create_api_librarian(api_key)
+            round2 = block.sub_agents[1]
+            assert search_archives in round2.tools
+
+    def test_us_archives_both_rounds_have_newspaper_tool(self):
+        """US Archives の Round 1 と Round 2 の両方が search_newspapers を持つ。"""
+        from mystery_agents.tools.librarian_tools import search_newspapers
+
+        block = create_api_librarian("us_archives")
+        round1 = block.sub_agents[0]
+        round2 = block.sub_agents[1]
+        assert search_newspapers in round1.tools
+        assert search_newspapers in round2.tools
+
+    def test_non_us_both_rounds_lack_newspaper_tool(self):
+        """US 以外の Round 1 と Round 2 は search_newspapers を持たない。"""
+        from mystery_agents.tools.librarian_tools import search_newspapers
+
+        for api_key in ["europeana", "internet_archive", "ndl", "trove", "delpher"]:
+            block = create_api_librarian(api_key)
+            round1 = block.sub_agents[0]
+            round2 = block.sub_agents[1]
+            assert search_newspapers not in round1.tools
+            assert search_newspapers not in round2.tools
+
+    def test_all_block_names_unique(self):
+        """全ブロック名、Round 1 名、Round 2 名がそれぞれユニーク。"""
+        blocks = create_all_api_librarians()
+        block_names = []
+        round1_names = []
+        round2_names = []
+        for block in blocks:
+            block_names.append(repr(block))
+            round1_names.append(repr(block.sub_agents[0]))
+            round2_names.append(repr(block.sub_agents[1]))
+        assert len(block_names) == len(set(block_names))
+        assert len(round1_names) == len(set(round1_names))
+        assert len(round2_names) == len(set(round2_names))


### PR DESCRIPTION
## Summary

- 各 API Librarian を `SequentialAgent(Round 1 + Round 2)` でラップし、資料収集の網羅性を向上
- Round 1（temp=0.3）: 堅実な初回検索 → `collected_documents_{api_key}`
- Round 2（temp=0.7）: Round 1 の結果を分析し、異なるキーワード戦略で補完検索 → `adaptive_search_{api_key}`
- Aggregator は `raw_search_results*` スキャンで R1+R2 を自動マージ（変更不要）

### パイプライン構造（変更後）

```
batched_api_librarians (SequentialAgent)
  ├─ parallel_batch_1 (ParallelAgent)
  │   ├─ librarian_us_archives_block (SequentialAgent) ← NEW
  │   │   ├─ librarian_us_archives (LlmAgent, temp=0.3) — Round 1
  │   │   └─ librarian_us_archives_adaptive (LlmAgent, temp=0.7) — Round 2
  │   ├─ librarian_europeana_block
  │   └─ librarian_internet_archive_block
  └─ parallel_batch_2 (ParallelAgent)
      ├─ librarian_ndl_block
      ├─ librarian_delpher_block
      └─ librarian_trove_block
```

### 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `mystery_agents/agents/api_librarians.py` | `create_api_librarian()` が `SequentialAgent(R1+R2)` を返すように拡張 |
| `mystery_agents/agents/librarian_instructions.py` | `ADAPTIVE_INSTRUCTION` テンプレート追加（Prompt Language Policy 準拠） |
| `mystery_agents/agent.py` | `SKIP_AUTHORS` に6ブロック名追加 |
| `shared/state_keys.py` | `adaptive_search_key()` 関数追加 |
| `tests/unit/test_api_librarians.py` | SequentialAgent 構造・温度・命名・出力キーのテスト追加（35テスト） |

### QPM・コスト影響

| 指標 | 現状 | 変更後 |
|------|------|--------|
| LLM 呼び出し（Librarian） | 6 | 12（+6 Flash） |
| 同時 LLM 呼び出し | 3 | 3（変更なし） |
| Librarian フェーズ時間 | ~30秒 | ~60秒 |

## Test plan

- [x] `pytest tests/unit/test_api_librarians.py -v` — 35テスト全パス
- [x] `pytest tests/unit/ -v` — 1411テスト全パス
- [x] `python -c "from mystery_agents.agent import build_pipeline; p = build_pipeline(); print(p.name)"` — パイプライン構築確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)