### PR TITLE
fix: 証拠 excerpt の OCR ゴミ表示問題を修正 — raw_text グラウンディング上書き削除

### DIFF
--- a/mystery_agents/tools/scholar_tools.py
+++ b/mystery_agents/tools/scholar_tools.py
@@ -126,15 +126,6 @@ def _validate_evidence_grounding(
             if raw_source_type:
                 ev["archive_source"] = raw_source_type
 
-            # relevant_excerpt を API 原文でグラウンディング
-            raw_text = raw_doc.get("raw_text")
-            if raw_text and raw_text.strip():
-                ev["relevant_excerpt"] = raw_text
-            else:
-                warnings.append(
-                    f"{label}: raw_text が空 — LLM excerpt を維持"
-                )
-
             # キーワード妥当性チェック
             kw_matched = raw_doc.get("keywords_matched", [])
             ev["_kw_match_count"] = len(kw_matched)

--- a/tests/unit/test_scholar_tools.py
+++ b/tests/unit/test_scholar_tools.py
@@ -448,7 +448,7 @@ class TestEvidenceGrounding:
     """証拠グラウンディング検証のテスト。"""
 
     def test_matching_url_overwrites_metadata(self):
-        """URL が raw_search_results と一致 → title/date/excerpt を上書き。"""
+        """URL が raw_search_results と一致 → title/date を上書き、excerpt は維持。"""
         mock_ctx = _make_ctx({
             "raw_search_results_en": [{
                 "documents": [{
@@ -475,21 +475,21 @@ class TestEvidenceGrounding:
 
         assert result_data["status"] == "success"
         saved_ev = mock_ctx.state["structured_report"]["evidence_a"]
-        # raw データで上書きされている
+        # メタデータは raw データで上書きされている
         assert saved_ev["source_title"] == "Correct Title From API"
         assert saved_ev["source_date"] == "1893-01-15"
         assert saved_ev["archive_source"] == "nypl"
-        # relevant_excerpt が raw_text で上書きされている
-        assert saved_ev["relevant_excerpt"] == "Original text from the API document."
+        # relevant_excerpt は LLM の出力が維持される（OCR 品質問題を回避）
+        assert saved_ev["relevant_excerpt"] == "LLM generated summary"
 
-    def test_matching_url_overwrites_relevant_excerpt(self):
-        """URL 一致時に raw_text → relevant_excerpt 上書き。"""
+    def test_matching_url_preserves_llm_excerpt(self):
+        """URL 一致時でも relevant_excerpt は LLM 出力を維持する。"""
         mock_ctx = _make_ctx({
             "raw_search_results_en": [{
                 "documents": [{
                     "title": "API Doc",
                     "source_url": "https://loc.gov/item/456",
-                    "raw_text": "Authentic archive text from LOC.",
+                    "raw_text": "Garbled OCR t3xt fr0m 19th c. newspaper",
                     "keywords_matched": ["key"],
                 }],
             }],
@@ -499,7 +499,7 @@ class TestEvidenceGrounding:
             "title": "Test",
             "evidence_a": {
                 "source_url": "https://loc.gov/item/456",
-                "relevant_excerpt": "LLM fabricated text",
+                "relevant_excerpt": "Polymath meaningful excerpt",
             },
         }
         result = save_structured_report(json.dumps(report_data), mock_ctx)
@@ -507,35 +507,8 @@ class TestEvidenceGrounding:
 
         assert result_data["status"] == "success"
         saved_ev = mock_ctx.state["structured_report"]["evidence_a"]
-        assert saved_ev["relevant_excerpt"] == "Authentic archive text from LOC."
-
-    def test_matching_url_empty_raw_text_keeps_llm_excerpt(self):
-        """raw_text が空の場合 LLM テキストを維持し警告。"""
-        mock_ctx = _make_ctx({
-            "raw_search_results_en": [{
-                "documents": [{
-                    "title": "API Doc",
-                    "source_url": "https://loc.gov/item/789",
-                    "raw_text": "",
-                    "keywords_matched": ["key"],
-                }],
-            }],
-        })
-
-        report_data = {
-            "title": "Test",
-            "evidence_a": {
-                "source_url": "https://loc.gov/item/789",
-                "relevant_excerpt": "LLM generated text kept as fallback",
-            },
-        }
-        result = save_structured_report(json.dumps(report_data), mock_ctx)
-        result_data = json.loads(result)
-
-        assert result_data["status"] == "success"
-        saved_ev = mock_ctx.state["structured_report"]["evidence_a"]
-        assert saved_ev["relevant_excerpt"] == "LLM generated text kept as fallback"
-        assert any("raw_text が空" in w for w in result_data["warnings"])
+        # raw_text ではなく LLM excerpt が維持される
+        assert saved_ev["relevant_excerpt"] == "Polymath meaningful excerpt"
 
     def test_ungrounded_additional_evidence_removed(self):
         """URL 不一致の additional_evidence が除外される。"""


### PR DESCRIPTION
## Summary

- PR #457 で導入したグラウンディング処理が Armchair Polymath の meaningful な `relevant_excerpt` をアーカイブ API の生 OCR テキスト（`raw_text`）で上書きしていた
- 19世紀新聞など OCR 品質が低いソースでは、証拠ブロックの原文表示が文字化けのように見え、翻訳（金色テキスト）とも一致しない状態になっていた
- `raw_text → relevant_excerpt` 上書きロジックを削除し、LLM が生成した意味のある excerpt を維持するよう修正

## 変更内容

| ファイル | 変更 |
|---------|------|
| `mystery_agents/tools/scholar_tools.py` | `raw_text → relevant_excerpt` 上書きロジック削除（メタデータグラウンディング・キーワードチェックは維持） |
| `tests/unit/test_scholar_tools.py` | excerpt 上書きテストを「LLM excerpt 維持」に書き換え、`raw_text` 空時の警告テストを削除 |

## 変更しないもの

- **メタデータグラウンディング**: title/date/source_type の上書きは正しい動作なので維持
- **キーワード妥当性チェック**: false positive 検出のため維持
- **Polymath instruction**: 既に「verbatim quote か brief paraphrase」を指示済み
- **既存 Firestore データ**: 今回の変更は今後のパイプライン実行にのみ影響

## Test plan

- [x] `pytest tests/unit/test_scholar_tools.py -v` — 全48テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)