### PR TITLE
fix: probe_hits を total_hits(int) から全文取得可否(bool) に変更

### DIFF
--- a/curator_agents/probe.py
+++ b/curator_agents/probe.py
@@ -1,13 +1,12 @@
 """テーマ候補に対する軽量 API プローブ。
 
 Curator が生成した probe_keywords を使い、全ソースを並列検索して
-実際のヒット件数に基づいた coverage_score を算出・上書きする。
+全文取得可能かどうかに基づいた coverage_score を算出・上書きする。
 """
 
 from __future__ import annotations
 
 import logging
-from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from mystery_agents.tools.source_registry import get_all_sources
@@ -25,19 +24,20 @@ def _build_source_to_group_map() -> dict[str, str]:
     return mapping
 
 
-def probe_theme(keywords: list[str]) -> dict[str, int]:
-    """1テーマについて全ソースを並列プローブし、API グループごとのヒット件数を返す。
+def probe_theme(keywords: list[str]) -> dict[str, bool]:
+    """1テーマについて全ソースを並列プローブし、API グループごとの全文取得可否を返す。
 
     Args:
         keywords: 検索キーワードリスト（probe_keywords）
 
     Returns:
-        {api_group_key: total_hits} 形式の dict
+        {api_group_key: has_content} 形式の dict。
+        raw_text を持つドキュメントが1件でもあれば True。
     """
     all_sources = get_all_sources()
     source_to_group = _build_source_to_group_map()
 
-    group_hits: dict[str, int] = defaultdict(int)
+    group_content: dict[str, bool] = {}
 
     with ThreadPoolExecutor(max_workers=7) as executor:
         futures = {
@@ -49,7 +49,14 @@ def probe_theme(keywords: list[str]) -> dict[str, int]:
             try:
                 result = future.result()
                 api_group = source_to_group.get(source_key, source_key)
-                group_hits[api_group] += result.total_hits
+                has_content = any(
+                    getattr(doc, "raw_text", None)
+                    for doc in result.documents
+                )
+                if has_content:
+                    group_content[api_group] = True
+                elif api_group not in group_content:
+                    group_content[api_group] = False
             except Exception:
                 logger.debug(
                     "プローブ失敗 (source=%s): %s",
@@ -57,7 +64,7 @@ def probe_theme(keywords: list[str]) -> dict[str, int]:
                     future.exception(),
                 )
 
-    return dict(group_hits)
+    return dict(group_content)
 
 
 def probe_all_themes(themes: list[dict]) -> list[dict]:

--- a/curator_agents/schemas.py
+++ b/curator_agents/schemas.py
@@ -38,8 +38,8 @@ class ThemeSuggestion(BaseModel):
     primary_apis: list[str] = []
     # LLM が出力、プローブで使用（未出力時はテーマ文をフォールバック分割）
     probe_keywords: list[str] = []
-    # プローブ結果（API グループ → ヒット件数）
-    probe_hits: dict[str, int] = {}
+    # プローブ結果（API グループ → 全文取得可否）
+    probe_hits: dict[str, bool] = {}
 
     @field_validator("primary_apis")
     @classmethod

--- a/shared/api_coverage.py
+++ b/shared/api_coverage.py
@@ -132,20 +132,20 @@ def build_coverage_prompt_table() -> str:
 
 
 def calculate_coverage_score(
-    probe_results: dict[str, int],
+    probe_results: dict[str, bool],
 ) -> tuple[str, list[str]]:
     """プローブ結果からスコアと有効 API リストを算出する。
 
     Args:
-        probe_results: {api_key: total_hits} 形式のプローブ結果
+        probe_results: {api_key: has_content} 形式のプローブ結果
 
     Returns:
         (score, primary_apis) タプル。
         score は "HIGH" / "MEDIUM" / "LOW"。
-        primary_apis はヒットがあった API キーのリスト。
+        primary_apis は全文取得可能だった API キーのリスト。
     """
-    # ヒットがあった API を抽出
-    hit_apis = [k for k, v in probe_results.items() if v > 0]
+    # 全文取得可能な API を抽出
+    hit_apis = [k for k, v in probe_results.items() if v]
     hit_count = len(hit_apis)
 
     # 全文信頼度 HIGH の API がヒットに含まれるか

--- a/tests/unit/test_api_coverage.py
+++ b/tests/unit/test_api_coverage.py
@@ -79,34 +79,34 @@ class TestCalculateCoverageScore:
     """calculate_coverage_score() のスコア算出ロジックテスト。"""
 
     def test_high_score_three_apis_with_high_reliability(self):
-        """3+ API ヒット、うち 1+ が HIGH → HIGH。"""
-        probe = {"us_archives": 5, "internet_archive": 3, "trove": 2}
+        """3+ API で全文取得可能、うち 1+ が HIGH → HIGH。"""
+        probe = {"us_archives": True, "internet_archive": True, "trove": True}
         score, apis = calculate_coverage_score(probe)
         assert score == "HIGH"
         assert set(apis) == {"us_archives", "internet_archive", "trove"}
 
     def test_medium_score_two_apis(self):
-        """2 API ヒット → MEDIUM。"""
-        probe = {"europeana": 3, "ndl": 1}
+        """2 API で全文取得可能 → MEDIUM。"""
+        probe = {"europeana": True, "ndl": True}
         score, apis = calculate_coverage_score(probe)
         assert score == "MEDIUM"
         assert set(apis) == {"europeana", "ndl"}
 
     def test_high_score_three_apis_with_delpher(self):
-        """3 API ヒットで delpher(HIGH) 含む → HIGH。"""
-        probe = {"europeana": 3, "ndl": 2, "delpher": 1}
+        """3 API で全文取得可能、delpher(HIGH) 含む → HIGH。"""
+        probe = {"europeana": True, "ndl": True, "delpher": True}
         score, apis = calculate_coverage_score(probe)
         assert score == "HIGH"
 
     def test_low_score_single_api(self):
-        """1 API のみヒット → LOW。"""
-        probe = {"ndl": 5}
+        """1 API のみ全文取得可能 → LOW。"""
+        probe = {"ndl": True}
         score, apis = calculate_coverage_score(probe)
         assert score == "LOW"
 
     def test_low_score_no_hits(self):
-        """全 API ヒットなし → LOW。"""
-        probe = {"us_archives": 0, "europeana": 0}
+        """全 API で全文取得不可 → LOW。"""
+        probe = {"us_archives": False, "europeana": False}
         score, apis = calculate_coverage_score(probe)
         assert score == "LOW"
         assert apis == []
@@ -119,7 +119,7 @@ class TestCalculateCoverageScore:
 
     def test_unknown_api_key_ignored_for_reliability_check(self):
         """未知の API キーは信頼度チェックで無視される。"""
-        probe = {"unknown_api_1": 5, "unknown_api_2": 3, "unknown_api_3": 2}
+        probe = {"unknown_api_1": True, "unknown_api_2": True, "unknown_api_3": True}
         score, apis = calculate_coverage_score(probe)
-        # 3 API ヒットだが全て未知 → HIGH reliability なし → MEDIUM
+        # 3 API で全文取得可能だが全て未知 → HIGH reliability なし → MEDIUM
         assert score == "MEDIUM"

--- a/tests/unit/test_curator_probe.py
+++ b/tests/unit/test_curator_probe.py
@@ -1,6 +1,6 @@
 """Unit tests for curator_agents/probe.py.
 
-API プローブの並列実行、ヒット集約、エラー時のグレースフルデグラデーションをテストする。
+API プローブの並列実行、全文取得可否判定、エラー時のグレースフルデグラデーションをテストする。
 """
 
 from unittest.mock import MagicMock, patch
@@ -8,7 +8,18 @@ from unittest.mock import MagicMock, patch
 from curator_agents.probe import probe_all_themes, probe_theme
 
 
-def _make_mock_source(source_key: str, total_hits: int = 0, raise_error: bool = False):
+def _make_mock_doc(raw_text: str | None = None):
+    """テスト用のモックドキュメントを生成する。"""
+    doc = MagicMock()
+    doc.raw_text = raw_text
+    return doc
+
+
+def _make_mock_source(
+    source_key: str,
+    documents: list | None = None,
+    raise_error: bool = False,
+):
     """テスト用のモックソースを生成する。"""
     source = MagicMock()
     source.source_key = source_key
@@ -16,7 +27,8 @@ def _make_mock_source(source_key: str, total_hits: int = 0, raise_error: bool = 
         source.search.side_effect = Exception("API error")
     else:
         result = MagicMock()
-        result.total_hits = total_hits
+        result.documents = documents if documents is not None else []
+        result.total_hits = len(result.documents)
         source.search.return_value = result
     return source
 
@@ -24,26 +36,47 @@ def _make_mock_source(source_key: str, total_hits: int = 0, raise_error: bool = 
 class TestProbeTheme:
     """probe_theme() のテスト。"""
 
-    def test_aggregates_hits_by_api_group(self):
-        """source_key レベルの結果を API グループレベルに集約すること。"""
+    def test_detects_content_by_api_group(self):
+        """raw_text を持つドキュメントがある API グループは True になること。"""
         mock_sources = {
-            "nypl": _make_mock_source("nypl", total_hits=5),
-            "chronicling_america": _make_mock_source("chronicling_america", total_hits=3),
-            "europeana": _make_mock_source("europeana", total_hits=2),
-            "internet_archive": _make_mock_source("internet_archive", total_hits=0),
+            "nypl": _make_mock_source("nypl", documents=[_make_mock_doc("Full text here")]),
+            "chronicling_america": _make_mock_source("chronicling_america", documents=[_make_mock_doc("More text")]),
+            "europeana": _make_mock_source("europeana", documents=[_make_mock_doc("European text")]),
+            "internet_archive": _make_mock_source("internet_archive", documents=[]),
         }
         with patch("curator_agents.probe.get_all_sources", return_value=mock_sources):
             result = probe_theme(["Boston", "1850"])
 
-        # nypl + chronicling_america → us_archives に集約
-        assert result.get("us_archives", 0) == 8
-        assert result.get("europeana", 0) == 2
-        # internet_archive はヒット0だが結果には含まれる
-        assert result.get("internet_archive", 0) == 0
+        # nypl + chronicling_america → us_archives に集約（いずれかが True なら True）
+        assert result["us_archives"] is True
+        assert result["europeana"] is True
+        # internet_archive はドキュメントなし → False
+        assert result["internet_archive"] is False
+
+    def test_false_when_no_raw_text(self):
+        """ドキュメントはあるが raw_text が None の場合は False になること。"""
+        mock_sources = {
+            "europeana": _make_mock_source("europeana", documents=[_make_mock_doc(None)]),
+        }
+        with patch("curator_agents.probe.get_all_sources", return_value=mock_sources):
+            result = probe_theme(["test"])
+
+        assert result["europeana"] is False
+
+    def test_true_when_any_source_in_group_has_content(self):
+        """同一グループの複数ソースのうち1つでも raw_text があれば True になること。"""
+        mock_sources = {
+            "nypl": _make_mock_source("nypl", documents=[]),
+            "chronicling_america": _make_mock_source("chronicling_america", documents=[_make_mock_doc("Text")]),
+        }
+        with patch("curator_agents.probe.get_all_sources", return_value=mock_sources):
+            result = probe_theme(["test"])
+
+        assert result["us_archives"] is True
 
     def test_calls_search_with_max_results_1(self):
         """search を max_results=1 で呼ぶこと。"""
-        mock_source = _make_mock_source("nypl", total_hits=10)
+        mock_source = _make_mock_source("nypl", documents=[_make_mock_doc("text")])
         mock_sources = {"nypl": mock_source}
         with patch("curator_agents.probe.get_all_sources", return_value=mock_sources):
             probe_theme(["test"])
@@ -54,14 +87,14 @@ class TestProbeTheme:
         """API エラー時は該当ソースをスキップし、他のソースの結果を返すこと。"""
         mock_sources = {
             "nypl": _make_mock_source("nypl", raise_error=True),
-            "europeana": _make_mock_source("europeana", total_hits=5),
+            "europeana": _make_mock_source("europeana", documents=[_make_mock_doc("text")]),
         }
         with patch("curator_agents.probe.get_all_sources", return_value=mock_sources):
             result = probe_theme(["test"])
 
         # nypl はエラーで結果なし、europeana は正常
-        assert "us_archives" not in result or result.get("us_archives", 0) == 0
-        assert result.get("europeana", 0) == 5
+        assert "us_archives" not in result
+        assert result["europeana"] is True
 
     def test_empty_sources_returns_empty(self):
         """ソースが空の場合は空 dict を返すこと。"""
@@ -80,10 +113,10 @@ class TestProbeAllThemes:
              "probe_keywords": ["Boston", "harbor", "ghost"]},
         ]
         mock_sources = {
-            "nypl": _make_mock_source("nypl", total_hits=5),
-            "chronicling_america": _make_mock_source("chronicling_america", total_hits=3),
-            "internet_archive": _make_mock_source("internet_archive", total_hits=2),
-            "trove": _make_mock_source("trove", total_hits=1),
+            "nypl": _make_mock_source("nypl", documents=[_make_mock_doc("text")]),
+            "chronicling_america": _make_mock_source("chronicling_america", documents=[_make_mock_doc("text")]),
+            "internet_archive": _make_mock_source("internet_archive", documents=[_make_mock_doc("text")]),
+            "trove": _make_mock_source("trove", documents=[_make_mock_doc("text")]),
         }
         with patch("curator_agents.probe.get_all_sources", return_value=mock_sources):
             result = probe_all_themes(themes)
@@ -99,7 +132,7 @@ class TestProbeAllThemes:
             {"theme": "Boston Harbor Ghosts 1850", "description": "Test", "category": "OCC"},
         ]
         mock_sources = {
-            "nypl": _make_mock_source("nypl", total_hits=1),
+            "nypl": _make_mock_source("nypl", documents=[_make_mock_doc("text")]),
         }
         with patch("curator_agents.probe.get_all_sources", return_value=mock_sources) as _:
             probe_all_themes(themes)

--- a/tests/unit/test_curator_schemas.py
+++ b/tests/unit/test_curator_schemas.py
@@ -149,7 +149,7 @@ class TestValidateSuggestions:
                 "coverage_score": "HIGH",
                 "primary_apis": ["us_archives", "trove"],
                 "probe_keywords": ["Boston", "1850"],
-                "probe_hits": {"us_archives": 5, "trove": 2},
+                "probe_hits": {"us_archives": True, "trove": True},
             },
         ]
         result = validate_suggestions(raw)
@@ -157,7 +157,7 @@ class TestValidateSuggestions:
         assert result[0]["coverage_score"] == "HIGH"
         assert result[0]["primary_apis"] == ["us_archives", "trove"]
         assert result[0]["probe_keywords"] == ["Boston", "1850"]
-        assert result[0]["probe_hits"] == {"us_archives": 5, "trove": 2}
+        assert result[0]["probe_hits"] == {"us_archives": True, "trove": True}
 
 
 class TestBuildCategoryPromptSection:

--- a/web-admin/src/components/investigation-form.tsx
+++ b/web-admin/src/components/investigation-form.tsx
@@ -1,8 +1,10 @@
 import { Button } from "@ghost/shared/src/components/ui/button"
 import {
+  Check,
   Loader2,
   Search,
   Sparkles,
+  X,
 } from "lucide-react"
 
 const STORYTELLER_OPTIONS = [
@@ -38,7 +40,7 @@ interface ThemeSuggestion {
   description_ja?: string
   coverage_score?: "HIGH" | "MEDIUM" | "LOW"
   primary_apis?: string[]
-  probe_hits?: Record<string, number>
+  probe_hits?: Record<string, boolean>
 }
 
 interface InvestigationFormProps {
@@ -139,15 +141,22 @@ export function InvestigationForm({
                 <p className="text-xs text-muted-foreground mb-1">{s.theme_ja}</p>
               )}
               <p className="text-xs text-muted-foreground mb-1.5">{s.description_ja || s.description}</p>
-              {s.primary_apis && s.primary_apis.length > 0 && (
+              {s.probe_hits && Object.keys(s.probe_hits).length > 0 && (
                 <div className="flex flex-wrap gap-1">
-                  {s.primary_apis.map((api) => (
+                  {Object.entries(s.probe_hits).map(([api, found]) => (
                     <span
                       key={api}
-                      className="text-[10px] font-mono px-1.5 py-0.5 bg-border/30 text-muted-foreground rounded"
+                      className={`text-[10px] font-mono px-1.5 py-0.5 rounded inline-flex items-center gap-1 ${
+                        found
+                          ? "bg-border/30 text-muted-foreground"
+                          : "bg-border/10 text-muted-foreground/40"
+                      }`}
                     >
                       {API_DISPLAY_NAMES[api] || api}
-                      {s.probe_hits?.[api] != null && ` (${s.probe_hits[api]})`}
+                      {found
+                        ? <Check className="w-3 h-3 text-emerald-400" />
+                        : <X className="w-3 h-3 text-red-400/50" />
+                      }
                     </span>
                   ))}
                 </div>


### PR DESCRIPTION
## Summary

- `probe_hits` の型を `dict[str, int]`（API の total_hits）から `dict[str, bool]`（全文取得可否）に変更
- Delpher 3,300万件のような誤解を招く数字の代わりに、`raw_text` を持つドキュメントが実際に取得できたかどうかをバイナリ判定
- UI バッジを数字表示からチェックマーク（✓）/ バツ印（✗）に変更

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `curator_agents/probe.py` | `group_hits(int)` → `group_content(bool)`、`result.documents` の `raw_text` 有無で判定 |
| `shared/api_coverage.py` | `calculate_coverage_score` の引数型を `dict[str, bool]` に変更 |
| `curator_agents/schemas.py` | `ThemeSuggestion.probe_hits` の型を `dict[str, bool]` に変更 |
| `web-admin/src/components/investigation-form.tsx` | 数字バッジ → `Check`/`X` アイコン表示、`probe_hits` 全キーを表示 |
| `tests/unit/test_curator_probe.py` | ドキュメント・raw_text ベースのモックに書き換え |
| `tests/unit/test_api_coverage.py` | テスト入力を `int` → `bool` に変更 |
| `tests/unit/test_curator_schemas.py` | `probe_hits` テストデータを `bool` に変更 |

## Test plan

- [x] `pytest tests/unit/test_curator_probe.py tests/unit/test_api_coverage.py tests/unit/test_curator_schemas.py -v` — 51 passed
- [x] `pytest tests/unit/ -v` — 1413 passed
- [ ] Docker Compose でローカル起動 → テーマ提案 → バッジにチェックマーク/バツ印が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)