### PR TITLE
fix: ソース単位の全除外防止 — 非英語ドキュメント全喪失バグ修正

### DIFF
--- a/mystery_agents/tools/search_orchestration.py
+++ b/mystery_agents/tools/search_orchestration.py
@@ -97,12 +97,41 @@ def _search_single_source(
 def _filter_irrelevant_documents(
     docs: list[ArchiveDocument],
 ) -> tuple[list[ArchiveDocument], int]:
-    """keywords_matched が空のドキュメントを除外する。"""
-    filtered = [d for d in docs if d.keywords_matched]
-    removed = len(docs) - len(filtered)
-    if removed > 0:
-        logger.info("キーワード無一致ドキュメント除外: %d 件", removed)
-    return filtered, removed
+    """keywords_matched が空のドキュメントを除外する。
+
+    ソース単位の全除外防止: あるソースの全ドキュメントが除外対象の場合、
+    API の検索結果を尊重してそのソースのドキュメントを全て保持する。
+    これにより、形態論的差異（オランダ語等）で部分文字列マッチが
+    系統的に失敗するソースのドキュメントが失われることを防ぐ。
+    """
+    by_source: dict[str, list[ArchiveDocument]] = defaultdict(list)
+    for doc in docs:
+        by_source[doc.source_type].append(doc)
+
+    filtered: list[ArchiveDocument] = []
+    total_removed = 0
+
+    for source_type, source_docs in by_source.items():
+        matched = [d for d in source_docs if d.keywords_matched]
+        if matched:
+            # 一部マッチ → マッチしたもののみ保持（通常フィルタ）
+            filtered.extend(matched)
+            removed = len(source_docs) - len(matched)
+            if removed > 0:
+                logger.info(
+                    "キーワード無一致ドキュメント除外: %s から %d 件",
+                    source_type, removed,
+                )
+            total_removed += removed
+        else:
+            # 全除外防止: API 検索結果を尊重して全保持
+            filtered.extend(source_docs)
+            logger.info(
+                "キーワード無一致 全除外防止: %s の %d 件を保持（API 検索結果を尊重）",
+                source_type, len(source_docs),
+            )
+
+    return filtered, total_removed
 
 
 def _rank_documents(

--- a/tests/unit/test_evidence_relevance.py
+++ b/tests/unit/test_evidence_relevance.py
@@ -54,7 +54,7 @@ class TestFilterIrrelevantDocuments:
         assert removed == 0
 
     def test_filter_all_zero_match(self):
-        """全件0一致 → 空リスト。"""
+        """同一ソースで全件0一致 → 全除外防止で全件保持。"""
         from mystery_agents.tools.search_orchestration import _filter_irrelevant_documents
 
         docs = [
@@ -62,7 +62,43 @@ class TestFilterIrrelevantDocuments:
             make_archive_doc(url="https://example.com/2", keywords_matched=[]),
         ]
         result, removed = _filter_irrelevant_documents(docs)
-        assert result == []
+        assert len(result) == 2
+        assert removed == 0
+
+    def test_filter_preserves_source_with_all_zero_match(self):
+        """ソースA全件0一致 + ソースB一部一致 → ソースA全保持、ソースB通常フィルタ。"""
+        from mystery_agents.tools.search_orchestration import _filter_irrelevant_documents
+
+        docs = [
+            # delpher: 全件0一致 → 全除外防止で保持
+            make_archive_doc(url="https://example.com/d1", source_type="delpher", keywords_matched=[]),
+            make_archive_doc(url="https://example.com/d2", source_type="delpher", keywords_matched=[]),
+            # nypl: 一部一致 → 0一致は通常通り除外
+            make_archive_doc(url="https://example.com/n1", source_type="nypl", keywords_matched=["key1"]),
+            make_archive_doc(url="https://example.com/n2", source_type="nypl", keywords_matched=[]),
+        ]
+        result, removed = _filter_irrelevant_documents(docs)
+        urls = [d.source_url for d in result]
+        # delpher 2件は全保持
+        assert "https://example.com/d1" in urls
+        assert "https://example.com/d2" in urls
+        # nypl はマッチした1件のみ
+        assert "https://example.com/n1" in urls
+        assert "https://example.com/n2" not in urls
+        assert removed == 1
+
+    def test_filter_partial_match_source_still_filters(self):
+        """同一ソースで一部マッチ → 0一致ドキュメントは通常通り除外。"""
+        from mystery_agents.tools.search_orchestration import _filter_irrelevant_documents
+
+        docs = [
+            make_archive_doc(url="https://example.com/1", source_type="delpher", keywords_matched=["key"]),
+            make_archive_doc(url="https://example.com/2", source_type="delpher", keywords_matched=[]),
+            make_archive_doc(url="https://example.com/3", source_type="delpher", keywords_matched=[]),
+        ]
+        result, removed = _filter_irrelevant_documents(docs)
+        assert len(result) == 1
+        assert result[0].source_url == "https://example.com/1"
         assert removed == 2
 
 


### PR DESCRIPTION
## Summary

- `_filter_irrelevant_documents()` が非英語ソース（Delpher, NDL等）の全ドキュメントを除外するバグを修正
- 形態論的差異（オランダ語 `luchtschepen` vs `luchtschip` 等）で部分文字列マッチが系統的に失敗し、`keywords_matched=[]` → 全除外 → 偽の「データ不在」が発生していた
- ソース単位で判定し、全ドキュメントが除外対象のソースは API 検索結果を尊重して全保持する

## 変更内容

| ファイル | 変更 |
|---|---|
| `mystery_agents/tools/search_orchestration.py` | `_filter_irrelevant_documents()` をソース単位判定に変更 |
| `tests/unit/test_evidence_relevance.py` | 既存テスト期待値更新 + 新規テスト2件追加 |

## 修正ロジック

- **全除外防止**: あるソースの全ドキュメントが `keywords_matched=[]` → そのソース全保持
- **通常フィルタ**: 一部でもマッチするドキュメントがあるソース → 0一致ドキュメントは従来通り除外
- シグネチャ・戻り値の型は変更なし（`_rank_documents()` 等への影響なし）

## Test plan

- [x] `TestFilterIrrelevantDocuments` 6件全通過（既存4件 + 新規2件）
- [x] `TestRankDocumentsExcludesZeroMatch` 変更なしで通過
- [x] 関連テスト通過（`test_librarian_tools.py`, `test_delpher.py`）
- [x] 全ユニットテスト 1424件通過、リグレッションなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)