### PR TITLE
refactor: Firestore クライアント書き込みを Server Actions (Admin SDK) に移行

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -3,23 +3,23 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
 
-    // mysteries: web-admin（Cloud IAP 保護下）からの読み書き許可
+    // mysteries: 読み取りのみ許可（書き込みは Server Actions 経由で Admin SDK を使用）
     // web-public は SSG ビルド時に Admin SDK でアクセスするためルール不要
     match /mysteries/{mysteryId} {
       allow read: if true;
-      allow write: if true;
+      allow write: if false;
     }
 
-    // podcasts: web-admin からの読み書き許可
+    // podcasts: 読み取りのみ許可（書き込みは Server Actions 経由で Admin SDK を使用）
     match /podcasts/{podcastId} {
       allow read: if true;
-      allow write: if true;
+      allow write: if false;
     }
 
-    // product_designs: web-admin からの読み書き許可
+    // product_designs: 読み取りのみ許可（書き込みは Python Admin SDK のみ）
     match /product_designs/{designId} {
       allow read: if true;
-      allow write: if true;
+      allow write: if false;
     }
 
     // pipeline_runs: web-admin から読み取りのみ（進捗表示用）

--- a/web-admin/src/actions/mysteries.ts
+++ b/web-admin/src/actions/mysteries.ts
@@ -1,0 +1,66 @@
+"use server"
+
+/**
+ * Mystery 書き込み操作の Server Actions
+ * クライアント SDK → Admin SDK に移行してセキュリティルールをバイパス
+ */
+
+import { getAdminFirestore, ADMIN_COLLECTIONS } from "@/lib/firebase/admin"
+import { FieldValue } from "firebase-admin/firestore"
+
+type ActionResult = { success: true } | { success: false; error: string }
+
+/**
+ * ミステリーを承認（pending → published）
+ */
+export async function approveMystery(mysteryId: string): Promise<ActionResult> {
+  try {
+    const db = getAdminFirestore()
+    await db.collection(ADMIN_COLLECTIONS.MYSTERIES).doc(mysteryId).update({
+      status: "published",
+      publishedAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+    })
+    return { success: true }
+  } catch (error) {
+    console.error("Failed to approve mystery:", error)
+    const message = error instanceof Error ? error.message : "不明なエラー"
+    return { success: false, error: message }
+  }
+}
+
+/**
+ * ミステリーをアーカイブ（→ archived）
+ */
+export async function archiveMystery(mysteryId: string): Promise<ActionResult> {
+  try {
+    const db = getAdminFirestore()
+    await db.collection(ADMIN_COLLECTIONS.MYSTERIES).doc(mysteryId).update({
+      status: "archived",
+      updatedAt: FieldValue.serverTimestamp(),
+    })
+    return { success: true }
+  } catch (error) {
+    console.error("Failed to archive mystery:", error)
+    const message = error instanceof Error ? error.message : "不明なエラー"
+    return { success: false, error: message }
+  }
+}
+
+/**
+ * 公開済みミステリーを非公開に戻す（published → pending）
+ */
+export async function unpublishMystery(mysteryId: string): Promise<ActionResult> {
+  try {
+    const db = getAdminFirestore()
+    await db.collection(ADMIN_COLLECTIONS.MYSTERIES).doc(mysteryId).update({
+      status: "pending",
+      updatedAt: FieldValue.serverTimestamp(),
+    })
+    return { success: true }
+  } catch (error) {
+    console.error("Failed to unpublish mystery:", error)
+    const message = error instanceof Error ? error.message : "不明なエラー"
+    return { success: false, error: message }
+  }
+}

--- a/web-admin/src/actions/podcasts.ts
+++ b/web-admin/src/actions/podcasts.ts
@@ -1,0 +1,33 @@
+"use server"
+
+/**
+ * Podcast 書き込み操作の Server Actions
+ * クライアント SDK → Admin SDK に移行してセキュリティルールをバイパス
+ */
+
+import { getAdminFirestore, ADMIN_COLLECTIONS } from "@/lib/firebase/admin"
+import { FieldValue } from "firebase-admin/firestore"
+import type { PodcastScript } from "@ghost/shared/src/types/mystery"
+
+type ActionResult = { success: true } | { success: false; error: string }
+
+/**
+ * Podcast 脚本を更新
+ */
+export async function updatePodcastScript(
+  podcastId: string,
+  script: PodcastScript
+): Promise<ActionResult> {
+  try {
+    const db = getAdminFirestore()
+    await db.collection(ADMIN_COLLECTIONS.PODCASTS).doc(podcastId).update({
+      script,
+      updated_at: FieldValue.serverTimestamp(),
+    })
+    return { success: true }
+  } catch (error) {
+    console.error("Failed to update podcast script:", error)
+    const message = error instanceof Error ? error.message : "不明なエラー"
+    return { success: false, error: message }
+  }
+}

--- a/web-admin/src/app/(main)/podcasts/[id]/podcast-detail.tsx
+++ b/web-admin/src/app/(main)/podcasts/[id]/podcast-detail.tsx
@@ -6,7 +6,7 @@ import { Button } from "@ghost/shared/src/components/ui/button"
 import { usePodcast } from "@/hooks/use-podcast"
 import { usePipelineRun } from "@/hooks/use-pipeline-run"
 import { useActionFeedback } from "@/hooks/use-action-feedback"
-import { updatePodcastScript } from "@/lib/firestore/podcasts"
+import { updatePodcastScript } from "@/actions/podcasts"
 import { PodcastStatusBadge } from "@/components/podcast-status-badge"
 import { AudioPlayer } from "@/components/audio-player"
 import { ScriptEditor } from "@/components/script-editor"
@@ -52,13 +52,13 @@ export function PodcastDetail({ podcastId }: PodcastDetailProps) {
     if (!editedScript || !podcast) return
     setSaving(true)
     try {
-      await updatePodcastScript(podcastId, editedScript)
-      hasUnsavedChanges.current = false
-      feedback.showSuccess("脚本を保存しました")
-    } catch (error) {
-      console.error("Failed to save script:", error)
-      const message = error instanceof Error ? error.message : "不明なエラー"
-      feedback.showError(`脚本の保存に失敗しました: ${message}`)
+      const result = await updatePodcastScript(podcastId, editedScript)
+      if (result.success) {
+        hasUnsavedChanges.current = false
+        feedback.showSuccess("脚本を保存しました")
+      } else {
+        feedback.showError(`脚本の保存に失敗しました: ${result.error}`)
+      }
     } finally {
       setSaving(false)
     }

--- a/web-admin/src/hooks/use-mystery-actions.ts
+++ b/web-admin/src/hooks/use-mystery-actions.ts
@@ -1,7 +1,7 @@
 "use client"
 
 import { useCallback } from "react"
-import { approveMystery, archiveMystery, unpublishMystery } from "@/lib/firestore/mysteries"
+import { approveMystery, archiveMystery, unpublishMystery } from "@/actions/mysteries"
 import { useActionFeedback, type ActionFeedback } from "@/hooks/use-action-feedback"
 
 interface UseMysteryActionsOptions {
@@ -21,42 +21,36 @@ export function useMysteryActions({ onSuccess }: UseMysteryActionsOptions) {
   }
 
   const handleApprove = useCallback(async (id: string) => {
-    try {
-      await approveMystery(id)
+    const result = await approveMystery(id)
+    if (result.success) {
       feedback.showSuccess(`Case ${id} approved and published`)
       onSuccess()
       triggerRebuild()
-    } catch (error) {
-      console.error("Failed to approve:", error)
-      const message = error instanceof Error ? error.message : "不明なエラー"
-      feedback.showError(`承認に失敗しました: ${message}`)
+    } else {
+      feedback.showError(`承認に失敗しました: ${result.error}`)
     }
   }, [feedback, onSuccess])
 
   const handleArchive = useCallback(async (id: string) => {
-    try {
-      await archiveMystery(id)
+    const result = await archiveMystery(id)
+    if (result.success) {
       feedback.showSuccess(`Case ${id} archived`)
       onSuccess()
       triggerRebuild()
-    } catch (error) {
-      console.error("Failed to archive:", error)
-      const message = error instanceof Error ? error.message : "不明なエラー"
-      feedback.showError(`アーカイブに失敗しました: ${message}`)
+    } else {
+      feedback.showError(`アーカイブに失敗しました: ${result.error}`)
     }
   }, [feedback, onSuccess])
 
   const handleUnpublish = useCallback(async (id: string) => {
     if (!window.confirm("この記事を非公開に戻しますか？公開サイトから削除されます。")) return
-    try {
-      await unpublishMystery(id)
+    const result = await unpublishMystery(id)
+    if (result.success) {
       feedback.showSuccess(`Case ${id} unpublished`)
       onSuccess()
       triggerRebuild()
-    } catch (error) {
-      console.error("Failed to unpublish:", error)
-      const message = error instanceof Error ? error.message : "不明なエラー"
-      feedback.showError(`非公開への変更に失敗しました: ${message}`)
+    } else {
+      feedback.showError(`非公開への変更に失敗しました: ${result.error}`)
     }
   }, [feedback, onSuccess])
 

--- a/web-admin/src/lib/firebase/admin.ts
+++ b/web-admin/src/lib/firebase/admin.ts
@@ -70,4 +70,5 @@ export function getAdminFirestore(): Firestore {
 /** Admin用 Firestore コレクション名 */
 export const ADMIN_COLLECTIONS = {
   MYSTERIES: "mysteries",
+  PODCASTS: "podcasts",
 } as const;

--- a/web-admin/src/lib/firestore/mysteries.ts
+++ b/web-admin/src/lib/firestore/mysteries.ts
@@ -1,6 +1,6 @@
 /**
- * Mysteries Firestore 操作（管理者用）
- * 書き込み操作と管理者固有の読み取りクエリのみ
+ * Mysteries Firestore 読み取り操作（管理者用）
+ * 書き込み操作は Server Actions（@/actions/mysteries）に移行済み
  * 共通の読み取りクエリは @ghost/shared から動的ラッパー経由で提供
  *
  * NOTE: @ghost/shared/src/lib/firestore/queries は firebase/firestore と
@@ -77,61 +77,4 @@ export async function getAllMysteries(
 
   const snapshot = await getDocs(q);
   return snapshot.docs.map((d) => docToMystery(d.data()));
-}
-
-// ============================================
-// 書き込み操作
-// ============================================
-
-/**
- * ミステリーを承認（直接公開）
- * status を pending → published に更新
- * English-first フローでは翻訳は既にパイプライン内で完了しているため、
- * Approve は即座に公開する。
- */
-export async function approveMystery(mysteryId: string): Promise<void> {
-  const { doc, updateDoc, Timestamp } = await import("firebase/firestore");
-  const { getFirestoreDb, COLLECTIONS } = await import("@ghost/shared/src/lib/firebase/config");
-
-  const db = getFirestoreDb();
-  const docRef = doc(db, COLLECTIONS.MYSTERIES, mysteryId);
-
-  await updateDoc(docRef, {
-    status: "published" as MysteryStatus,
-    publishedAt: Timestamp.now(),
-    updatedAt: Timestamp.now(),
-  });
-}
-
-/**
- * ミステリーをアーカイブ（非公開化）
- */
-export async function archiveMystery(mysteryId: string): Promise<void> {
-  const { doc, updateDoc, Timestamp } = await import("firebase/firestore");
-  const { getFirestoreDb, COLLECTIONS } = await import("@ghost/shared/src/lib/firebase/config");
-
-  const db = getFirestoreDb();
-  const docRef = doc(db, COLLECTIONS.MYSTERIES, mysteryId);
-
-  await updateDoc(docRef, {
-    status: "archived" as MysteryStatus,
-    updatedAt: Timestamp.now(),
-  });
-}
-
-/**
- * 公開済みミステリーを非公開に戻す（published → pending）
- * publishedAt は再公開時の参考情報として保持する
- */
-export async function unpublishMystery(mysteryId: string): Promise<void> {
-  const { doc, updateDoc, Timestamp } = await import("firebase/firestore");
-  const { getFirestoreDb, COLLECTIONS } = await import("@ghost/shared/src/lib/firebase/config");
-
-  const db = getFirestoreDb();
-  const docRef = doc(db, COLLECTIONS.MYSTERIES, mysteryId);
-
-  await updateDoc(docRef, {
-    status: "pending" as MysteryStatus,
-    updatedAt: Timestamp.now(),
-  });
 }

--- a/web-admin/src/lib/firestore/podcasts.ts
+++ b/web-admin/src/lib/firestore/podcasts.ts
@@ -1,6 +1,6 @@
 /**
- * Podcasts Firestore 操作（管理者用）
- * podcasts コレクションの CRUD 操作
+ * Podcasts Firestore 読み取り操作（管理者用）
+ * 書き込み操作は Server Actions（@/actions/podcasts）に移行済み
  */
 
 import type { FirestorePodcast, PodcastScript } from "@ghost/shared/src/types/mystery"
@@ -90,25 +90,6 @@ export async function getPodcastsByMysteryId(
   const snapshot = await getDocs(q)
 
   return snapshot.docs.map((doc) => docToPodcast(doc.id, doc.data()))
-}
-
-/**
- * 脚本を更新（編集後の保存）
- */
-export async function updatePodcastScript(
-  podcastId: string,
-  script: PodcastScript
-): Promise<void> {
-  const { doc, updateDoc, Timestamp } = await import("firebase/firestore")
-  const { getFirestoreDb, COLLECTIONS } = await import("@ghost/shared/src/lib/firebase/config")
-
-  const db = getFirestoreDb()
-  const docRef = doc(db, COLLECTIONS.PODCASTS, podcastId)
-
-  await updateDoc(docRef, {
-    script,
-    updated_at: Timestamp.now(),
-  })
 }
 
 /**


### PR DESCRIPTION
## Summary

- Firestore セキュリティ強化: `allow write: if true` → `allow write: if false`
- web-admin の4つのクライアント書き込み操作を Next.js Server Actions（Admin SDK）に移行
- Admin SDK はセキュリティルールをバイパスするため、既存動作に影響なし

## 変更内容

### 新規作成
- `web-admin/src/actions/mysteries.ts` — approveMystery / archiveMystery / unpublishMystery を Admin SDK で実装
- `web-admin/src/actions/podcasts.ts` — updatePodcastScript を Admin SDK で実装

### 修正
- `web-admin/src/lib/firebase/admin.ts` — `ADMIN_COLLECTIONS` に `PODCASTS` を追加
- `web-admin/src/lib/firestore/mysteries.ts` — 書き込み関数3つを削除（読み取りのみ残す）
- `web-admin/src/lib/firestore/podcasts.ts` — `updatePodcastScript` を削除（読み取りのみ残す）
- `web-admin/src/hooks/use-mystery-actions.ts` — import 先を `@/actions/mysteries` に変更、戻り値チェック追加
- `web-admin/src/app/(main)/podcasts/[id]/podcast-detail.tsx` — import 先を `@/actions/podcasts` に変更、戻り値チェック追加

### セキュリティルール
- `firestore.rules` — mysteries / podcasts / product_designs の `allow write` を `if false` に変更

## 設計判断
- Server Actions の戻り値: `{ success: true } | { success: false; error: string }` （Error オブジェクトはシリアライズ不可のため）
- `triggerRebuild()` は hook にそのまま残す（UI 関心事、fire-and-forget）
- 読み取り操作（`onSnapshot` リアルタイムリスナー含む）は一切変更なし

## Test plan
- [ ] Firebase Emulator + dev サーバーで記事の Approve / Archive / Unpublish が動作する
- [ ] Podcast 脚本の編集・保存が動作する
- [ ] エラー時にトーストが正しく表示される
- [ ] クライアント読み取り（一覧表示、リアルタイム更新）が正常動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)