### PR TITLE
fix: 3層偽陽性対策 — reference_keywords_matched による主題的関連性の検証強化

### DIFF
--- a/mystery_agents/agents/aggregator.py
+++ b/mystery_agents/agents/aggregator.py
@@ -220,6 +220,13 @@ def _format_documents(
         if matched:
             kw_str = ", ".join(matched) if isinstance(matched, list) else str(matched)
             lines.append(f"- **Keywords matched**: {kw_str}")
+        ref_matched = doc.get("reference_keywords_matched")
+        if isinstance(ref_matched, list):
+            if ref_matched:
+                ref_str = ", ".join(ref_matched)
+                lines.append(f"- **Reference keywords matched**: {ref_str}")
+            else:
+                lines.append("- **Reference keywords matched**: (none — exploratory match only)")
         if doc.get("raw_text"):
             # テキスト抜粋は5000文字に制限（fulltext_extraction.max_output_chars と一致）
             excerpt = str(doc["raw_text"])[:5000]

--- a/mystery_agents/agents/polymath_instructions.py
+++ b/mystery_agents/agents/polymath_instructions.py
@@ -96,6 +96,14 @@ Armchair Polymath の instruction を構成する3つのセクション
 #    調査対象のミステリーと直接的かつ実質的な関連を持たなければならない。
 #    語呂合わせ、比喩、同音異義語、テーマ的類推でのみ繋がるソースは有効な証拠ではない。
 #    文書のタイトルが調査対象と関連しない場合、解釈的つながりがどれほど巧みでも選択しない。
+# 6. **証拠には reference キーワードマッチが必須**: すべての証拠ドキュメント
+#    （evidence_a, evidence_b, additional_evidence）は、タイトルまたはテキスト内に
+#    少なくとも1つの reference キーワードがマッチしていなければならない。
+#    Reference キーワードとは調査固有の固有名詞・日付・地名（例: "Watseka", "Vennum", "1877"）。
+#    探索的キーワード（"identity", "spirit", "possession" 等のテーマ的用語）のみにマッチする
+#    ドキュメントは文脈的背景であり、証拠ではない。文書インベントリの
+#    `reference_keywords_matched` 列を確認すること — 値が 0 の場合、そのドキュメントは
+#    調査対象との直接的な主題的関連がない。
 #
 # ## アーカイブ画像の審査（必須）
 # 文書インベントリは `archive_images` も返す — デジタルアーカイブからの視覚資料で、
@@ -400,6 +408,15 @@ to see all documents collected by the Librarian, organized by archive.
    investigation. A source connected only through wordplay, metaphor, homonym, or thematic
    analogy is NOT valid evidence. If a document's title does not relate to the investigation
    subject, do not select it — regardless of how clever the interpretive connection may seem.
+
+6. **Reference keyword matching is required for evidence**: Every evidence document
+   (evidence_a, evidence_b, additional_evidence) MUST match at least one reference
+   keyword in its title or text. Reference keywords are proper nouns, dates, and place
+   names specific to the investigation (e.g., "Watseka", "Vennum", "1877"). Documents
+   matching ONLY exploratory keywords (thematic terms like "identity", "spirit",
+   "possession") are contextual background, NOT evidence. In the document inventory,
+   check the `reference_keywords_matched` column — a value of 0 means the document
+   has no direct topical connection to the investigation subject.
 
 ## Archive Image Review (MANDATORY)
 

--- a/mystery_agents/agents/scholar_instructions.py
+++ b/mystery_agents/agents/scholar_instructions.py
@@ -33,6 +33,13 @@ Multilingual Scholar の instruction テンプレートを定義する。
 #   "FALSE POSITIVE: [タイトル] — 調査と無関係（キーワードの同音異義語またはメタデータマッチの可能性）"とフラグする
 # - false positive ドキュメントに基づいて分析結論を構築してはならない
 #
+# **Reference キーワード指標**: 各ドキュメントに "Reference keywords matched" 行が含まれる。
+# `(none — exploratory match only)` のドキュメントは、タイトルやテキストに調査テーマの固有名詞・日付・地名が含まれない。
+# これらのドキュメントは:
+# - **文脈情報としてのみ**扱うこと（時代背景、法制度など）
+# - 矛盾・アノマリー・食い違いの特定に使用しては**ならない**
+# - いかなる主張の一次証拠として引用しては**ならない**
+#
 # ## 分析フレームワーク 5: ソースカバレッジ評価
 # - デジタル化範囲: この時代・地域の {language_name} 語資料のうちデジタル化済みの割合
 # - OCR 品質: 当該時代の文書のOCR信頼性（活字体変遷、印刷品質、手書き文書）
@@ -82,6 +89,13 @@ INSUFFICIENT_DATA: No {language_name}-language documents available for analysis.
 - If a document's title and description have no clear connection to the investigation theme, flag it as:
   "FALSE POSITIVE: [title] — appears unrelated to the investigation (possible keyword homonym or metadata match)"
 - Do NOT build analysis conclusions on false positive documents.
+
+**Reference keyword indicator**: Each document now includes a "Reference keywords matched"
+line. Documents with `(none — exploratory match only)` have NO proper nouns, dates, or
+place names from the investigation theme in their title or text. These documents:
+- MUST be treated as **CONTEXT ONLY** (background on the era, legal system, etc.)
+- MUST NOT be used to identify discrepancies, anomalies, or contradictions
+- MUST NOT be cited as primary evidence for any claim
 
 ### 1. Source Analysis
 - Analyze {language_name}-language sources for their unique perspective on the investigation theme

--- a/mystery_agents/schemas/document.py
+++ b/mystery_agents/schemas/document.py
@@ -52,6 +52,10 @@ class ArchiveDocument(BaseModel):
     keywords_matched: List[str] = Field(
         default_factory=list, description="Keywords that matched this document"
     )
+    reference_keywords_matched: List[str] = Field(
+        default_factory=list,
+        description="Reference keywords (proper nouns, dates, places) found in title/summary",
+    )
 
     model_config = {"use_enum_values": True}
 

--- a/mystery_agents/tools/document_inventory.py
+++ b/mystery_agents/tools/document_inventory.py
@@ -123,6 +123,7 @@ def get_document_inventory(tool_context: Optional[ToolContext] = None) -> str:
                 "date": doc.get("date"),
                 "language": doc.get("language", ""),
                 "keywords_matched": len(doc.get("keywords_matched", [])),
+                "reference_keywords_matched": len(doc.get("reference_keywords_matched", [])),
             }
             by_archive[archive_name].append(entry)
             total += 1

--- a/mystery_agents/tools/librarian_tools.py
+++ b/mystery_agents/tools/librarian_tools.py
@@ -339,6 +339,14 @@ def search_newspapers(
         },
     )
 
+    # reference_keywords_matched を算出: title/summary 内の固有名詞マッチ
+    if reference_list:
+        for doc in all_docs:
+            combined = f"{doc.title} {doc.summary}".lower()
+            doc.reference_keywords_matched = [
+                kw for kw in reference_list if kw.lower() in combined
+            ]
+
     docs = [doc.model_dump() for doc in all_docs]
 
     link_validation_dict = {

--- a/mystery_agents/tools/scholar_tools.py
+++ b/mystery_agents/tools/scholar_tools.py
@@ -143,6 +143,17 @@ def _validate_evidence_grounding(
                     f"{label}: キーワード無一致 — false positive の可能性 "
                     f"(title: {raw_doc.get('title', 'unknown')})"
                 )
+
+            # reference キーワード妥当性チェック
+            # フィールドが明示的に存在する場合のみ（後方互換: 旧データにはフィールドなし）
+            ref_kw_matched = raw_doc.get("reference_keywords_matched")
+            if ref_kw_matched is not None:
+                ev["_ref_kw_match_count"] = len(ref_kw_matched)
+                if isinstance(ref_kw_matched, list) and not ref_kw_matched:
+                    warnings.append(
+                        f"{label}: reference キーワード無一致 — 主題的関連性が低い可能性 "
+                        f"(title: {raw_doc.get('title', 'unknown')})"
+                    )
         else:
             ev["_ungrounded"] = True
             warnings.append(
@@ -274,6 +285,32 @@ def save_structured_report(
             warnings.append(f"additional_evidence: {kw_removed} 件除外 (キーワード無一致)")
         report_data["additional_evidence"] = additional
 
+    # additional_evidence: reference キーワード無一致の項目を除外
+    # ただし、全 evidence の reference_keywords が空の場合はスキップ
+    # （Librarian が reference_keywords を生成しなかった調査を許容）
+    additional = report_data.get("additional_evidence")
+    if additional is not None:
+        # evidence_a/b + additional の全 evidence を対象に has_any_ref を判定
+        evidence_items_all = []
+        for key in ("evidence_a", "evidence_b"):
+            ev = report_data.get(key)
+            if ev and isinstance(ev, dict):
+                evidence_items_all.append(ev)
+        evidence_items_all.extend(additional)
+
+        has_any_ref = any(
+            ev.get("_ref_kw_match_count", 0) > 0 for ev in evidence_items_all
+        )
+        if has_any_ref:
+            before_ref = len(additional)
+            additional = [ev for ev in additional if ev.get("_ref_kw_match_count", 0) > 0]
+            ref_removed = before_ref - len(additional)
+            if ref_removed:
+                warnings.append(
+                    f"additional_evidence: {ref_removed} 件除外 (reference キーワード無一致)"
+                )
+        report_data["additional_evidence"] = additional
+
     # additional_evidence: _ungrounded 項目を除外
     additional = report_data.get("additional_evidence")
     if additional is not None:
@@ -301,6 +338,7 @@ def save_structured_report(
         ev = report_data.get(key)
         if ev and isinstance(ev, dict):
             ev.pop("_kw_match_count", None)
+            ev.pop("_ref_kw_match_count", None)
             ev.pop("_ungrounded", None)
 
     # additional_evidence の一時フィールドをクリーンアップ
@@ -308,6 +346,7 @@ def save_structured_report(
     if additional is not None:
         for ev in additional:
             ev.pop("_ungrounded", None)
+            ev.pop("_ref_kw_match_count", None)
 
     # タグバリデーション
     tags = report_data.get("tags")

--- a/mystery_agents/tools/search_orchestration.py
+++ b/mystery_agents/tools/search_orchestration.py
@@ -91,6 +91,14 @@ def _search_single_source(
             if docs:
                 break
 
+    # reference_keywords_matched を算出: title/summary 内の固有名詞マッチ
+    if reference_keywords:
+        for doc in docs:
+            combined = f"{doc.title} {doc.summary}".lower()
+            doc.reference_keywords_matched = [
+                kw for kw in reference_keywords if kw.lower() in combined
+            ]
+
     return key, docs, total_hits, error, fallback_used
 
 
@@ -150,7 +158,10 @@ def _rank_documents(
     for doc in docs:
         by_source[doc.source_type].append(doc)
     for key in by_source:
-        by_source[key].sort(key=lambda d: len(d.keywords_matched), reverse=True)
+        by_source[key].sort(
+            key=lambda d: (len(d.reference_keywords_matched), len(d.keywords_matched)),
+            reverse=True,
+        )
 
     # ラウンドロビンインターリーブ
     result: list[ArchiveDocument] = []

--- a/tests/unit/test_aggregator.py
+++ b/tests/unit/test_aggregator.py
@@ -234,6 +234,43 @@ class TestComputeFulltextMetrics:
         assert metrics["by_language"]["de"]["metadata_only"] == 2
 
 
+class TestReferenceKeywordsDisplay:
+    """reference_keywords_matched の表示テスト。"""
+
+    def test_format_documents_shows_reference_keywords(self):
+        """reference_keywords_matched があるドキュメントは表示されるべき。"""
+        docs = [
+            {
+                "title": "The Watseka Wonder",
+                "source_url": "https://example.com/watseka",
+                "summary": "About Lurancy Vennum",
+                "language": "en",
+                "source_type": "nypl",
+                "keywords_matched": ["spirit", "identity"],
+                "reference_keywords_matched": ["Watseka", "Vennum"],
+            }
+        ]
+        result = _format_documents("en", docs)
+        assert "Watseka, Vennum" in result
+        assert "Reference keywords matched" in result
+
+    def test_format_documents_shows_none_for_exploratory_only(self):
+        """reference_keywords_matched が空のドキュメントは (none) と表示されるべき。"""
+        docs = [
+            {
+                "title": "Spiritual Phenomena in 19th Century",
+                "source_url": "https://example.com/spirit",
+                "summary": "General article about spirits",
+                "language": "en",
+                "source_type": "internet_archive",
+                "keywords_matched": ["spirit", "identity"],
+                "reference_keywords_matched": [],
+            }
+        ]
+        result = _format_documents("en", docs)
+        assert "(none — exploratory match only)" in result
+
+
 class TestCreateAggregator:
     """create_aggregator ファクトリのテスト。"""
 

--- a/tests/unit/test_document_inventory.py
+++ b/tests/unit/test_document_inventory.py
@@ -243,6 +243,45 @@ class TestGetDocumentInventory:
         assert "_inventory_consulted" not in ctx.state
 
 
+class TestDocumentInventoryReferenceKeywords:
+    """reference_keywords_matched のインベントリ表示テスト。"""
+
+    def test_inventory_includes_reference_keywords_matched_count(self):
+        """インベントリの各エントリに reference_keywords_matched 数が含まれるべき。"""
+        ctx = make_tool_context(state={
+            "raw_search_results_en": [{
+                "documents": [
+                    {
+                        "title": "Watseka Wonder",
+                        "source_url": "https://loc.gov/item/1",
+                        "source_type": "nypl",
+                        "date": "1877-01-01",
+                        "language": "en",
+                        "keywords_matched": ["spirit"],
+                        "reference_keywords_matched": ["Watseka", "Vennum"],
+                    },
+                    {
+                        "title": "Spirit Phenomena",
+                        "source_url": "https://archive.org/details/1",
+                        "source_type": "internet_archive",
+                        "date": "1880-06-15",
+                        "language": "en",
+                        "keywords_matched": ["spirit", "identity"],
+                        "reference_keywords_matched": [],
+                    },
+                ],
+            }],
+        })
+
+        result = json.loads(get_document_inventory(ctx))
+
+        assert result["status"] == "ok"
+        nypl_docs = result["by_archive"]["NYPL Digital Collections"]
+        ia_docs = result["by_archive"]["Internet Archive"]
+        assert nypl_docs[0]["reference_keywords_matched"] == 2
+        assert ia_docs[0]["reference_keywords_matched"] == 0
+
+
 class TestArchiveImagesInInventory:
     """archive_images セクションのテスト。"""
 

--- a/tests/unit/test_scholar_tools.py
+++ b/tests/unit/test_scholar_tools.py
@@ -794,6 +794,140 @@ class TestValidateEvidenceGroundingDirect:
         assert warnings == []
 
 
+class TestReferenceKeywordGrounding:
+    """reference_keywords_matched によるグラウンディング検証のテスト。"""
+
+    def test_evidence_with_no_reference_match_warns(self):
+        """evidence_a/b が reference keyword 無一致の場合、警告が出るべき。"""
+        mock_ctx = _make_ctx({
+            "raw_search_results_en": [{
+                "documents": [{
+                    "title": "General Spiritual Phenomena",
+                    "source_url": "https://archive.org/details/spirit",
+                    "source_type": "internet_archive",
+                    "keywords_matched": ["spirit"],
+                    "reference_keywords_matched": [],
+                    "raw_text": "A general article about spiritual phenomena.",
+                }],
+            }],
+        })
+
+        report_data = {
+            "title": "Test",
+            "evidence_a": {
+                "source_url": "https://archive.org/details/spirit",
+                "relevant_excerpt": "Text",
+            },
+            "approved_image_urls": [],
+        }
+        result = save_structured_report(json.dumps(report_data), mock_ctx)
+        result_data = json.loads(result)
+
+        assert result_data["status"] == "success"
+        assert any(
+            "reference キーワード無一致" in w
+            for w in result_data["warnings"]
+        )
+
+    def test_additional_evidence_no_reference_match_filtered(self):
+        """additional_evidence で reference keyword 無一致の項目は除外されるべき。"""
+        mock_ctx = _make_ctx({
+            "raw_search_results_en": [{
+                "documents": [
+                    {
+                        "title": "Watseka Wonder",
+                        "source_url": "https://loc.gov/item/watseka",
+                        "source_type": "nypl",
+                        "keywords_matched": ["spirit", "Watseka"],
+                        "reference_keywords_matched": ["Watseka"],
+                        "raw_text": "The Watseka Wonder case.",
+                    },
+                    {
+                        "title": "General Spirit Article",
+                        "source_url": "https://archive.org/details/spirit",
+                        "source_type": "internet_archive",
+                        "keywords_matched": ["spirit"],
+                        "reference_keywords_matched": [],
+                        "raw_text": "A general article.",
+                    },
+                ],
+            }],
+        })
+
+        report_data = {
+            "title": "Test",
+            "evidence_a": {
+                "source_url": "https://loc.gov/item/watseka",
+                "relevant_excerpt": "Text",
+            },
+            "additional_evidence": [
+                {
+                    "source_url": "https://archive.org/details/spirit",
+                    "relevant_excerpt": "General text",
+                },
+            ],
+            "approved_image_urls": [],
+        }
+        result = save_structured_report(json.dumps(report_data), mock_ctx)
+        result_data = json.loads(result)
+
+        assert result_data["status"] == "success"
+        saved = mock_ctx.state["structured_report"]
+        # reference keyword 無一致の additional_evidence は除外される
+        assert len(saved["additional_evidence"]) == 0
+        assert any(
+            "reference キーワード無一致" in w
+            for w in result_data["warnings"]
+        )
+
+    def test_reference_keywords_empty_skips_filter(self):
+        """raw_search_results に reference_keywords_matched が空の場合、フィルタをスキップすべき。"""
+        mock_ctx = _make_ctx({
+            "raw_search_results_en": [{
+                "documents": [
+                    {
+                        "title": "Doc A",
+                        "source_url": "https://loc.gov/item/a",
+                        "source_type": "nypl",
+                        "keywords_matched": ["keyword"],
+                        "reference_keywords_matched": [],
+                        "raw_text": "Some text.",
+                    },
+                    {
+                        "title": "Doc B",
+                        "source_url": "https://archive.org/details/b",
+                        "source_type": "internet_archive",
+                        "keywords_matched": ["keyword"],
+                        "reference_keywords_matched": [],
+                        "raw_text": "Another text.",
+                    },
+                ],
+            }],
+        })
+
+        report_data = {
+            "title": "Test",
+            "evidence_a": {
+                "source_url": "https://loc.gov/item/a",
+                "relevant_excerpt": "Text",
+            },
+            "additional_evidence": [
+                {
+                    "source_url": "https://archive.org/details/b",
+                    "relevant_excerpt": "Other text",
+                },
+            ],
+            "approved_image_urls": [],
+        }
+        result = save_structured_report(json.dumps(report_data), mock_ctx)
+        result_data = json.loads(result)
+
+        assert result_data["status"] == "success"
+        saved = mock_ctx.state["structured_report"]
+        # 全 evidence の reference_keywords が空 → フィルタスキップ → 保持
+        assert len(saved["additional_evidence"]) == 1
+
+
 class TestWordCountVerifiedCheck:
     """語数検証フラグ強制チェックのテスト。"""
 

--- a/tests/unit/test_search_orchestration.py
+++ b/tests/unit/test_search_orchestration.py
@@ -1,0 +1,155 @@
+"""Unit tests for mystery_agents/tools/search_orchestration.py
+
+reference_keywords_matched の算出・ランキングロジックのテスト。
+"""
+
+from mystery_agents.tools.search_orchestration import (
+    _rank_documents,
+    _search_single_source,
+)
+from tests.fakes import make_archive_doc as _make_doc
+
+from mystery_agents.tools.archive_source_base import ArchiveSearchResult
+
+
+def _make_mock_source(
+    source_key="mock",
+    docs=None,
+    total_hits=0,
+    error=None,
+    supports_language_filter=False,
+):
+    """テスト用のモック ArchiveSource を作成する。"""
+
+    class MockSource:
+        pass
+
+    s = MockSource()
+    s.source_key = source_key
+    s.source_name = f"Mock {source_key}"
+    s.supports_language_filter = supports_language_filter
+
+    def _search(**kwargs):
+        return ArchiveSearchResult(
+            documents=list(docs or []),
+            total_hits=total_hits,
+            error=error,
+        )
+
+    s.search = _search
+    return s
+
+
+class TestReferenceKeywordsMatched:
+    """_search_single_source が reference_keywords_matched を算出すること。"""
+
+    def test_reference_keywords_matched_from_title(self):
+        """タイトルに固有名詞が含まれるドキュメントは reference_keywords_matched に含まれるべき。"""
+        doc = _make_doc(title="The Watseka Wonder of 1877", url="https://example.com/1")
+        source = _make_mock_source(docs=[doc], total_hits=1)
+
+        _, docs, _, _, _ = _search_single_source(
+            source,
+            [["identity", "spirit"]],
+            date_start=None,
+            date_end=None,
+            per_source_limit=10,
+            language=None,
+            reference_keywords=["Watseka", "Vennum"],
+        )
+
+        assert len(docs) == 1
+        assert "Watseka" in docs[0].reference_keywords_matched
+        # "Vennum" はタイトル/サマリーに含まれないので無し
+        assert "Vennum" not in docs[0].reference_keywords_matched
+
+    def test_no_reference_keywords_leaves_empty(self):
+        """reference_keywords が空の場合、全ドキュメントの reference_keywords_matched は空のまま。"""
+        doc = _make_doc(title="Some Document", url="https://example.com/2")
+        source = _make_mock_source(docs=[doc], total_hits=1)
+
+        _, docs, _, _, _ = _search_single_source(
+            source,
+            [["ghost"]],
+            date_start=None,
+            date_end=None,
+            per_source_limit=10,
+            language=None,
+            reference_keywords=None,
+        )
+
+        assert docs[0].reference_keywords_matched == []
+
+    def test_reference_keywords_case_insensitive(self):
+        """大文字小文字を区別しないマッチング。"""
+        doc = _make_doc(
+            title="WATSEKA historical records",
+            url="https://example.com/3",
+        )
+        source = _make_mock_source(docs=[doc], total_hits=1)
+
+        _, docs, _, _, _ = _search_single_source(
+            source,
+            [["spirit"]],
+            date_start=None,
+            date_end=None,
+            per_source_limit=10,
+            language=None,
+            reference_keywords=["watseka"],
+        )
+
+        assert "watseka" in docs[0].reference_keywords_matched
+
+    def test_reference_keywords_matched_from_summary(self):
+        """サマリーに固有名詞が含まれるドキュメントもマッチする。"""
+        from mystery_agents.schemas.document import ArchiveDocument
+
+        doc = ArchiveDocument(
+            title="Spiritual Phenomena Report",
+            source_url="https://example.com/4",
+            summary="The case of Lurancy Vennum in Watseka, Illinois",
+            language="en",
+            location="Illinois",
+            source_type="nypl",
+            keywords_matched=["spirit"],
+        )
+        source = _make_mock_source(docs=[doc], total_hits=1)
+
+        _, docs, _, _, _ = _search_single_source(
+            source,
+            [["spirit"]],
+            date_start=None,
+            date_end=None,
+            per_source_limit=10,
+            language=None,
+            reference_keywords=["Watseka", "Vennum"],
+        )
+
+        assert "Watseka" in docs[0].reference_keywords_matched
+        assert "Vennum" in docs[0].reference_keywords_matched
+
+
+class TestRankDocumentsWithReference:
+    """reference_keywords_matched 数で優先ソートされること。"""
+
+    def test_reference_match_ranked_higher(self):
+        """reference match ありのドキュメントが exploratory match のみより上位にランクされるべき。"""
+        doc_ref = _make_doc(
+            url="https://a.com/ref",
+            source_type="nypl",
+            keywords_matched=["spirit"],
+        )
+        doc_ref.reference_keywords_matched = ["Watseka"]
+
+        doc_exp = _make_doc(
+            url="https://a.com/exp",
+            source_type="nypl",
+            keywords_matched=["spirit", "identity", "possession"],
+        )
+        doc_exp.reference_keywords_matched = []
+
+        ranked = _rank_documents([doc_exp, doc_ref])
+
+        # reference match ありが先（keywords_matched は少ないが reference が優先）
+        assert ranked[0].source_url == "https://a.com/ref"
+        assert ranked[1].source_url == "https://a.com/exp"


### PR DESCRIPTION
## 概要

HIS-US-CHI-20260301113750 の品質検証で発覚した偽陽性問題を、パイプライン全体（Librarian→Scholar→Polymath）の3層で対策。

### 根本原因
`reference_keywords`（固有名詞: "Watseka", "Vennum"）と `exploratory_keywords`（汎用語: "identity", "spirit"）の区別が検索時に存在するが、ドキュメント単位では追跡されなかった。下流の Scholar・Polymath に主題的関連性の判断材料が渡らず、偽陽性文書が evidence_a/b に採用されていた。

### 変更内容

**Layer 1: 検索後処理（Librarian）**
- `ArchiveDocument` スキーマに `reference_keywords_matched` フィールド追加
- `_search_single_source()` / `search_newspapers()` で title/summary 内の固有名詞マッチを算出
- `_rank_documents()` で reference match 数を第一ソートキーに変更

**Layer 2: 表示・インベントリ（Aggregator → Scholar）**
- Aggregator の `_format_documents()` に reference keywords matched 行を追加
- Document Inventory に `reference_keywords_matched` カウントを追加
- Scholar/Polymath instruction に reference keyword 指標の解釈ガイドを追加

**Layer 3: 証拠検証（save_structured_report）**
- `_validate_evidence_grounding()` で reference keyword 無一致を警告
- `save_structured_report()` で additional_evidence の reference keyword 無一致項目を自動除外
- 後方互換: `reference_keywords_matched` フィールドが存在しない旧データではフィルタをスキップ

## 変更ファイル（12件、+467/-1）

| ファイル | 変更 |
|---|---|
| `mystery_agents/schemas/document.py` | フィールド追加 |
| `mystery_agents/tools/search_orchestration.py` | 後処理 + ランキング |
| `mystery_agents/tools/librarian_tools.py` | `search_newspapers` 後処理 |
| `mystery_agents/agents/aggregator.py` | 表示追加 |
| `mystery_agents/tools/document_inventory.py` | フィールド追加 |
| `mystery_agents/tools/scholar_tools.py` | 検証 + フィルタ |
| `mystery_agents/agents/scholar_instructions.py` | Framework 0.5 強化 |
| `mystery_agents/agents/polymath_instructions.py` | Selection Principle #6 |
| `tests/unit/test_search_orchestration.py` | **新規** (5テスト) |
| `tests/unit/test_aggregator.py` | 2テスト追加 |
| `tests/unit/test_document_inventory.py` | 1テスト追加 |
| `tests/unit/test_scholar_tools.py` | 3テスト追加 |

## テスト計画

- [x] Step 1: `pytest tests/unit/test_search_orchestration.py tests/unit/test_librarian_tools.py -v` — PASS
- [x] Step 2: `pytest tests/unit/test_aggregator.py tests/unit/test_document_inventory.py -v` — PASS
- [x] Step 3: `pytest tests/unit/test_scholar_tools.py -v` — PASS
- [x] 全体回帰: `pytest tests/unit/ -v` — 1439 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>