### PR TITLE
chore: .claude/settings.json の deny/ask ルールを .gitignore と整合

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,14 +13,30 @@
       "Read(.ruff_cache/**)",
       "Read(ghostinthearchive.egg-info/**)",
       "Read(.DS_Store)",
-      "Read(*.tsbuildinfo)"
+      "Read(*.tsbuildinfo)",
+      "Read(.env*)",
+      "Read(terraform/*.tfvars)",
+      "Read(terraform/*.tfvars.json)",
+      "Read(.firebase/**)",
+      "Read(.mypy_cache/**)",
+      "Read(dist/**)",
+      "Read(build/**)",
+      "Read(.idea/**)",
+      "Read(.vscode/**)"
     ],
     "ask": [
       "Read(logs/**)",
       "Read(.adk/**)",
       "Read(uv.lock)",
       "Read(package-lock.json)",
-      "Read(firebase-debug.log)"
+      "Read(firebase-debug.log)",
+      "Read(firestore-debug.log)",
+      "Read(ui-debug.log)",
+      "Read(storage-debug.log)",
+      "Read(.firebase-emulator-data/**)",
+      "Read(htmlcov/**)",
+      "Read(.coverage)",
+      "Read(data/**)"
     ]
   }
 }


### PR DESCRIPTION
## Summary

- `.gitignore` に記載されているがClaude Code の deny/ask ルールに反映されていなかったパターンを追加
- 特にシークレットファイル（`.env*`, `*.tfvars`）を deny に追加し、誤読み取りを防止

### deny 追加（9パターン）
| パターン | 理由 |
|----------|------|
| `.env*` | シークレット（API キー等） |
| `terraform/*.tfvars` | Terraform シークレット |
| `terraform/*.tfvars.json` | Terraform シークレット |
| `.firebase/**` | Firebase キャッシュ（ルート） |
| `.mypy_cache/**` | 型チェッカーキャッシュ |
| `dist/**` | Python ビルド成果物 |
| `build/**` | Python ビルド成果物 |
| `.idea/**` | IDE 設定 |
| `.vscode/**` | IDE 設定 |

### ask 追加（7パターン）
| パターン | 理由 |
|----------|------|
| `firestore-debug.log` | Firebase Emulator デバッグログ |
| `ui-debug.log` | Firebase Emulator デバッグログ |
| `storage-debug.log` | Firebase Emulator デバッグログ |
| `.firebase-emulator-data/**` | Emulator エクスポートデータ |
| `htmlcov/**` | カバレッジレポート |
| `.coverage` | テストカバレッジデータ |
| `data/**` | データディレクトリ |

## Test plan
- [ ] deny 対象ファイル（例: `.env`）を Read しようとしてブロックされることを確認
- [ ] ask 対象ファイル（例: `firestore-debug.log`）を Read しようとして確認プロンプトが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)